### PR TITLE
[DOP-16676] Use Postgres advisory locks to avoid insert conflicts

### DIFF
--- a/data_rentgen/db/models/job.py
+++ b/data_rentgen/db/models/job.py
@@ -49,5 +49,6 @@ class Job(Base):
         ChoiceType(JobType, impl=String(32)),
         index=True,
         nullable=False,
+        default=JobType.UNKNOWN,
         doc="Job type, e.g. AIRFLOW_DAG, AIRFLOW_TASK, SPARK_APPLICATION",
     )

--- a/data_rentgen/db/repositories/dataset.py
+++ b/data_rentgen/db/repositories/dataset.py
@@ -5,46 +5,23 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from data_rentgen.db.models import Dataset, Location
-from data_rentgen.db.models.dataset_symlink import DatasetSymlink, DatasetSymlinkType
 from data_rentgen.db.repositories.base import Repository
 from data_rentgen.dto import DatasetDTO, PaginationDTO
 
 
 class DatasetRepository(Repository[Dataset]):
     async def create_or_update(self, dataset: DatasetDTO, location_id: int) -> Dataset:
-        statement = select(Dataset).where(
-            Dataset.location_id == location_id,
-            Dataset.name == dataset.name,
-        )
-        result = await self._session.scalar(statement)
+        result = await self._get(location_id, dataset.name)
+
         if not result:
-            result = Dataset(location_id=location_id, name=dataset.name, format=dataset.format)
-            self._session.add(result)
-        elif dataset.format:
-            result.format = dataset.format
+            # try one more time, but with lock acquired.
+            # if another worker already created the same row, just use it. if not - create with holding the lock.
+            await self._lock(location_id, dataset.name)
+            result = await self._get(location_id, dataset.name)
 
-        await self._session.flush([result])
-        return result
-
-    async def create_or_update_symlink(
-        self,
-        from_dataset_id: int,
-        to_dataset_id: int,
-        symlink_type: DatasetSymlinkType,
-    ) -> DatasetSymlink:
-        statement = select(DatasetSymlink).where(
-            DatasetSymlink.from_dataset_id == from_dataset_id,
-            DatasetSymlink.to_dataset_id == to_dataset_id,
-        )
-        result = await self._session.scalar(statement)
         if not result:
-            result = DatasetSymlink(from_dataset_id=from_dataset_id, to_dataset_id=to_dataset_id, type=symlink_type)
-            self._session.add(result)
-        else:
-            result.type = symlink_type
-
-        await self._session.flush([result])
-        return result
+            return await self._create(dataset, location_id)
+        return await self._update(result, dataset)
 
     async def paginate(self, page: int, page_size: int, dataset_id: list[int]) -> PaginationDTO[Dataset]:
         query = (
@@ -53,3 +30,19 @@ class DatasetRepository(Repository[Dataset]):
             .options(selectinload(Dataset.location).selectinload(Location.addresses))
         )
         return await self._paginate_by_query(order_by=[Dataset.id], page=page, page_size=page_size, query=query)
+
+    async def _get(self, location_id: int, name: str) -> Dataset | None:
+        statement = select(Dataset).where(Dataset.location_id == location_id, Dataset.name == name)
+        return await self._session.scalar(statement)
+
+    async def _create(self, dataset: DatasetDTO, location_id: int) -> Dataset:
+        result = Dataset(location_id=location_id, name=dataset.name, format=dataset.format)
+        self._session.add(result)
+        await self._session.flush([result])
+        return result
+
+    async def _update(self, existing: Dataset, new: DatasetDTO) -> Dataset:
+        if new.format:
+            existing.format = new.format
+            await self._session.flush([existing])
+        return existing

