### PR TITLE
[DOP-16669] Do not use INSERT ON CONFLICT

### DIFF
--- a/data_rentgen/db/repositories/operation.py
+++ b/data_rentgen/db/repositories/operation.py
@@ -3,7 +3,7 @@
 
 from uuid import UUID
 
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy import select
 
 from data_rentgen.db.models import Operation, OperationType, Status
 from data_rentgen.db.repositories.base import Repository
@@ -12,38 +12,36 @@ from data_rentgen.dto import OperationDTO
 
 class OperationRepository(Repository[Operation]):
     async def create_or_update(self, operation: OperationDTO, run_id: UUID | None) -> Operation:
-        mandatory_fields = {
-            "created_at": operation.created_at,
-            "id": operation.id,
-            "name": operation.name,
-        }
-        optional_fields = {
-            # Operation run_id and type are not null while operation is created, but may be empty in later events
-            "run_id": run_id,
-            "type": OperationType(operation.type) if operation.type else None,
-            "status": Status(operation.status) if operation.status else None,
-            "started_at": operation.started_at,
-            "ended_at": operation.ended_at,
-            "description": operation.description,
-            "position": operation.position,
-        }
+        query = select(Operation).where(Operation.id == operation.id, Operation.created_at == operation.created_at)
+        result = await self._session.scalar(query)
+        if not result:
+            result = Operation(
+                created_at=operation.created_at,
+                id=operation.id,
+                run_id=run_id,
+                name=operation.name,
+                type=OperationType(operation.type) if operation.type else None,
+                status=Status(operation.status) if operation.status else None,
+                started_at=operation.started_at,
+                ended_at=operation.ended_at,
+                description=operation.description,
+                position=operation.position,
+            )
+            self._session.add(result)
+        else:
+            optional_fields = {
+                # Operation run_id and type are not null while operation is created, but may be empty in later events
+                "run_id": run_id,
+                "type": OperationType(operation.type) if operation.type else None,
+                "status": Status(operation.status) if operation.status else None,
+                "started_at": operation.started_at,
+                "ended_at": operation.ended_at,
+                "description": operation.description,
+                "position": operation.position,
+            }
+            for column, value in optional_fields.items():
+                if value is not None:
+                    setattr(result, column, value)
 
-        insert_statement = insert(Operation)
-        insert_statement = insert_statement.on_conflict_do_update(
-            index_elements=[Operation.created_at, Operation.id],
-            set_={
-                # Different operationEvents may have different parts of information - one only 'started_at', second only 'ended_at',
-                # third only 'parent_operation_id'. If field value is unknown, we should keep original value
-                getattr(Operation, column): getattr(insert_statement.excluded, column)
-                for column, value in optional_fields.items()
-                if value is not None
-            },
-        )
-        return await self._session.scalar(  # type: ignore[return-value]
-            insert_statement.returning(Operation),
-            {
-                **mandatory_fields,
-                **optional_fields,
-            },
-            execution_options={"populate_existing": True},
-        )
+        await self._session.flush([result])
+        return result

--- a/data_rentgen/db/repositories/run.py
+++ b/data_rentgen/db/repositories/run.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from sqlalchemy import select
-from sqlalchemy.dialects.postgresql import insert
 from uuid6 import UUID
 
 from data_rentgen.db.models import Run, Status
@@ -12,53 +11,48 @@ from data_rentgen.dto import RunDTO
 
 class RunRepository(Repository[Run]):
     async def get_or_create_minimal(self, run: RunDTO, job_id: int) -> Run:
-        statement = select(Run).where(
-            Run.id == run.id,
-            Run.created_at == run.created_at,
-        )
-        result = await self._session.scalar(statement)
+        query = select(Run).where(Run.id == run.id, Run.created_at == run.created_at)
+        result = await self._session.scalar(query)
         if not result:
-            result = await self._session.scalar(
-                insert(Run).on_conflict_do_nothing().returning(Run),
-                {"job_id": job_id, "id": run.id, "created_at": run.created_at},
-                execution_options={"populate_existing": True},
-            )
+            result = Run(id=run.id, created_at=run.created_at, job_id=job_id)
+            self._session.add(result)
+            await self._session.flush([result])
 
-        return result  # type: ignore[return-value]
+        return result
 
     async def create_or_update(self, run: RunDTO, job_id: int, parent_run_id: UUID | None) -> Run:
-        mandatory_fields = {
-            "created_at": run.created_at,
-            "id": run.id,
-            "job_id": job_id,
-        }
-        optional_fields = {
-            "status": Status(run.status) if run.status else None,
-            "parent_run_id": parent_run_id,
-            "started_at": run.started_at,
-            "ended_at": run.ended_at,
-            "external_id": run.external_id,
-            "attempt": run.attempt,
-            "persistent_log_url": run.persistent_log_url,
-            "running_log_url": run.running_log_url,
-        }
+        query = select(Run).where(Run.id == run.id, Run.created_at == run.created_at)
+        result = await self._session.scalar(query)
+        if not result:
+            result = Run(
+                id=run.id,
+                created_at=run.created_at,
+                job_id=job_id,
+                status=Status(run.status) if run.status else None,
+                parent_run_id=parent_run_id,
+                started_at=run.started_at,
+                ended_at=run.ended_at,
+                external_id=run.external_id,
+                attempt=run.attempt,
+                persistent_log_url=run.persistent_log_url,
+                running_log_url=run.running_log_url,
+            )
+            self._session.add(result)
+        else:
+            optional_fields = {
+                "status": Status(run.status) if run.status else None,
+                "parent_run_id": parent_run_id,
+                "started_at": run.started_at,
+                "ended_at": run.ended_at,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+            }
 
-        insert_statement = insert(Run)
-        insert_statement = insert_statement.on_conflict_do_update(
-            index_elements=[Run.created_at, Run.id],
-            set_={
-                # Different runEvents may have different parts of information - one only 'started_at', second only 'ended_at',
-                # third only 'parent_run_id'. If field value is unknown, we should keep original value
-                getattr(Run, column): getattr(insert_statement.excluded, column)
-                for column, value in optional_fields.items()
-                if value is not None
-            },
-        )
-        return await self._session.scalar(  # type: ignore[return-value]
-            insert_statement.returning(Run),
-            {
-                **mandatory_fields,
-                **optional_fields,
-            },
-            execution_options={"populate_existing": True},
-        )
+            for column, value in optional_fields.items():
+                if value is not None:
+                    setattr(result, column, value)
+
+        await self._session.flush([result])
+        return result


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Replace `INSERT ... ON CONFLICT ...` with plain SQLAlchemy session.
* `ON CONFLICT` does prevent issues only if row object was inserted by another session, and the same session tries to insert the same row again. But if both sessions inserted the same row, but not commited changes yet, this will not help at all.
* `create_or_update` methods currently perform updates on every call, even if row data haven't been changed. Postgres does not have optimization for skipping update of a row in this case - it will create a new version of a row and delete the old one, leading to unnecessary IO operations. 
* `INSERT ... ON CONFLICT DO NOTHING RETURNING ...` does not return existing row, instead if returns no rows at all. This leads to errors like https://github.com/MobileTeleSystems/data-rentgen/actions/runs/9910247590/job/27380186585?pr=20

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
