### PR TITLE
[DOP-18989] Fix InvalidRequest schema not used by FastAPI

### DIFF
--- a/data_rentgen/server/api/handlers.py
+++ b/data_rentgen/server/api/handlers.py
@@ -7,6 +7,7 @@ import logging
 
 from asgi_correlation_id import correlation_id
 from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.exceptions import RequestValidationError
 from pydantic import ValidationError
 
 from data_rentgen.server.errors.base import APIErrorSchema, BaseErrorSchema
@@ -107,6 +108,10 @@ def exception_json_response(
 
 def apply_exception_handlers(app: FastAPI) -> None:
     app.add_exception_handler(ApplicationError, application_exception_handler)  # type: ignore[arg-type]
+    app.add_exception_handler(
+        RequestValidationError,
+        validation_exception_handler,  # type: ignore[arg-type]
+    )
     app.add_exception_handler(
         ValidationError,
         validation_exception_handler,  # type: ignore[arg-type]

--- a/tests/test_server/test_get_datasets.py
+++ b/tests/test_server/test_get_datasets.py
@@ -3,10 +3,8 @@ from http import HTTPStatus
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
-from sqlalchemy.sql import select
 
-from data_rentgen.db.models import Dataset, Location
+from data_rentgen.db.models import Dataset
 from tests.test_server.utils.enrich import enrich_datasets
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
@@ -21,7 +19,7 @@ async def test_get_dataset_by_missing_id(
         params={"dataset_id": new_dataset.id},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
@@ -50,7 +48,7 @@ async def test_get_dataset(
         params={"dataset_id": dataset.id},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
@@ -91,7 +89,7 @@ async def test_get_datasets_by_multiple_ids(
         params={"dataset_id": [dataset.id for dataset in datasets]},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
@@ -128,12 +126,12 @@ async def test_get_datasets_no_filters(
     datasets = await enrich_datasets(datasets, async_session)
     response = await test_client.get("v1/datasets")
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
             "page_size": 20,
-            "total_count": 2,
+            "total_count": len(datasets),
             "pages_count": 1,
             "has_next": False,
             "has_previous": False,

--- a/tests/test_server/test_get_jobs.py
+++ b/tests/test_server/test_get_jobs.py
@@ -21,7 +21,7 @@ async def test_get_jobs_by_unknown_id(
         params={"job_id": new_job.id},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
@@ -50,7 +50,7 @@ async def test_get_jobs_by_one_id(
         params={"job_id": job.id},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
@@ -90,7 +90,7 @@ async def test_get_jobs_by_multiple_ids(
         params={"job_id": [job.id for job in selected_jobs]},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
@@ -126,7 +126,7 @@ async def test_get_jobs_no_filters(
     jobs = await enrich_jobs(jobs, async_session)
     response = await test_client.get("v1/jobs")
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,

--- a/tests/test_server/test_get_operations_by_id.py
+++ b/tests/test_server/test_get_operations_by_id.py
@@ -45,7 +45,7 @@ async def test_get_operations_by_missing_id(
         params={"operation_id": str(new_operation.id)},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
@@ -70,7 +70,7 @@ async def test_get_operations_by_one_id(
         params={"operation_id": str(operation.id)},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
@@ -111,7 +111,7 @@ async def test_get_operations_by_multiple_ids(
         params={"operation_id": [str(operation.id) for operation in selected_operations]},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,

--- a/tests/test_server/test_get_operations_by_run_id.py
+++ b/tests/test_server/test_get_operations_by_run_id.py
@@ -124,7 +124,7 @@ async def test_get_operations_by_missing_run_id(
         },
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
@@ -160,7 +160,7 @@ async def test_get_operations_by_run_id(
         },
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
@@ -210,7 +210,7 @@ async def test_get_operations_by_run_id_with_until(
         },
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,

--- a/tests/test_server/test_get_runs_by_id.py
+++ b/tests/test_server/test_get_runs_by_id.py
@@ -69,7 +69,7 @@ async def test_get_runs_by_missing_id(
         params={"run_id": str(new_run.id)},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
@@ -98,7 +98,7 @@ async def test_get_runs_by_one_id(
         params={"run_id": str(run.id)},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
@@ -144,7 +144,7 @@ async def test_get_runs_by_multiple_ids(
         params={"run_id": [str(run.id) for run in selected_runs]},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,

--- a/tests/test_server/test_get_runs_by_job_id.py
+++ b/tests/test_server/test_get_runs_by_job_id.py
@@ -126,7 +126,7 @@ async def test_get_runs_by_job_id_missing(
         params={"since": new_run.created_at.isoformat(), "job_id": new_run.job_id},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
@@ -166,7 +166,7 @@ async def test_get_runs_by_job_id(
         },
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,
@@ -220,7 +220,7 @@ async def test_get_runs_time_range(
         },
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "meta": {
             "page": 1,

--- a/tests/test_server/test_lineage/test_job_lineage.py
+++ b/tests/test_server/test_lineage/test_job_lineage.py
@@ -34,7 +34,7 @@ async def test_get_job_lineage(
         },
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "relations": [
             {
@@ -152,7 +152,7 @@ async def test_get_job_lineage_with_direction_and_until(
         },
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "relations": [
             {

--- a/tests/test_server/test_lineage/test_operation_lineage.py
+++ b/tests/test_server/test_lineage/test_operation_lineage.py
@@ -34,7 +34,7 @@ async def test_get_operation_lineage(
         },
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "relations": [
             {
@@ -150,7 +150,7 @@ async def test_get_operation_lineage_with_direction_and_until(
         },
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "relations": [
             {

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -4,10 +4,8 @@ from http import HTTPStatus
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
-from sqlalchemy.sql import select
 
-from data_rentgen.db.models import Dataset, Interaction, Job, Location, Operation, Run
+from data_rentgen.db.models import Dataset, Interaction, Job, Operation, Run
 from tests.test_server.utils.enrich import enrich_datasets, enrich_jobs, enrich_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
@@ -36,7 +34,7 @@ async def test_get_run_lineage(
         },
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "relations": [
             {
@@ -153,7 +151,7 @@ async def test_get_run_lineage_with_direction_and_until(
         },
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "relations": [
             {

--- a/tests/test_server/test_search/test_dataset.py
+++ b/tests/test_server/test_search/test_dataset.py
@@ -11,13 +11,24 @@ from tests.test_server.utils.enrich import enrich_datasets
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
 
-async def test_dataset_search_no_query(test_client: AsyncClient, datasets: list[Dataset]) -> None:
-
+async def test_dataset_search_no_query(test_client: AsyncClient) -> None:
     response = await test_client.get("/v1/datasets/search")
 
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     assert response.json() == {
-        "detail": [{"input": None, "loc": ["query", "search_query"], "msg": "Field required", "type": "missing"}],
+        "error": {
+            "code": "invalid_request",
+            "message": "Invalid request",
+            "details": [
+                {
+                    "location": ["query", "search_query"],
+                    "code": "missing",
+                    "message": "Field required",
+                    "input": None,
+                    "context": {},
+                },
+            ],
+        },
     }
 
 
@@ -34,7 +45,7 @@ async def test_dataset_search_in_addres_url(
         params={"search_query": "namenode"},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "items": [
             {
@@ -111,7 +122,7 @@ async def test_dataset_search_in_location_name(
         params={"search_query": "postgres.location"},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
 
     # At this case the order is unstable
     response_diff = DeepDiff(expected_response, response.json(), ignore_order=True)
@@ -157,7 +168,7 @@ async def test_dataset_search_in_dataset_name(
         params={"search_query": "location_history"},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == expected_response
 
 
@@ -204,7 +215,7 @@ async def test_dataset_search_in_location_name_and_address_url(
         params={"search_query": "my-cluster"},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
 
     # At this case the order is unstable
     response_diff = DeepDiff(expected_response, response.json(), ignore_order=True)

--- a/tests/test_server/test_search/test_job.py
+++ b/tests/test_server/test_search/test_job.py
@@ -15,7 +15,19 @@ async def test_job_search_no_query(test_client: AsyncClient) -> None:
     response = await test_client.get("/v1/jobs/search")
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     assert response.json() == {
-        "detail": [{"input": None, "loc": ["query", "search_query"], "msg": "Field required", "type": "missing"}],
+        "error": {
+            "code": "invalid_request",
+            "message": "Invalid request",
+            "details": [
+                {
+                    "location": ["query", "search_query"],
+                    "code": "missing",
+                    "message": "Field required",
+                    "input": None,
+                    "context": {},
+                },
+            ],
+        },
     }
 
 
@@ -32,7 +44,7 @@ async def test_job_search_in_addres_url(
         params={"search_query": "airflow-host"},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "items": [
             {
@@ -98,7 +110,7 @@ async def test_job_search_in_location_name(
         params={"search_query": "data-product"},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
 
     response_diff = DeepDiff(expected_response, response.json(), ignore_order=True)
     assert not response_diff, f"Response diff: {response_diff.to_json()}"
@@ -190,7 +202,7 @@ async def test_job_search_in_location_name_and_address_url(
         params={"search_query": "my-cluster"},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
 
     # At this case the order is unstable
     response_diff = DeepDiff(expected_response, response.json(), ignore_order=True)

--- a/tests/test_server/test_search/test_run.py
+++ b/tests/test_server/test_search/test_run.py
@@ -15,7 +15,19 @@ async def test_run_search_no_query(test_client: AsyncClient) -> None:
     response = await test_client.get("/v1/runs/search")
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     assert response.json() == {
-        "detail": [{"input": None, "loc": ["query", "search_query"], "msg": "Field required", "type": "missing"}],
+        "error": {
+            "code": "invalid_request",
+            "message": "Invalid request",
+            "details": [
+                {
+                    "location": ["query", "search_query"],
+                    "code": "missing",
+                    "message": "Field required",
+                    "input": None,
+                    "context": {},
+                },
+            ],
+        },
     }
 
 
@@ -65,7 +77,7 @@ async def test_run_search_in_external_id(
         params={"search_query": "1638922609021"},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     # At this case the order is unstable
     response_diff = DeepDiff(expected_response, response.json(), ignore_order=True)
     assert not response_diff, f"Response diff: {response_diff.to_json()}"
@@ -114,7 +126,7 @@ async def test_run_search_in_job_name(
         params={"search_query": "airflow_dag"},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
     # At this case the order is unstable
     response_diff = DeepDiff(expected_response, response.json(), ignore_order=True)
     assert not response_diff, f"Response diff: {response_diff.to_json()}"
@@ -166,7 +178,7 @@ async def test_run_search_in_job_type(
         params={"search_query": "SPARK"},
     )
 
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK, response.json()
 
     # At this case the order is unstable
     response_diff = DeepDiff(expected_response, response.json(), ignore_order=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

* Sometimes `InvalidRequest` error schema was not used by FastAPI, fixed
* Show full json response if assert for response code is failed
* Endpoint validation tests does not actually need entities to exist in the database, removed useless fixtures

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