--- a/data_rentgen/db/repositories/dataset_symlink.py
+++ b/data_rentgen/db/repositories/dataset_symlink.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+
+from sqlalchemy import select
+
+from data_rentgen.db.models.dataset_symlink import DatasetSymlink, DatasetSymlinkType
+from data_rentgen.db.repositories.base import Repository
+
+
+class DatasetSymlinkRepository(Repository[DatasetSymlink]):
+    async def create_or_update(
+        self,
+        from_dataset_id: int,
+        to_dataset_id: int,
+        symlink_type: DatasetSymlinkType,
+    ) -> DatasetSymlink:
+        result = await self._get(from_dataset_id, to_dataset_id)
+        if not result:
+            # try one more time, but with lock acquired.
+            # if another worker already created the same row, just use it. if not - create with holding the lock.
+            await self._lock(from_dataset_id, to_dataset_id)
+            result = await self._get(from_dataset_id, to_dataset_id)
+
+        if not result:
+            return await self._create(from_dataset_id, to_dataset_id, symlink_type)
+        return await self._update(result, symlink_type)
+
+    async def _get(self, from_dataset_id: int, to_dataset_id: int) -> DatasetSymlink | None:
+        query = select(DatasetSymlink).where(
+            DatasetSymlink.from_dataset_id == from_dataset_id,
+            DatasetSymlink.to_dataset_id == to_dataset_id,
+        )
+        return await self._session.scalar(query)
+
+    async def _create(
+        self,
+        from_dataset_id: int,
+        to_dataset_id: int,
+        symlink_type: DatasetSymlinkType,
+    ) -> DatasetSymlink:
+        result = DatasetSymlink(from_dataset_id=from_dataset_id, to_dataset_id=to_dataset_id, type=symlink_type)
+        self._session.add(result)
+        await self._session.flush([result])
+        return result
+
+    async def _update(self, existing: DatasetSymlink, new_type: DatasetSymlinkType) -> DatasetSymlink:
+        existing.type = new_type
+        await self._session.flush([existing])
+        return existing

--- a/data_rentgen/db/repositories/interaction.py
+++ b/data_rentgen/db/repositories/interaction.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import datetime
+
 from sqlalchemy import select
 from uuid6 import UUID
 
@@ -25,35 +27,56 @@ class InteractionRepository(Repository[Interaction]):
         # to avoid scanning all partitions and speed up insert queries
         created_at = extract_timestamp_from_uuid(operation_id)
 
+        # instead of using UniqueConstraint on multiple fields, one of which (schema_id) can be NULL,
+        # use them to calculate unique id
         id_components = f"{operation_id}.{dataset_id}.{interaction.type}.{schema_id}"
         interaction_id = generate_incremental_uuid(created_at, id_components.encode("utf-8"))
 
-        query = select(Interaction).where(
-            Interaction.created_at == created_at,
-            Interaction.id == interaction_id,
-        )
-        result = await self._session.scalar(query)
+        result = await self._get(created_at, interaction_id)
+        if not result:
+            # try one more time, but with lock acquired.
+            # if another worker already created the same row, just use it. if not - create with holding the lock.
+            await self._lock(interaction_id)
+            result = await self._get(created_at, interaction_id)
 
         if not result:
-            result = Interaction(
-                created_at=created_at,
-                id=interaction_id,
-                operation_id=operation_id,
-                dataset_id=dataset_id,
-                type=InteractionType(interaction.type),
-                schema_id=schema_id,
-                num_bytes=interaction.num_bytes,
-                num_rows=interaction.num_rows,
-                num_files=interaction.num_files,
-            )
-            self._session.add(result)
-        else:
-            if interaction.num_bytes is not None:
-                result.num_bytes = interaction.num_bytes
-            if interaction.num_rows is not None:
-                result.num_rows = interaction.num_rows
-            if interaction.num_files is not None:
-                result.num_files = interaction.num_files
+            return await self._create(created_at, interaction_id, interaction, operation_id, dataset_id, schema_id)
+        return await self._update(result, interaction)
 
+    async def _get(self, created_at: datetime, interaction_id: UUID) -> Interaction | None:
+        query = select(Interaction).where(Interaction.created_at == created_at, Interaction.id == interaction_id)
+        return await self._session.scalar(query)
+
+    async def _create(
+        self,
+        created_at: datetime,
+        interaction_id: UUID,
+        interaction: InteractionDTO,
+        operation_id: UUID,
+        dataset_id: int,
+        schema_id: int | None = None,
+    ) -> Interaction:
+        result = Interaction(
+            created_at=created_at,
+            id=interaction_id,
+            operation_id=operation_id,
+            dataset_id=dataset_id,
+            type=InteractionType(interaction.type),
+            schema_id=schema_id,
+            num_bytes=interaction.num_bytes,
+            num_rows=interaction.num_rows,
+            num_files=interaction.num_files,
+        )
+        self._session.add(result)
         await self._session.flush([result])
         return result
+
+    async def _update(self, existing: Interaction, new: InteractionDTO) -> Interaction:
+        if new.num_bytes is not None:
+            existing.num_bytes = new.num_bytes
+        if new.num_rows is not None:
+            existing.num_rows = new.num_rows
+        if new.num_files is not None:
+            existing.num_files = new.num_files
+        await self._session.flush([existing])
+        return existing

--- a/data_rentgen/db/repositories/location.py
+++ b/data_rentgen/db/repositories/location.py
@@ -11,6 +11,15 @@ from data_rentgen.dto import LocationDTO
 
 class LocationRepository(Repository[Location]):
     async def get_or_create(self, location: LocationDTO) -> Location:
