### PR TITLE
[DOP-18286] Strip Spark appName prefix from operation names

### DIFF
--- a/tests/test_consumer/test_handlers/test_runs_handler_spark.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_spark.py
@@ -82,7 +82,7 @@ async def test_runs_handler_spark(
     assert job_operation.id == UUID("01908225-1fd7-746b-910c-70d24f2898b1")
     assert job_operation.created_at == datetime(2024, 7, 5, 9, 6, 29, 463000, tzinfo=timezone.utc)
     assert job_operation.run_id == application_run.id
-    assert job_operation.name == "spark_session.execute_save_into_data_source_command"
+    assert job_operation.name == "execute_save_into_data_source_command"
     assert job_operation.type == OperationType.BATCH
     assert job_operation.status == Status.SUCCEEDED
     assert job_operation.started_at == datetime(2024, 7, 5, 9, 6, 29, 462000, tzinfo=timezone.utc)

--- a/tests/test_consumer/test_openlineage/test_run_event_spark.py
+++ b/tests/test_consumer/test_openlineage/test_run_event_spark.py
@@ -224,7 +224,7 @@ def test_run_event_spark_job_running():
         "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
         "eventType": "RUNNING",
         "run": {
-            "runId": "01907e54-1606-7d8e-90b4-54d26da1c0e2",
+            "runId": "01908225-1fd7-746b-910c-70d24f2898b1",
             "facets": {
                 "parent": {
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.18.0/integration/spark",
@@ -415,7 +415,7 @@ def test_run_event_spark_job_running():
             ),
         ),
         run=OpenLineageRun(
-            runId=UUID("01907e54-1606-7d8e-90b4-54d26da1c0e2"),
+            runId=UUID("01908225-1fd7-746b-910c-70d24f2898b1"),
             facets=OpenLineageRunFacets(
                 parent=OpenLineageParentRunFacet(
                     job=OpenLineageParentJob(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

* If Spark job has Spark session as parent (almost always), strip appName prefix from job name.
* If Spark job name contains symbols like `\n`, replace them with space.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
