### PR TITLE
[DOP-18263] Handle run user in consumer

### DIFF
--- a/data_rentgen/consumer/extractors/__init__.py
+++ b/data_rentgen/consumer/extractors/__init__.py
@@ -14,6 +14,7 @@ from data_rentgen.consumer.extractors.interaction import (
 from data_rentgen.consumer.extractors.job import extract_job
 from data_rentgen.consumer.extractors.operation import extract_operation
 from data_rentgen.consumer.extractors.run import extract_parent_run, extract_run
+from data_rentgen.consumer.extractors.user import extract_run_user
 
 __all__ = [
     "extract_dataset",
@@ -26,4 +27,5 @@ __all__ = [
     "extract_input_interaction",
     "extract_output_interaction",
     "extract_interaction_schema",
+    "extract_run_user",
 ]

--- a/data_rentgen/consumer/extractors/run.py
+++ b/data_rentgen/consumer/extractors/run.py
@@ -5,7 +5,7 @@ from urllib.parse import quote
 
 from packaging.version import Version
 
-from data_rentgen.consumer.extractors.job import extract_job
+from data_rentgen.consumer.extractors import extract_job
 from data_rentgen.consumer.openlineage.run_event import (
     OpenLineageRunEvent,
     OpenLineageRunEventType,

--- a/data_rentgen/consumer/extractors/user.py
+++ b/data_rentgen/consumer/extractors/user.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+
+from data_rentgen.consumer.openlineage.run_event import OpenLineageRunEvent
+from data_rentgen.dto import UserDTO
+
+
+def extract_run_user(event: OpenLineageRunEvent) -> UserDTO | None:
+    spark_application_details = event.run.facets.spark_applicationDetails
+    if spark_application_details:
+        return UserDTO(name=spark_application_details.userName)
+    # Airflow DAG and task have 'owner' field, but if can be either user or group name,
+    # and also it does not mean that this exact user started this run.
+    return None

--- a/data_rentgen/db/migrations/versions/2024-06-27_412d5fbdb362_create_interaction.py
+++ b/data_rentgen/db/migrations/versions/2024-06-27_412d5fbdb362_create_interaction.py
@@ -26,7 +26,6 @@ def upgrade() -> None:
         sa.Column("dataset_id", sa.BigInteger(), nullable=False),
         sa.Column("type", sa.String(length=255), nullable=False),
         sa.Column("schema_id", sa.BigInteger(), nullable=True),
-        sa.Column("connect_as_user_id", sa.BigInteger(), nullable=True),
         sa.Column("num_bytes", sa.BigInteger(), nullable=True),
         sa.Column("num_rows", sa.BigInteger(), nullable=True),
         sa.Column("num_files", sa.BigInteger(), nullable=True),
@@ -36,11 +35,9 @@ def upgrade() -> None:
     op.create_index(op.f("ix__interaction__dataset_id"), "interaction", ["dataset_id"], unique=False)
     op.create_index(op.f("ix__interaction__operation_id"), "interaction", ["operation_id"], unique=False)
     op.create_index(op.f("ix__interaction__schema_id"), "interaction", ["schema_id"], unique=False)
-    op.create_index(op.f("ix__interaction__connect_as_user_id"), "interaction", ["connect_as_user_id"], unique=False)
 
 
 def downgrade() -> None:
-    op.drop_index(op.f("ix__interaction__connect_as_user_id"), table_name="interaction")
     op.drop_index(op.f("ix__interaction__schema_id"), table_name="interaction")
     op.drop_index(op.f("ix__interaction__operation_id"), table_name="interaction")
     op.drop_index(op.f("ix__interaction__dataset_id"), table_name="interaction")

--- a/data_rentgen/db/models/README.rst
+++ b/data_rentgen/db/models/README.rst
@@ -98,7 +98,6 @@ DB structure
         type
         ended_at
         schema_id
-        connect_as_user_id
         num_bytes
         num_rows
         num_files
@@ -121,6 +120,5 @@ DB structure
     Interaction ||--o{ Operation
     Interaction ||--o{ Dataset
     Interaction |o--o{ Schema
-    Interaction "connect_as_user_id" |o--o{ User
 
     @enduml

--- a/data_rentgen/db/models/interaction.py
+++ b/data_rentgen/db/models/interaction.py
@@ -16,7 +16,6 @@ from data_rentgen.db.models.base import Base
 from data_rentgen.db.models.dataset import Dataset
 from data_rentgen.db.models.operation import Operation
 from data_rentgen.db.models.schema import Schema
-from data_rentgen.db.models.user import User
 
 
 class InteractionType(str, Enum):
@@ -95,19 +94,6 @@ class Interaction(Base):
         primaryjoin="Interaction.schema_id == Schema.id",
         lazy="noload",
         foreign_keys=[schema_id],
-    )
-
-    connect_as_user_id: Mapped[int | None] = mapped_column(
-        BigInteger,
-        index=True,
-        nullable=True,
-        doc="Username used for dataset access",
-    )
-    as_user: Mapped[User | None] = relationship(
-        User,
-        primaryjoin="Interaction.connect_as_user_id == User.id",
-        lazy="noload",
-        foreign_keys=[connect_as_user_id],
     )
 
     num_bytes: Mapped[int | None] = mapped_column(

--- a/data_rentgen/db/repositories/run.py
+++ b/data_rentgen/db/repositories/run.py
@@ -22,7 +22,13 @@ class RunRepository(Repository[Run]):
 
         return result
 
-    async def create_or_update(self, run: RunDTO, job_id: int, parent_run_id: UUID | None) -> Run:
+    async def create_or_update(
+        self,
+        run: RunDTO,
+        job_id: int,
+        parent_run_id: UUID | None,
+        started_by_user_id: int | None,
+    ) -> Run:
         created_at = extract_timestamp_from_uuid(run.id)
         query = select(Run).where(Run.id == run.id, Run.created_at == created_at)
         result = await self._session.scalar(query)
@@ -39,6 +45,7 @@ class RunRepository(Repository[Run]):
                 attempt=run.attempt,
                 persistent_log_url=run.persistent_log_url,
                 running_log_url=run.running_log_url,
+                started_by_user_id=started_by_user_id,
             )
             self._session.add(result)
         else:
@@ -51,6 +58,7 @@ class RunRepository(Repository[Run]):
                 "attempt": run.attempt,
                 "persistent_log_url": run.persistent_log_url,
                 "running_log_url": run.running_log_url,
+                "started_by_user_id": started_by_user_id,
             }
 
             for column, value in optional_fields.items():

--- a/data_rentgen/db/repositories/user.py
+++ b/data_rentgen/db/repositories/user.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+
+from sqlalchemy import select
+
+from data_rentgen.db.models import User
+from data_rentgen.db.repositories.base import Repository
+from data_rentgen.dto import UserDTO
+
+
+class UserRepository(Repository[User]):
+    async def get_or_create(self, user: UserDTO) -> User:
+        statement = select(User).where(User.name == user.name)
+        result = await self._session.scalar(statement)
+        if not result:
+            result = User(name=user.name)
+            self._session.add(result)
+            await self._session.flush([result])
+
+        return result

--- a/data_rentgen/dto/__init__.py
+++ b/data_rentgen/dto/__init__.py
@@ -14,6 +14,7 @@ from data_rentgen.dto.operation import (
 from data_rentgen.dto.pagination import PaginationDTO
 from data_rentgen.dto.run import RunDTO, RunStatusDTO
 from data_rentgen.dto.schema import SchemaDTO
+from data_rentgen.dto.user import UserDTO
 
 __all__ = [
     "DatasetDTO",
@@ -30,4 +31,5 @@ __all__ = [
     "RunDTO",
     "RunStatusDTO",
     "SchemaDTO",
+    "UserDTO",
 ]

--- a/data_rentgen/dto/user.py
+++ b/data_rentgen/dto/user.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class UserDTO:
+    name: str

--- a/data_rentgen/services/uow.py
+++ b/data_rentgen/services/uow.py
@@ -12,6 +12,7 @@ from data_rentgen.db.repositories.location import LocationRepository
 from data_rentgen.db.repositories.operation import OperationRepository
 from data_rentgen.db.repositories.run import RunRepository
 from data_rentgen.db.repositories.schema import SchemaRepository
+from data_rentgen.db.repositories.user import UserRepository
 from data_rentgen.dependencies import Stub
 
 
@@ -28,6 +29,7 @@ class UnitOfWork:
         self.dataset = DatasetRepository(session)
         self.schema = SchemaRepository(session)
         self.interaction = InteractionRepository(session)
+        self.user = UserRepository(session)
 
     async def __aenter__(self):
         return self

--- a/tests/test_consumer/test_extractors/test_extractors_user.py
+++ b/tests/test_consumer/test_extractors/test_extractors_user.py
@@ -1,0 +1,75 @@
+from datetime import datetime, timezone
+
+from data_rentgen.consumer.extractors import extract_run_user
+from data_rentgen.consumer.openlineage.job import OpenLineageJob
+from data_rentgen.consumer.openlineage.run import OpenLineageRun
+from data_rentgen.consumer.openlineage.run_event import (
+    OpenLineageRunEvent,
+    OpenLineageRunEventType,
+)
+from data_rentgen.consumer.openlineage.run_facets import (
+    OpenLineageAirflowDagInfo,
+    OpenLineageAirflowDagRunInfo,
+    OpenLineageAirflowRunFacet,
+    OpenLineageAirflowTaskInfo,
+    OpenLineageAirflowTaskInstanceInfo,
+    OpenLineageRunFacets,
+    OpenLineageSparkApplicationDetailsRunFacet,
+    OpenLineageSparkDeployMode,
+)
+from data_rentgen.db.utils.uuid import generate_new_uuid
+from data_rentgen.dto import UserDTO
+
+
+def test_extractors_extract_user_spark_app():
+    run = OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.START,
+        eventTime=datetime.now(),
+        job=OpenLineageJob(namespace="yarn://cluster", name="myjob"),
+        run=OpenLineageRun(
+            runId=generate_new_uuid(),
+            facets=OpenLineageRunFacets(
+                spark_applicationDetails=OpenLineageSparkApplicationDetailsRunFacet(
+                    master="yarn",
+                    appName="myapp",
+                    applicationId="application_1234_5678",
+                    deployMode=OpenLineageSparkDeployMode.CLIENT,
+                    driverHost="localhost",
+                    userName="myuser",
+                    uiWebUrl="http://localhost:4040",
+                    proxyUrl="http://yarn-proxy:8088/proxy/application_1234_5678",
+                    historyUrl="http://history-server:18081/history/application_1234_5678/",
+                ),
+            ),
+        ),
+    )
+    assert extract_run_user(run) == UserDTO(name="myuser")
+
+
+def test_extractors_extract_run_airflow_task():
+    run = OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.COMPLETE,
+        eventTime=datetime.now(),
+        job=OpenLineageJob(namespace="airflow://airflow-host:8081", name="mydag.mytask"),
+        run=OpenLineageRun(
+            runId=generate_new_uuid(),
+            facets=OpenLineageRunFacets(
+                airflow=OpenLineageAirflowRunFacet(
+                    dag=OpenLineageAirflowDagInfo(dag_id="mydag"),
+                    dagRun=OpenLineageAirflowDagRunInfo(
+                        run_id="manual__123",
+                        data_interval_start=datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc),
+                        data_interval_end=datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc),
+                    ),
+                    task=OpenLineageAirflowTaskInfo(
+                        task_id="mytask",
+                    ),
+                    taskInstance=OpenLineageAirflowTaskInstanceInfo(
+                        try_number=1,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    assert extract_run_user(run) is None

--- a/tests/test_consumer/test_handlers/test_runs_handler_airflow.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_airflow.py
@@ -60,6 +60,7 @@ async def test_runs_handler_airflow(
     assert dag_run.ended_at == datetime(2024, 7, 5, 9, 8, 5, 691973, tzinfo=timezone.utc)
     assert dag_run.persistent_log_url is None
     assert dag_run.running_log_url is None
+    assert dag_run.started_by_user_id is None
 
     task_run = runs[1]
     assert task_run.id == UUID("01908223-0782-7fc0-9d69-b1df9dac2c60")
@@ -75,6 +76,7 @@ async def test_runs_handler_airflow(
         "http://airflow-host:8081/dags/mydag/grid?tab=logs&dag_run_id=manual__2024-07-05T09%3A04%3A12.162809%2B00%3A00&task_id=mytask&map_index=-1"
     )
     assert task_run.running_log_url is None
+    assert task_run.started_by_user_id is None
 
     operation_query = select(Operation)
     operation_scalars = await async_session.scalars(operation_query)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

* Extract user info from run. Currently only Spark application is supported.
* If there is a user info for run, create User and bound Run to it.
* Drop `Interaction.as_user_id` because currently there is no facet which can be used to extract username used for connecting to a database.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