+        result = await self._get(location)
+        if not result:
+            await self._lock(location.type, location.name)
+            result = await self._get(location) or await self._create(location)
+
+        await self._update_addresses(result, location)
+        return result
+
+    async def _get(self, location: LocationDTO) -> Location | None:
         by_name = select(Location).where(Location.type == location.type, Location.name == location.name)
         by_addresses = (
             select(Location)
@@ -21,17 +30,19 @@ class LocationRepository(Repository[Location]):
             select(Location).from_statement(by_name.union(by_addresses)).options(selectinload(Location.addresses))
         )
 
-        result = await self._session.scalar(statement)
-        if not result:
-            result = Location(type=location.type, name=location.name)
-            self._session.add(result)
-            await self._session.flush([result])
+        return await self._session.scalar(statement)
 
-        existing_urls = {address.url for address in result.addresses}
-        new_urls = set(location.addresses) - existing_urls
-        if new_urls:
-            addresses = [Address(url=url, location_id=result.id) for url in new_urls]
-            result.addresses.extend(addresses)
-
+    async def _create(self, location: LocationDTO) -> Location:
+        result = Location(type=location.type, name=location.name)
+        self._session.add(result)
         await self._session.flush([result])
         return result
+
+    async def _update_addresses(self, existing: Location, new: LocationDTO) -> Location:
+        existing_urls = {address.url for address in existing.addresses}
+        new_urls = set(new.addresses) - existing_urls
+        if new_urls:
+            addresses = [Address(url=url, location_id=existing.id) for url in new_urls]
+            existing.addresses.extend(addresses)
+            await self._session.flush([existing])
+        return existing

--- a/data_rentgen/db/repositories/operation.py
+++ b/data_rentgen/db/repositories/operation.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import select
@@ -13,39 +14,53 @@ from data_rentgen.dto import OperationDTO
 
 class OperationRepository(Repository[Operation]):
     async def create_or_update(self, operation: OperationDTO, run_id: UUID | None) -> Operation:
+        # avoid calculating created_at twice
         created_at = extract_timestamp_from_uuid(operation.id)
-        query = select(Operation).where(
-            Operation.created_at == created_at,
-            Operation.id == operation.id,
-        )
-        result = await self._session.scalar(query)
+        result = await self._get(created_at, operation.id)
         if not result:
-            result = Operation(
-                created_at=created_at,
-                id=operation.id,
-                run_id=run_id,
-                name=operation.name,
-                type=OperationType(operation.type) if operation.type else OperationType.BATCH,
-                status=Status(operation.status) if operation.status else Status.UNKNOWN,
-                started_at=operation.started_at,
-                ended_at=operation.ended_at,
-                description=operation.description,
-                position=operation.position,
-            )
-            self._session.add(result)
-        else:
-            optional_fields = {
-                # Operation run_id and type are not null while operation is created, but may be empty in later events
-                "type": OperationType(operation.type) if operation.type else None,
-                "status": Status(operation.status) if operation.status else None,
-                "started_at": operation.started_at,
-                "ended_at": operation.ended_at,
-                "description": operation.description,
-                "position": operation.position,
-            }
-            for column, value in optional_fields.items():
-                if value is not None:
-                    setattr(result, column, value)
+            # try one more time, but with lock acquired.
+            # if another worker already created the same row, just use it. if not - create with holding the lock.
+            await self._lock(operation.id)
+            result = await self._get(created_at, operation.id)
 
+        if not result:
+            # run_id is always present in first event, but may be missing in later ones
+            return await self._create(created_at, operation, run_id)  # type: ignore[arg-type]
+        return await self._update(result, operation)
+
+    async def _get(self, created_at: datetime, operation_id: UUID) -> Operation | None:
+        query = select(Operation).where(Operation.created_at == created_at, Operation.id == operation_id)
+        return await self._session.scalar(query)
+
+    async def _create(self, created_at: datetime, operation: OperationDTO, run_id: UUID) -> Operation:
+        result = Operation(
+            created_at=created_at,
+            id=operation.id,
+            run_id=run_id,
+            name=operation.name,
+            type=OperationType(operation.type),
+            status=Status(operation.status) if operation.status else Status.UNKNOWN,
+            started_at=operation.started_at,
+            ended_at=operation.ended_at,
+            description=operation.description,
+            position=operation.position,
+        )
+        self._session.add(result)
         await self._session.flush([result])
         return result
