### PR TITLE
[DOP-18285] Collect run.start_reason in consumer

### DIFF
--- a/data_rentgen/consumer/openlineage/run_facets/__init__.py
+++ b/data_rentgen/consumer/openlineage/run_facets/__init__.py
@@ -5,6 +5,7 @@ from data_rentgen.consumer.openlineage.base import OpenLineageBase
 from data_rentgen.consumer.openlineage.run_facets.airflow import (
     OpenLineageAirflowDagInfo,
     OpenLineageAirflowDagRunInfo,
+    OpenLineageAirflowDagRunType,
     OpenLineageAirflowRunFacet,
     OpenLineageAirflowTaskInfo,
     OpenLineageAirflowTaskInstanceInfo,
@@ -39,6 +40,7 @@ __all__ = [
     "OpenLineageAirflowTaskInstanceInfo",
     "OpenLineageAirflowTaskInfo",
     "OpenLineageAirflowDagRunInfo",
+    "OpenLineageAirflowDagRunType",
     "OpenLineageAirflowDagInfo",
     "OpenLineageSparkDeployMode",
     "OpenLineageSparkApplicationDetailsRunFacet",

--- a/data_rentgen/consumer/openlineage/run_facets/airflow.py
+++ b/data_rentgen/consumer/openlineage/run_facets/airflow.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
+from enum import Enum
 
 from data_rentgen.consumer.openlineage.base import OpenLineageBase
 from data_rentgen.consumer.openlineage.run_facets.base import OpenLineageRunFacet
@@ -15,12 +16,24 @@ class OpenLineageAirflowDagInfo(OpenLineageBase):
     dag_id: str
 
 
+class OpenLineageAirflowDagRunType(Enum):
+    """Airflow dagRun type.
+    See [DagRunType](https://github.com/apache/airflow/blob/2.9.3/airflow/utils/types.py#L48-L54).
+    """
+
+    BACKFILL_JOB = "backfill"
+    SCHEDULED = "scheduled"
+    MANUAL = "manual"
+    DATASET_TRIGGERED = "dataset_triggered"
+
+
 class OpenLineageAirflowDagRunInfo(OpenLineageBase):
     """Airflow dagRun info.
     See [DagRun](https://github.com/apache/airflow/blob/providers-openlineage/1.9.0/airflow/providers/openlineage/facets/AirflowRunFacet.json).
     """
 
     run_id: str
+    run_type: OpenLineageAirflowDagRunType
     data_interval_start: datetime
     data_interval_end: datetime
 

--- a/data_rentgen/db/migrations/versions/2024-06-27_5f8fff06dd76_create_run.py
+++ b/data_rentgen/db/migrations/versions/2024-06-27_5f8fff06dd76_create_run.py
@@ -31,8 +31,9 @@ def upgrade() -> None:
         sa.Column("running_log_url", sa.String(), nullable=True),
         sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("started_by_user_id", sa.BigInteger(), nullable=True),
+        sa.Column("start_reason", sa.String(length=32), nullable=True),
         sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("ended_reason", sa.String(), nullable=True),
+        sa.Column("end_reason", sa.String(), nullable=True),
         sa.PrimaryKeyConstraint("created_at", "id", name=op.f("pk__run")),
         postgresql_partition_by="RANGE (created_at)",
     )

--- a/data_rentgen/db/models/README.rst
+++ b/data_rentgen/db/models/README.rst
@@ -56,7 +56,7 @@ DB structure
 
     entity Run {
         * id: UUIDv7
-        * started_at: Datetime
+        * created_at: Datetime
         ----
         * job_id
         status
@@ -65,9 +65,11 @@ DB structure
         attempt
         persistent_log_url
         running_log_url
+        started_at
         started_by_user_id
+        start_reason
         ended_at
-        ended_reason
+        end_reason
     }
 
     entity Operation {

--- a/data_rentgen/db/models/__init__.py
+++ b/data_rentgen/db/models/__init__.py
@@ -9,7 +9,7 @@ from data_rentgen.db.models.interaction import Interaction, InteractionType
 from data_rentgen.db.models.job import Job, JobType
 from data_rentgen.db.models.location import Location
 from data_rentgen.db.models.operation import Operation, OperationType
-from data_rentgen.db.models.run import Run
+from data_rentgen.db.models.run import Run, RunStartReason
 from data_rentgen.db.models.schema import Schema
 from data_rentgen.db.models.status import Status
 from data_rentgen.db.models.user import User
@@ -28,6 +28,7 @@ __all__ = [
     "Operation",
     "OperationType",
     "Run",
+    "RunStartReason",
     "Schema",
     "Status",
     "User",

--- a/data_rentgen/db/models/run.py
+++ b/data_rentgen/db/models/run.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from enum import Enum
 
 from sqlalchemy import UUID as SQL_UUID
 from sqlalchemy import BigInteger, DateTime, PrimaryKeyConstraint, String
@@ -15,6 +16,14 @@ from data_rentgen.db.models.base import Base
 from data_rentgen.db.models.job import Job
 from data_rentgen.db.models.status import Status
 from data_rentgen.db.models.user import User
+
+
+class RunStartReason(str, Enum):
+    MANUAL = "MANUAL"
+    AUTOMATIC = "AUTOMATIC"
+
+    def __str__(self) -> str:
+        return str(self.value)
 
 
 # no foreign keys to avoid scanning all the partitions
@@ -102,13 +111,18 @@ class Run(Base):
         lazy="noload",
         foreign_keys=[started_by_user_id],
     )
+    start_reason: Mapped[RunStartReason | None] = mapped_column(
+        ChoiceType(RunStartReason, impl=String(32)),
+        nullable=True,
+        doc="Start reason of the run, e.g. MANUAL or AUTOMATIC",
+    )
 
     ended_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         nullable=True,
         doc="End time of the run",
     )
-    ended_reason: Mapped[str | None] = mapped_column(
+    end_reason: Mapped[str | None] = mapped_column(
         String,
         nullable=True,
         doc="End reason of the run, e.g. exception string",

--- a/data_rentgen/db/repositories/run.py
+++ b/data_rentgen/db/repositories/run.py
@@ -4,7 +4,7 @@
 from sqlalchemy import select
 from uuid6 import UUID
 
-from data_rentgen.db.models import Run, Status
+from data_rentgen.db.models import Run, RunStartReason, Status
 from data_rentgen.db.repositories.base import Repository
 from data_rentgen.db.utils.uuid import extract_timestamp_from_uuid
 from data_rentgen.dto import RunDTO
@@ -40,12 +40,13 @@ class RunRepository(Repository[Run]):
                 status=Status(run.status) if run.status else None,
                 parent_run_id=parent_run_id,
                 started_at=run.started_at,
+                started_by_user_id=started_by_user_id,
+                start_reason=RunStartReason(run.start_reason) if run.start_reason else None,
                 ended_at=run.ended_at,
                 external_id=run.external_id,
                 attempt=run.attempt,
                 persistent_log_url=run.persistent_log_url,
                 running_log_url=run.running_log_url,
-                started_by_user_id=started_by_user_id,
             )
             self._session.add(result)
         else:
@@ -53,12 +54,13 @@ class RunRepository(Repository[Run]):
                 "status": Status(run.status) if run.status else None,
                 "parent_run_id": parent_run_id,
                 "started_at": run.started_at,
+                "started_by_user_id": started_by_user_id,
+                "start_reason": RunStartReason(run.start_reason) if run.start_reason else None,
                 "ended_at": run.ended_at,
                 "external_id": run.external_id,
                 "attempt": run.attempt,
                 "persistent_log_url": run.persistent_log_url,
                 "running_log_url": run.running_log_url,
-                "started_by_user_id": started_by_user_id,
             }
 
             for column, value in optional_fields.items():

--- a/data_rentgen/dto/__init__.py
+++ b/data_rentgen/dto/__init__.py
@@ -12,7 +12,7 @@ from data_rentgen.dto.operation import (
     OperationTypeDTO,
 )
 from data_rentgen.dto.pagination import PaginationDTO
-from data_rentgen.dto.run import RunDTO, RunStatusDTO
+from data_rentgen.dto.run import RunDTO, RunStartReasonDTO, RunStatusDTO
 from data_rentgen.dto.schema import SchemaDTO
 from data_rentgen.dto.user import UserDTO
 
@@ -30,6 +30,7 @@ __all__ = [
     "OperationTypeDTO",
     "PaginationDTO",
     "RunDTO",
+    "RunStartReasonDTO",
     "RunStatusDTO",
     "SchemaDTO",
     "UserDTO",

--- a/data_rentgen/dto/run.py
+++ b/data_rentgen/dto/run.py
@@ -19,6 +19,17 @@ class RunStatusDTO(str, Enum):
     FAILED = "FAILED"
     UNKNOWN = "UNKNOWN"
 
+    def __str__(self) -> str:
+        return str(self.value)
+
+
+class RunStartReasonDTO(str, Enum):
+    MANUAL = "MANUAL"
+    AUTOMATIC = "AUTOMATIC"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
 
 @dataclass(slots=True)
 class RunDTO:
@@ -26,6 +37,7 @@ class RunDTO:
     job: JobDTO
     status: RunStatusDTO | None = None
     started_at: datetime | None = None
+    start_reason: RunStartReasonDTO | None = None
     ended_at: datetime | None = None
     external_id: str | None = None
     attempt: str | None = None

--- a/tests/test_consumer/test_extractors/test_extractors_user.py
+++ b/tests/test_consumer/test_extractors/test_extractors_user.py
@@ -10,6 +10,7 @@ from data_rentgen.consumer.openlineage.run_event import (
 from data_rentgen.consumer.openlineage.run_facets import (
     OpenLineageAirflowDagInfo,
     OpenLineageAirflowDagRunInfo,
+    OpenLineageAirflowDagRunType,
     OpenLineageAirflowRunFacet,
     OpenLineageAirflowTaskInfo,
     OpenLineageAirflowTaskInstanceInfo,
@@ -58,6 +59,7 @@ def test_extractors_extract_run_airflow_task():
                     dag=OpenLineageAirflowDagInfo(dag_id="mydag"),
                     dagRun=OpenLineageAirflowDagRunInfo(
                         run_id="manual__123",
+                        run_type=OpenLineageAirflowDagRunType.MANUAL,
                         data_interval_start=datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc),
                         data_interval_end=datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc),
                     ),

--- a/tests/test_consumer/test_handlers/test_runs_handler_spark.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_spark.py
@@ -21,6 +21,7 @@ from data_rentgen.db.models import (
     Operation,
     OperationType,
     Run,
+    RunStartReason,
     Schema,
     Status,
 )
@@ -68,12 +69,13 @@ async def test_runs_handler_spark(
     assert application_run.job_id == jobs[0].id
     assert application_run.status == Status.SUCCEEDED
     assert application_run.started_at == datetime(2024, 7, 5, 9, 4, 48, 794900, tzinfo=timezone.utc)
+    assert application_run.started_by_user is not None
+    assert application_run.started_by_user.name == "myuser"
+    assert application_run.start_reason is None
     assert application_run.ended_at == datetime(2024, 7, 5, 9, 7, 15, 646000, tzinfo=timezone.utc)
     assert application_run.external_id == "local-1719136537510"
     assert application_run.running_log_url == "http://127.0.0.1:4040"
     assert application_run.persistent_log_url is None
-    assert application_run.started_by_user is not None
-    assert application_run.started_by_user.name == "myuser"
 
     operation_query = select(Operation).order_by(Operation.id)
     operation_scalars = await async_session.scalars(operation_query)

--- a/tests/test_consumer/test_openlineage/test_run_event_airflow.py
+++ b/tests/test_consumer/test_openlineage/test_run_event_airflow.py
@@ -23,6 +23,7 @@ from data_rentgen.consumer.openlineage.run_event import (
 from data_rentgen.consumer.openlineage.run_facets import (
     OpenLineageAirflowDagInfo,
     OpenLineageAirflowDagRunInfo,
+    OpenLineageAirflowDagRunType,
     OpenLineageAirflowRunFacet,
     OpenLineageAirflowTaskInfo,
     OpenLineageAirflowTaskInstanceInfo,
@@ -366,6 +367,7 @@ def test_run_event_airflow_task_start():
                     ),
                     dagRun=OpenLineageAirflowDagRunInfo(
                         run_id="manual__2024-07-05T09:04:12.162809+00:00",
+                        run_type=OpenLineageAirflowDagRunType.MANUAL,
                         data_interval_start=datetime(2024, 7, 5, 9, 4, 12, 162809, tzinfo=timezone.utc),
                         data_interval_end=datetime(2024, 7, 5, 9, 4, 12, 162809, tzinfo=timezone.utc),
                     ),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

* Add `Run.start_reason` field with allowed values `MANUAL`, `AUTOMATIC`. Also rename `ended_reason` to `end_reason`, for consistency.
* Add enrich function to fill up this field from Airflow `dagRun` info. For Spark we currently have no such information.
* Add tests.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