+
+    async def _update(self, existing: Operation, new: OperationDTO) -> Operation:
+        optional_fields = {
+            "type": OperationType(new.type) if new.type else None,
+            "status": Status(new.status) if new.status else None,
+            "started_at": new.started_at,
+            "ended_at": new.ended_at,
+            "description": new.description,
+            "position": new.position,
+        }
+        for column, value in optional_fields.items():
+            if value is not None:
+                setattr(existing, column, value)
+
+        await self._session.flush([existing])
+        return existing

--- a/data_rentgen/db/repositories/run.py
+++ b/data_rentgen/db/repositories/run.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import datetime
+
 from sqlalchemy import select
 from uuid6 import UUID
 
@@ -12,14 +14,14 @@ from data_rentgen.dto import RunDTO
 
 class RunRepository(Repository[Run]):
     async def get_or_create_minimal(self, run: RunDTO, job_id: int) -> Run:
+        # avoid calculating created_at twice
         created_at = extract_timestamp_from_uuid(run.id)
-        query = select(Run).where(Run.id == run.id, Run.created_at == created_at)
-        result = await self._session.scalar(query)
+        result = await self._get(created_at, run.id)
         if not result:
-            result = Run(id=run.id, created_at=created_at, job_id=job_id)
-            self._session.add(result)
-            await self._session.flush([result])
-
+            # try one more time, but with lock acquired.
+            # if another worker already created the same row, just use it. if not - create with holding the lock.
+            await self._lock(run.id)
+            result = await self._get(created_at, run.id) or await self._create(created_at, run, job_id)
         return result
 
     async def create_or_update(
@@ -29,43 +31,72 @@ class RunRepository(Repository[Run]):
         parent_run_id: UUID | None,
         started_by_user_id: int | None,
     ) -> Run:
+        # avoid calculating created_at twice
         created_at = extract_timestamp_from_uuid(run.id)
-        query = select(Run).where(Run.id == run.id, Run.created_at == created_at)
-        result = await self._session.scalar(query)
+        result = await self._get(created_at, run.id)
         if not result:
-            result = Run(
-                id=run.id,
-                created_at=created_at,
-                job_id=job_id,
-                status=Status(run.status) if run.status else None,
-                parent_run_id=parent_run_id,
-                started_at=run.started_at,
-                started_by_user_id=started_by_user_id,
-                start_reason=RunStartReason(run.start_reason) if run.start_reason else None,
-                ended_at=run.ended_at,
-                external_id=run.external_id,
-                attempt=run.attempt,
-                persistent_log_url=run.persistent_log_url,
-                running_log_url=run.running_log_url,
-            )
-            self._session.add(result)
-        else:
-            optional_fields = {
-                "status": Status(run.status) if run.status else None,
-                "parent_run_id": parent_run_id,
-                "started_at": run.started_at,
-                "started_by_user_id": started_by_user_id,
-                "start_reason": RunStartReason(run.start_reason) if run.start_reason else None,
-                "ended_at": run.ended_at,
-                "external_id": run.external_id,
-                "attempt": run.attempt,
-                "persistent_log_url": run.persistent_log_url,
-                "running_log_url": run.running_log_url,
-            }
+            # try one more time, but with lock acquired.
+            # if another worker already created the same row, just use it. if not - create with holding the lock.
+            await self._lock(run.id)
+            result = await self._get(created_at, run.id)
 
-            for column, value in optional_fields.items():
-                if value is not None:
-                    setattr(result, column, value)
+        if not result:
+            return await self._create(created_at, run, job_id, parent_run_id, started_by_user_id)
+        return await self._update(result, run, parent_run_id, started_by_user_id)
 
+    async def _get(self, created_at: datetime, run_id: UUID) -> Run | None:
+        query = select(Run).where(Run.id == run_id, Run.created_at == created_at)
+        return await self._session.scalar(query)
+
+    async def _create(
+        self,
+        created_at: datetime,
+        run: RunDTO,
+        job_id: int,
+        parent_run_id: UUID | None = None,
+        started_by_user_id: int | None = None,
+    ) -> Run:
+        result = Run(
+            created_at=created_at,
+            id=run.id,
+            job_id=job_id,
+            status=Status(run.status) if run.status else Status.UNKNOWN,
+            parent_run_id=parent_run_id,
+            started_at=run.started_at,
+            started_by_user_id=started_by_user_id,
+            start_reason=RunStartReason(run.start_reason) if run.start_reason else None,
+            ended_at=run.ended_at,
+            external_id=run.external_id,
+            attempt=run.attempt,
+            persistent_log_url=run.persistent_log_url,
+            running_log_url=run.running_log_url,
+        )
+        self._session.add(result)
         await self._session.flush([result])
         return result
+
+    async def _update(
+        self,
+        existing: Run,
+        new: RunDTO,
+        parent_run_id: UUID | None = None,
+        started_by_user_id: int | None = None,
+    ) -> Run:
+        optional_fields = {
+            "status": Status(new.status) if new.status else None,
+            "parent_run_id": parent_run_id,
+            "started_at": new.started_at,
+            "started_by_user_id": started_by_user_id,
+            "start_reason": RunStartReason(new.start_reason) if new.start_reason else None,
+            "ended_at": new.ended_at,
+            "external_id": new.external_id,
+            "attempt": new.attempt,
+            "persistent_log_url": new.persistent_log_url,
+            "running_log_url": new.running_log_url,
+        }
+        for column, value in optional_fields.items():
+            if value is not None:
+                setattr(existing, column, value)
+
+        await self._session.flush([existing])
+        return existing

--- a/data_rentgen/db/repositories/schema.py
+++ b/data_rentgen/db/repositories/schema.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
+from uuid import UUID
+
 from sqlalchemy import select
 
 from data_rentgen.db.models import Schema
@@ -11,16 +13,22 @@ from data_rentgen.dto import SchemaDTO
 
 class SchemaRepository(Repository[Schema]):
     async def get_or_create(self, schema: SchemaDTO) -> Schema:
-        statement = select(Schema).where(
-            Schema.digest == get_fields_digest(schema.fields),
-        )
-        result = await self._session.scalar(statement)
+        # avoid calculating digest twice
+        digest = get_fields_digest(schema.fields)
+        result = await self._get(digest)
         if not result:
-            result = Schema(
-                digest=get_fields_digest(schema.fields),
-                fields=schema.fields,
-            )
-            self._session.add(result)
-            await self._session.flush([result])
+            # try one more time, but with lock acquired.
+            # if another worker already created the same row, just use it. if not - create with holding the lock.
+            await self._lock(digest)
+            result = await self._get(digest) or await self._create(digest, schema)
+        return result
 
+    async def _get(self, digest: UUID) -> Schema | None:
+        statement = select(Schema).where(Schema.digest == digest)
+        return await self._session.scalar(statement)
+
+    async def _create(self, digest: UUID, schema: SchemaDTO) -> Schema:
+        result = Schema(digest=digest, fields=schema.fields)
+        self._session.add(result)
+        await self._session.flush([result])
         return result

--- a/data_rentgen/db/repositories/user.py
+++ b/data_rentgen/db/repositories/user.py
@@ -10,11 +10,18 @@ from data_rentgen.dto import UserDTO
 
 class UserRepository(Repository[User]):
     async def get_or_create(self, user: UserDTO) -> User:
-        statement = select(User).where(User.name == user.name)
-        result = await self._session.scalar(statement)
+        result = await self._get(user.name)
         if not result:
-            result = User(name=user.name)
-            self._session.add(result)
-            await self._session.flush([result])
+            await self._lock(user.name)
+            result = await self._get(user.name) or await self._create(user)
+        return result
 
+    async def _get(self, name: str) -> User | None:
+        statement = select(User).where(User.name == name)
+        return await self._session.scalar(statement)
+
+    async def _create(self, user: UserDTO) -> User:
+        result = User(name=user.name)
+        self._session.add(result)
+        await self._session.flush([result])
         return result

--- a/data_rentgen/services/uow.py
+++ b/data_rentgen/services/uow.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
 from data_rentgen.db.repositories.dataset import DatasetRepository
+from data_rentgen.db.repositories.dataset_symlink import DatasetSymlinkRepository
 from data_rentgen.db.repositories.interaction import InteractionRepository
 from data_rentgen.db.repositories.job import JobRepository
 from data_rentgen.db.repositories.location import LocationRepository
@@ -27,6 +28,7 @@ class UnitOfWork:
         self.run = RunRepository(session)
         self.operation = OperationRepository(session)
         self.dataset = DatasetRepository(session)
+        self.dataset_symlink = DatasetSymlinkRepository(session)
         self.schema = SchemaRepository(session)
         self.interaction = InteractionRepository(session)
         self.user = UserRepository(session)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Using multiple FastStream workers to handle events in parallel may lead to insert conflicts - both workers try to create the same parent job or the same dataset, one worker commits first, and the second worker fails because of unique index/constraint violation.

Instead, if some row does not exist yet, try to acquire a lock using [pg_advisory_xact_lock](https://www.postgresql.org/docs/current/functions-admin.html), insert the row, and release the lock when transaction is ended. Another worker will be unable to insert the same row, until the lock is released.

Currently there are no explicit tests for this behavior, because it is hard to start multiple parallel workers with pytest. This may require integration tests with real workers running in the background, which will be probably implemented in future.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
