### PR TITLE
[DOP-18989] Add depth option to lineage endpoint

### DIFF
--- a/data_rentgen/db/repositories/dataset.py
+++ b/data_rentgen/db/repositories/dataset.py
@@ -34,6 +34,8 @@ class DatasetRepository(Repository[Dataset]):
         return await self._paginate_by_query(order_by=[Dataset.name], page=page, page_size=page_size, query=query)
 
     async def list_by_ids(self, dataset_ids: Iterable[int]) -> list[Dataset]:
+        if not dataset_ids:
+            return []
         query = (
             select(Dataset)
             .where(Dataset.id.in_(dataset_ids))

--- a/data_rentgen/db/repositories/job.py
+++ b/data_rentgen/db/repositories/job.py
@@ -33,6 +33,8 @@ class JobRepository(Repository[Job]):
         return await self._update(result, job)
 
     async def list_by_ids(self, job_ids: Iterable[int]) -> list[Job]:
+        if not job_ids:
+            return []
         query = (
             select(Job).where(Job.id.in_(job_ids)).options(selectinload(Job.location).selectinload(Location.addresses))
         )

--- a/data_rentgen/db/repositories/operation.py
+++ b/data_rentgen/db/repositories/operation.py
@@ -72,6 +72,8 @@ class OperationRepository(Repository[Operation]):
         return list(result.all())
 
     async def list_by_ids(self, operation_ids: Iterable[UUID]) -> list[Operation]:
+        if not operation_ids:
+            return []
         created_at = extract_timestamp_from_uuid(min(i for i in operation_ids))
         query = select(Operation).where(Operation.created_at >= created_at, Operation.id.in_(operation_ids))
         result = await self._session.scalars(query)

--- a/data_rentgen/db/repositories/run.py
+++ b/data_rentgen/db/repositories/run.py
@@ -74,6 +74,8 @@ class RunRepository(Repository[Run]):
         return await self._paginate_by_query(order_by=[Run.id], page=page, page_size=page_size, query=query)
 
     async def list_by_ids(self, run_ids: Iterable[UUID]) -> list[Run]:
+        if not run_ids:
+            return []
         created_at = extract_timestamp_from_uuid(min(i for i in run_ids))
         query = (
             select(Run)

--- a/data_rentgen/server/api/v1/router/lineage.py
+++ b/data_rentgen/server/api/v1/router/lineage.py
@@ -40,21 +40,25 @@ async def get_lineage(
             get_lineage_method = lineage_service.get_lineage_by_jobs  # type: ignore[assignment]
 
     lineage = await get_lineage_method(
-        point_id=pagination_args.point_id,  # type: ignore[arg-type]
+        point_ids=[pagination_args.point_id],  # type: ignore[list-item]
         direction=pagination_args.direction,
         since=pagination_args.since,
         until=pagination_args.until,
+        depth=pagination_args.depth,
     )
 
     response = LineageResponseV1()
 
-    for job in lineage.jobs:
+    for job_id in sorted(lineage.jobs):
+        job = lineage.jobs[job_id]
         response.nodes.append(JobResponseV1.model_validate(job))
 
-    for dataset in lineage.datasets:
+    for dataset_id in sorted(lineage.datasets):
+        dataset = lineage.datasets[dataset_id]
         response.nodes.append(DatasetResponseV1.model_validate(dataset))
 
-    for run in lineage.runs:
+    for run_id in sorted(lineage.runs):
+        run = lineage.runs[run_id]
         response.relations.append(
             LineageRelationv1(
                 kind=LineageRelationKindV1.PARENT,
@@ -64,7 +68,8 @@ async def get_lineage(
         )
         response.nodes.append(RunResponseV1.model_validate(run))
 
-    for operation in lineage.operations:
+    for operation_id in sorted(lineage.operations):
+        operation = lineage.operations[operation_id]
         response.relations.append(
             LineageRelationv1(
                 kind=LineageRelationKindV1.PARENT,

--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -71,11 +71,22 @@ class LineageQueryV1(BaseModel):
         Query(description="Type of the Lineage start point", examples=["job"]),
     )
     point_id: int | UUID = Field(
-        Query(description="Id of the Lineage start point"),
-        examples=[42, "01913217-b761-7b1a-bb52-489da9c8b9c8"],
+        Query(
+            description="Id of the Lineage start point",
+            examples=[42, "01913217-b761-7b1a-bb52-489da9c8b9c8"],
+        ),
     )
     direction: LineageDirectionV1 = Field(
         Query(description="Direction of the lineage", examples=["from"]),
+    )
+    depth: int = Field(
+        Query(
+            default=1,
+            ge=1,
+            le=3,
+            description="Depth of the lineage",
+            examples=[1, 2, 3],
+        ),
     )
 
     @field_validator("until", mode="after")

--- a/data_rentgen/server/services/lineage.py
+++ b/data_rentgen/server/services/lineage.py
@@ -1,11 +1,13 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, Iterable
 
 from fastapi import Depends
+from uuid6 import UUID
 
 from data_rentgen.db.models.dataset import Dataset
 from data_rentgen.db.models.interaction import Interaction
@@ -15,19 +17,51 @@ from data_rentgen.db.models.run import Run
 from data_rentgen.dto.interaction import InteractionTypeDTO
 from data_rentgen.server.schemas.v1.lineage import LineageDirectionV1
 from data_rentgen.services.uow import UnitOfWork
-from data_rentgen.utils import UUID
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
 class LineageServiceResult:
-    jobs: list[Job] = field(default_factory=list)
-    runs: list[Run] = field(default_factory=list)
-    operations: list[Operation] = field(default_factory=list)
-    datasets: list[Dataset] = field(default_factory=list)
+    jobs: dict[int, Job] = field(default_factory=dict)
+    runs: dict[UUID, Run] = field(default_factory=dict)
+    operations: dict[UUID, Operation] = field(default_factory=dict)
+    datasets: dict[int, Dataset] = field(default_factory=dict)
     interactions: list[Interaction] = field(default_factory=list)
 
+    def merge(self, other: "LineageServiceResult") -> "LineageServiceResult":
+        self.jobs.update(other.jobs)
+        self.runs.update(other.runs)
+        self.operations.update(other.operations)
+        self.datasets.update(other.datasets)
+        self.interactions.extend(other.interactions)
+        return self
 
-# TODO: Add depth logic: DOP-18989
+
+@dataclass
+class IdsToSkip:
+    jobs: set[int] = field(default_factory=set)
+    runs: set[UUID] = field(default_factory=set)
+    operations: set[UUID] = field(default_factory=set)
+    datasets: set[int] = field(default_factory=set)
+
+    @classmethod
+    def from_result(cls, result: LineageServiceResult) -> "IdsToSkip":
+        return cls(
+            jobs=set(result.jobs.keys()),
+            runs=set(result.runs.keys()),
+            operations=set(result.operations.keys()),
+            datasets=set(result.datasets.keys()),
+        )
+
+    def merge(self, other: "IdsToSkip") -> "IdsToSkip":
+        self.jobs.update(other.jobs)
+        self.runs.update(other.runs)
+        self.operations.update(other.operations)
+        self.datasets.update(other.datasets)
+        return self
+
+
 # TODO: Add granularity logic: DOP-18988
 class LineageService:
     def __init__(self, uow: Annotated[UnitOfWork, Depends()]):
@@ -35,130 +69,300 @@ class LineageService:
 
     async def get_lineage_by_jobs(
         self,
-        point_id: int,
+        point_ids: Iterable[int],
         direction: LineageDirectionV1,
         since: datetime,
         until: datetime | None,
+        depth: int,
     ) -> LineageServiceResult:
-        jobs = await self._uow.job.list_by_ids([point_id])
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(
+                "Get lineage by jobs %r, with direction %s, since %s, until %s, depth %s",
+                sorted(point_ids),
+                direction,
+                since,
+                until,
+                depth,
+            )
+        jobs = await self._uow.job.list_by_ids(point_ids)
+        jobs_by_id = {job.id: job for job in jobs}
         if not jobs:
+            logger.info("No jobs found")
             return LineageServiceResult()
 
-        runs = await self._uow.run.list_by_job_ids({job.id for job in jobs}, since, until)
-        operations = await self._uow.operation.list_by_run_ids({run.id for run in runs}, since, until)
+        runs = await self._uow.run.list_by_job_ids(jobs_by_id.keys(), since, until)
+        runs_by_id = {run.id: run for run in runs}
+
+        operations = await self._uow.operation.list_by_run_ids(runs_by_id.keys(), since, until)
+        operations_by_id = {operation.id: operation for operation in operations}
 
         interaction_types = self.get_interaction_types(direction)
         interactions = await self._uow.interaction.list_by_operation_ids(
-            {operation.id for operation in operations},
+            operations_by_id.keys(),
             interaction_types,
             since,
             until,
         )
 
         datasets = await self._uow.dataset.list_by_ids({interaction.dataset_id for interaction in interactions})
-        return LineageServiceResult(
-            datasets=datasets,
+        datasets_by_id = {dataset.id: dataset for dataset in datasets}
+
+        result = LineageServiceResult(
+            datasets=datasets_by_id,
             interactions=interactions,
-            operations=operations,
-            runs=runs,
-            jobs=jobs,
+            operations=operations_by_id,
+            runs=runs_by_id,
+            jobs=jobs_by_id,
         )
+        if depth > 1:
+            result.merge(
+                await self.get_lineage_by_datasets(
+                    point_ids=datasets_by_id.keys(),
+                    direction=direction,
+                    since=since,
+                    until=until,
+                    depth=depth - 1,
+                    ids_to_skip=IdsToSkip.from_result(result),
+                ),
+            )
+
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(
+                "Found %d datasets, %d interactions, %d operations, %d runs, %d jobs",
+                len(result.datasets),
+                len(result.interactions),
+                len(result.operations),
+                len(result.runs),
+                len(result.jobs),
+            )
+        return result
 
     async def get_lineage_by_runs(
         self,
-        point_id: UUID,
+        point_ids: Iterable[UUID],
         direction: LineageDirectionV1,
         since: datetime,
         until: datetime | None,
+        depth: int,
     ) -> LineageServiceResult:
-        runs = await self._uow.run.list_by_ids([point_id])
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(
+                "Get lineage by runs %r, with direction %s, since %s, until %s, depth %s",
+                sorted(point_ids),
+                direction,
+                since,
+                until,
+                depth,
+            )
+
+        runs = await self._uow.run.list_by_ids(point_ids)
+        runs_by_id = {run.id: run for run in runs}
         if not runs:
+            logger.info("No runs found")
             return LineageServiceResult()
 
-        operations = await self._uow.operation.list_by_run_ids({run.id for run in runs}, since, until)
+        operations = await self._uow.operation.list_by_run_ids(runs_by_id.keys(), since, until)
+        operations_by_id = {operation.id: operation for operation in operations}
 
         interaction_types = self.get_interaction_types(direction)
         interactions = await self._uow.interaction.list_by_operation_ids(
-            {operation.id for operation in operations},
+            operations_by_id.keys(),
             interaction_types,
             since,
             until,
         )
 
         datasets = await self._uow.dataset.list_by_ids({interaction.dataset_id for interaction in interactions})
-        jobs = await self._uow.job.list_by_ids({run.job_id for run in runs})
+        datasets_by_id = {dataset.id: dataset for dataset in datasets}
 
-        return LineageServiceResult(
-            datasets=datasets,
+        jobs = await self._uow.job.list_by_ids({run.job_id for run in runs})
+        jobs_by_id = {job.id: job for job in jobs}
+
+        result = LineageServiceResult(
+            datasets=datasets_by_id,
             interactions=interactions,
-            operations=operations,
-            runs=runs,
-            jobs=jobs,
+            operations=operations_by_id,
+            runs=runs_by_id,
+            jobs=jobs_by_id,
         )
+        if depth > 1:
+            result.merge(
+                await self.get_lineage_by_datasets(
+                    point_ids=datasets_by_id.keys(),
+                    direction=direction,
+                    since=since,
+                    until=until,
+                    depth=depth - 1,
+                    ids_to_skip=IdsToSkip.from_result(result),
+                ),
+            )
+
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(
+                "Found %d datasets, %d interactions, %d operations, %d runs, %d jobs",
+                len(result.datasets),
+                len(result.interactions),
+                len(result.operations),
+                len(result.runs),
+                len(result.jobs),
+            )
+
+        return result
 
     async def get_lineage_by_operations(
         self,
-        point_id: UUID,
+        point_ids: Iterable[UUID],
         direction: LineageDirectionV1,
         since: datetime,
         until: datetime | None,
+        depth: int,
+        ids_to_skip: IdsToSkip | None = None,
     ) -> LineageServiceResult:
-        operations = await self._uow.operation.list_by_ids([point_id])
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(
+                "Get lineage by operations %r, with direction %s, since %s, until %s, depth %s",
+                sorted(point_ids),
+                direction,
+                since,
+                until,
+                depth,
+            )
+
+        operations = await self._uow.operation.list_by_ids(point_ids)
+        operations_by_id = {operation.id: operation for operation in operations}
         if not operations:
+            logger.info("No operations found")
             return LineageServiceResult()
 
         interaction_types = self.get_interaction_types(direction)
         interactions = await self._uow.interaction.list_by_operation_ids(
-            {operation.id for operation in operations},
+            operations_by_id.keys(),
             interaction_types,
             since,
             until,
         )
 
-        datasets = await self._uow.dataset.list_by_ids({interaction.dataset_id for interaction in interactions})
-        runs = await self._uow.run.list_by_ids({operation.run_id for operation in operations})
-        jobs = await self._uow.job.list_by_ids({run.job_id for run in runs})
+        ids_to_skip = ids_to_skip or IdsToSkip()
+        dataset_ids_to_load = {interaction.dataset_id for interaction in interactions} - ids_to_skip.datasets
+        datasets = await self._uow.dataset.list_by_ids(dataset_ids_to_load)
+        datasets_by_id = {dataset.id: dataset for dataset in datasets}
 
-        return LineageServiceResult(
-            datasets=datasets,
+        run_ids_to_load = {operation.run_id for operation in operations} - ids_to_skip.runs
+        runs = await self._uow.run.list_by_ids(run_ids_to_load)
+        runs_by_id = {run.id: run for run in runs}
+
+        job_ids_to_load = {run.job_id for run in runs} - ids_to_skip.jobs
+        jobs = await self._uow.job.list_by_ids(job_ids_to_load)
+        jobs_by_id = {job.id: job for job in jobs}
+
+        result = LineageServiceResult(
+            datasets=datasets_by_id,
             interactions=interactions,
-            operations=operations,
-            runs=runs,
-            jobs=jobs,
+            operations=operations_by_id,
+            runs=runs_by_id,
+            jobs=jobs_by_id,
         )
+        if depth > 1:
+            result.merge(
+                await self.get_lineage_by_datasets(
+                    point_ids=datasets_by_id.keys(),
+                    direction=direction,
+                    since=since,
+                    until=until,
+                    depth=depth - 1,
+                    ids_to_skip=ids_to_skip.merge(IdsToSkip.from_result(result)),
+                ),
+            )
+
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(
+                "Found %d datasets, %d interactions, %d operations, %d runs, %d jobs",
+                len(result.datasets),
+                len(result.interactions),
+                len(result.operations),
+                len(result.runs),
+                len(result.jobs),
+            )
+        return result
 
     async def get_lineage_by_datasets(
         self,
-        point_id: int,
+        point_ids: Iterable[int],
         direction: LineageDirectionV1,
         since: datetime,
         until: datetime | None,
+        depth: int,
+        ids_to_skip: IdsToSkip | None = None,
     ) -> LineageServiceResult:
-        datasets = await self._uow.dataset.list_by_ids([point_id])
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(
+                "Get lineage by datasets %r, with direction %s, since %s, until %s, depth %s",
+                sorted(point_ids),
+                direction,
+                since,
+                until,
+                depth,
+            )
+
+        datasets = await self._uow.dataset.list_by_ids(point_ids)
+        datasets_by_id = {dataset.id: dataset for dataset in datasets}
         if not datasets:
+            logger.info("No datasets found")
             return LineageServiceResult()
 
         # Get datasets -> interactions -> operations -> runs -> jobs
         # Directions are inverted for datasets
         interaction_types = self.get_interaction_types(~direction)
         interactions = await self._uow.interaction.list_by_dataset_ids(
-            [point_id],
+            datasets_by_id.keys(),
             interaction_types,
             since,
             until,
         )
 
-        operations = await self._uow.operation.list_by_ids({interaction.operation_id for interaction in interactions})
-        runs = await self._uow.run.list_by_ids({operation.run_id for operation in operations})
-        jobs = await self._uow.job.list_by_ids({run.job_id for run in runs})
+        ids_to_skip = ids_to_skip or IdsToSkip()
+        operation_ids_to_load = {interaction.operation_id for interaction in interactions} - ids_to_skip.operations
+        operations = await self._uow.operation.list_by_ids(operation_ids_to_load)
+        operations_by_id = {operation.id: operation for operation in operations}
 
-        return LineageServiceResult(
-            datasets=datasets,
+        # Get runs and jobs only on top level, to reduce number of queries made
+        run_ids_to_load = {operation.run_id for operation in operations} - ids_to_skip.runs
+        runs = await self._uow.run.list_by_ids(run_ids_to_load)
+        runs_by_id = {run.id: run for run in runs}
+
+        job_ids_to_load = {run.job_id for run in runs} - ids_to_skip.jobs
+        jobs = await self._uow.job.list_by_ids(job_ids_to_load)
+        jobs_by_id = {job.id: job for job in jobs}
+
+        result = LineageServiceResult(
+            datasets=datasets_by_id,
             interactions=interactions,
-            operations=operations,
-            runs=runs,
-            jobs=jobs,
+            operations=operations_by_id,
+            runs=runs_by_id,
+            jobs=jobs_by_id,
         )
+        if depth > 1:
+            result.merge(
+                await self.get_lineage_by_operations(
+                    point_ids=operations_by_id.keys(),
+                    direction=direction,
+                    since=since,
+                    until=until,
+                    depth=depth - 1,
+                    ids_to_skip=ids_to_skip.merge(IdsToSkip.from_result(result)),
+                ),
+            )
+
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(
+                "Found %d datasets, %d interactions, %d operations, %d runs, %d jobs",
+                len(result.datasets),
+                len(result.interactions),
+                len(result.operations),
+                len(result.runs),
+                len(result.jobs),
+            )
+        return result
 
     def get_interaction_types(self, direction: LineageDirectionV1) -> list[str]:
         if direction == LineageDirectionV1.TO:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ exclude_lines = [
   "raise NotImplementedError",
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
-  "if log.isEnabledFor(logging.DEBUG)",
+  "if logger.isEnabledFor",
   "if sys.version_info",
   "@(abc\\.)?abstractmethod",
   "\\.\\.\\.",

--- a/tests/test_server/fixtures/factories/dataset.py
+++ b/tests/test_server/fixtures/factories/dataset.py
@@ -61,7 +61,7 @@ async def dataset(
         await async_session.commit()
 
 
-@pytest_asyncio.fixture(params=[(2, {})])
+@pytest_asyncio.fixture(params=[(10, {})])
 async def datasets(
     request: pytest.FixtureRequest,
     async_session_maker: Callable[[], AsyncContextManager[AsyncSession]],

--- a/tests/test_server/fixtures/factories/lineage.py
+++ b/tests/test_server/fixtures/factories/lineage.py
@@ -27,7 +27,10 @@ async def lineage(
     datasets: list[Dataset],
 ) -> AsyncGenerator[LINEAGE_FIXTURE_ANNOTATION, None]:
     interactions = []
-    # each operation interacted with some dataset, both read and append
+    # Make graph like this:
+    # Dataset0 - READ - Operation0 - APPEND - Dataset0
+    # Dataset1 - READ - Operation1 - APPEND - Dataset1
+    # ...
     for operation, dataset in zip(operations, datasets):
         interactions.append(
             interaction_factory(
@@ -149,3 +152,64 @@ async def lineage_with_same_dataset(
     jobs = [job for job in all_jobs if job.id in job_ids]
 
     return jobs, runs, operations, [dataset], interactions
+
+
+@pytest_asyncio.fixture()
+async def lineage_with_depth(
+    async_session_maker: Callable[[], AsyncContextManager[AsyncSession]],
+    jobs: list[Job],
+    runs: list[Run],
+    operations: list[Operation],
+    datasets: list[Dataset],
+) -> AsyncGenerator[LINEAGE_FIXTURE_ANNOTATION, None]:
+    interactions = []
+    # Make graph like this:
+    # Dataset0 - READ - Operation0 - APPEND - Dataset1 - ... OperationN - APPEND - Dataset0
+    for operation, dataset in zip(operations, datasets):
+        interactions.append(
+            interaction_factory(
+                created_at=operation.created_at,
+                operation_id=operation.id,
+                dataset_id=dataset.id,
+                type=InteractionType.READ,
+            ),
+        )
+
+    for operation, dataset in zip(operations, datasets[1:] + datasets[:1]):
+        interactions.append(
+            interaction_factory(
+                created_at=operation.created_at,
+                operation_id=operation.id,
+                dataset_id=dataset.id,
+                type=InteractionType.APPEND,
+            ),
+        )
+
+    # operations are randomly distributed along runs. select only those which will appear in lineage graph
+    run_ids = {operation.run_id for operation in operations}
+    actual_runs = [run for run in runs if run.id in run_ids]
+
+    # same for jobs
+    job_ids = {run.job_id for run in actual_runs}
+    actual_jobs = [job for job in jobs if job.id in job_ids]
+
+    async with async_session_maker() as async_session:
+        for item in interactions:
+            async_session.add(item)
+        await async_session.commit()
+
+        # remove current object from async_session. this is required to compare object against new state fetched
+        # from database, and also to remove it from cache
+        for item in interactions:
+            await async_session.refresh(item)
+
+        async_session.expunge_all()
+
+    yield actual_jobs, actual_runs, operations, datasets, interactions
+
+    delete_interaction = delete(Interaction).where(
+        Interaction.operation_id.in_([operation.id for operation in operations]),
+    )
+    async with async_session_maker() as async_session:
+        await async_session.execute(delete_interaction)
+        await async_session.commit()

--- a/tests/test_server/fixtures/factories/operation.py
+++ b/tests/test_server/fixtures/factories/operation.py
@@ -67,7 +67,7 @@ async def operation(
         await async_session.commit()
 
 
-@pytest_asyncio.fixture(params=[(5, {})])
+@pytest_asyncio.fixture(params=[(10, {})])
 async def operations(
     request: pytest.FixtureRequest,
     async_session_maker: Callable[[], AsyncContextManager[AsyncSession]],
@@ -102,7 +102,7 @@ async def operations(
         await async_session.commit()
 
 
-@pytest_asyncio.fixture(params=[(5, {})])
+@pytest_asyncio.fixture(params=[(10, {})])
 async def operations_with_same_run(
     request: pytest.FixtureRequest,
     async_session_maker: Callable[[], AsyncContextManager[AsyncSession]],

--- a/tests/test_server/test_lineage/test_dataset_lineage.py
+++ b/tests/test_server/test_lineage/test_dataset_lineage.py
@@ -5,7 +5,14 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from data_rentgen.db.models import Dataset, Interaction, Job, Operation, Run
+from data_rentgen.db.models import (
+    Dataset,
+    Interaction,
+    InteractionType,
+    Job,
+    Operation,
+    Run,
+)
 from tests.test_server.utils.enrich import enrich_datasets, enrich_jobs, enrich_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
@@ -43,7 +50,7 @@ async def test_get_dataset_lineage(
                 "to": {"kind": "RUN", "id": str(run.id)},
                 "type": None,
             }
-            for run in runs
+            for run in sorted(runs, key=lambda x: x.id)
         ]
         + [
             {
@@ -52,7 +59,7 @@ async def test_get_dataset_lineage(
                 "to": {"kind": "OPERATION", "id": str(operation.id)},
                 "type": None,
             }
-            for operation in operations
+            for operation in sorted(operations, key=lambda x: x.id)
         ]
         + [
             {
@@ -194,7 +201,7 @@ async def test_get_dataset_lineage_with_direction_and_until(
                     "addresses": [{"url": address.url} for address in job.location.addresses],
                 },
             }
-            for job in jobs
+            for job in sorted(jobs, key=lambda x: x.id)
         ]
         + [
             {
@@ -226,7 +233,7 @@ async def test_get_dataset_lineage_with_direction_and_until(
                 "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "end_reason": run.end_reason,
             }
-            for run in runs
+            for run in sorted(runs, key=lambda x: x.id)
         ]
         + [
             {
@@ -241,6 +248,322 @@ async def test_get_dataset_lineage_with_direction_and_until(
                 "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             }
-            for operation in operations
+            for operation in sorted(operations, key=lambda x: x.id)
+        ],
+    }
+
+
+async def test_get_dataset_lineage_with_depth(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    lineage_with_depth: LINEAGE_FIXTURE_ANNOTATION,
+):
+    all_jobs, all_runs, all_operations, all_datasets, all_interactions = lineage_with_depth
+
+    # Go dataset -> operations[first level]
+    first_level_dataset = all_datasets[0]
+    first_level_interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.dataset_id == first_level_dataset.id and interaction.type == InteractionType.READ
+    ]
+    first_level_operation_ids = {interaction.operation_id for interaction in first_level_interactions}
+    first_level_operations = [operation for operation in all_operations if operation.id in first_level_operation_ids]
+    assert first_level_operations
+
+    # Go operations[first level] -> datasets[second level]
+    second_level_interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.operation_id in first_level_operation_ids and interaction.type == InteractionType.APPEND
+    ]
+    second_level_dataset_ids = {interaction.dataset_id for interaction in second_level_interactions}
+    second_level_datasets = [dataset for dataset in all_datasets if dataset.id in second_level_dataset_ids]
+    assert second_level_datasets
+
+    second_level_operation_ids = {interaction.operation_id for interaction in second_level_interactions}
+    second_level_operations = [operation for operation in all_operations if operation.id in second_level_operation_ids]
+    assert second_level_operations
+
+    # Go datasets[second level] -> operations[third level]
+    # There are more levels in this graph, but we stop here
+    third_level_dataset_ids = second_level_dataset_ids - {first_level_dataset.id}
+    third_level_interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.dataset_id in third_level_dataset_ids and interaction.type == InteractionType.READ
+    ]
+    third_level_datasets = [dataset for dataset in all_datasets if dataset.id in third_level_dataset_ids]
+    assert third_level_datasets
+
+    third_level_operation_ids = (
+        {interaction.operation_id for interaction in third_level_interactions}
+        - second_level_operation_ids
+        - first_level_operation_ids
+    )
+    third_level_operations = [operation for operation in all_operations if operation.id in third_level_operation_ids]
+    assert third_level_operations
+
+    dataset_ids = {first_level_dataset.id} | second_level_dataset_ids | third_level_dataset_ids
+    datasets = [dataset for dataset in all_datasets if dataset.id in dataset_ids]
+
+    operation_ids = first_level_operation_ids | second_level_operation_ids | third_level_operation_ids
+    operations = [operation for operation in all_operations if operation.id in operation_ids]
+
+    run_ids = {operation.run_id for operation in operations}
+    runs = [run for run in all_runs if run.id in run_ids]
+
+    job_ids = {run.job_id for run in runs}
+    jobs = [job for job in all_jobs if job.id in job_ids]
+
+    jobs = await enrich_jobs(jobs, async_session)
+    runs = await enrich_runs(runs, async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+
+    since = min(run.created_at for run in runs)
+    response = await test_client.get(
+        "v1/lineage",
+        params={
+            "since": since.isoformat(),
+            "point_kind": "DATASET",
+            "point_id": first_level_dataset.id,
+            "direction": "FROM",
+            "depth": 3,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+                "type": None,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "RUN", "id": str(operation.run_id)},
+                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "type": None,
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "DATASET", "id": interaction.dataset_id},
+                "to": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "type": "READ",
+            }
+            for interaction in first_level_interactions
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "to": {"kind": "DATASET", "id": interaction.dataset_id},
+                "type": "APPEND",
+            }
+            for interaction in second_level_interactions
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "DATASET", "id": interaction.dataset_id},
+                "to": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "type": "READ",
+            }
+            for interaction in third_level_interactions
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "location": {
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                },
+            }
+            for job in sorted(jobs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.value,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "OPERATION",
+                "id": str(operation.id),
+                "run_id": str(operation.run_id),
+                "name": operation.name,
+                "status": operation.status.value,
+                "type": operation.type.value,
+                "position": operation.position,
+                "description": operation.description,
+                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ],
+    }
+
+
+async def test_get_dataset_lineage_with_depth_ignore_cycles(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    lineage_with_same_dataset: LINEAGE_FIXTURE_ANNOTATION,
+):
+    jobs, runs, operations, [dataset], _ = lineage_with_same_dataset
+
+    # The there is a cycle dataset -> operation, so there is only one level of lineage.
+    # All relations should be in the response, without duplicates.
+    jobs = await enrich_jobs(jobs, async_session)
+    runs = await enrich_runs(runs, async_session)
+    [dataset] = await enrich_datasets([dataset], async_session)
+
+    since = min(run.created_at for run in runs)
+    response = await test_client.get(
+        "v1/lineage",
+        params={
+            "since": since.isoformat(),
+            "point_kind": "DATASET",
+            "point_id": dataset.id,
+            "direction": "FROM",
+            "depth": 3,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+                "type": None,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "RUN", "id": str(operation.run_id)},
+                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "type": None,
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "DATASET", "id": dataset.id},
+                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "type": "READ",
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "OPERATION", "id": str(operation.id)},
+                "to": {"kind": "DATASET", "id": dataset.id},
+                "type": "APPEND",
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "location": {
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                },
+            }
+            for job in sorted(jobs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.value,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "OPERATION",
+                "id": str(operation.id),
+                "run_id": str(operation.run_id),
+                "name": operation.name,
+                "status": operation.status.value,
+                "type": operation.type.value,
+                "position": operation.position,
+                "description": operation.description,
+                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
         ],
     }

--- a/tests/test_server/test_lineage/test_job_lineage.py
+++ b/tests/test_server/test_lineage/test_job_lineage.py
@@ -5,7 +5,14 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from data_rentgen.db.models import Dataset, Interaction, Job, Operation, Run
+from data_rentgen.db.models import (
+    Dataset,
+    Interaction,
+    InteractionType,
+    Job,
+    Operation,
+    Run,
+)
 from tests.test_server.utils.enrich import enrich_datasets, enrich_jobs, enrich_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
@@ -43,7 +50,7 @@ async def test_get_job_lineage(
                 "to": {"kind": "RUN", "id": str(run.id)},
                 "type": None,
             }
-            for run in runs
+            for run in sorted(runs, key=lambda x: x.id)
         ]
         + [
             {
@@ -52,7 +59,7 @@ async def test_get_job_lineage(
                 "to": {"kind": "OPERATION", "id": str(operation.id)},
                 "type": None,
             }
-            for operation in operations
+            for operation in sorted(operations, key=lambda x: x.id)
         ]
         + [
             {
@@ -87,7 +94,7 @@ async def test_get_job_lineage(
                     "addresses": [{"url": address.url} for address in dataset.location.addresses],
                 },
             }
-            for dataset in datasets
+            for dataset in sorted(datasets, key=lambda x: x.id)
         ]
         + [
             {
@@ -106,7 +113,7 @@ async def test_get_job_lineage(
                 "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "end_reason": run.end_reason,
             }
-            for run in runs
+            for run in sorted(runs, key=lambda x: x.id)
         ]
         + [
             {
@@ -121,7 +128,7 @@ async def test_get_job_lineage(
                 "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             }
-            for operation in operations
+            for operation in sorted(operations, key=lambda x: x.id)
         ],
     }
 
@@ -129,17 +136,47 @@ async def test_get_job_lineage(
 async def test_get_job_lineage_with_direction_and_until(
     test_client: AsyncClient,
     async_session: AsyncSession,
-    lineage_with_same_job: LINEAGE_FIXTURE_ANNOTATION,
+    lineage: LINEAGE_FIXTURE_ANNOTATION,
 ):
-    jobs, runs, all_operations, datasets, _ = lineage_with_same_job
+    all_jobs, all_runs, all_operations, all_datasets, all_interactions = lineage
 
-    [job] = await enrich_jobs(jobs, async_session)
+    # There is no guarantee that first job will have any interactions with READ type,
+    # so we need to search for any job
+    some_interaction = next(interaction for interaction in all_interactions if interaction.type == InteractionType.READ)
+    some_operation = next(operation for operation in all_operations if operation.id == some_interaction.operation_id)
+    some_run = next(run for run in all_runs if run.id == some_operation.run_id)
+    job = next(job for job in all_jobs if job.id == some_run.job_id)
+
+    since = min(run.created_at for run in all_runs if run.job_id == job.id)
+    until = since + timedelta(seconds=1)
+
+    runs = [run for run in all_runs if run.job_id == job.id and since <= run.created_at <= until]
+    run_ids = {run.id for run in runs}
+    assert runs
+
+    operations = [
+        operation
+        for operation in all_operations
+        if operation.run_id in run_ids and since <= operation.created_at <= until
+    ]
+    operation_ids = {operation.id for operation in operations}
+    assert operations
+
+    interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.type == InteractionType.READ
+        and interaction.operation_id in operation_ids
+        and since <= interaction.created_at <= until
+    ]
+    assert interactions
+
+    dataset_ids = {interaction.dataset_id for interaction in interactions}
+    datasets = [dataset for dataset in all_datasets if dataset.id in dataset_ids]
+
+    [job] = await enrich_jobs([job], async_session)
     runs = await enrich_runs(runs, async_session)
     datasets = await enrich_datasets(datasets, async_session)
-
-    since = min(run.created_at for run in runs)
-    until = since + timedelta(seconds=1)
-    operations = [operation for operation in all_operations if since <= operation.created_at <= until]
 
     response = await test_client.get(
         "v1/lineage",
@@ -161,7 +198,7 @@ async def test_get_job_lineage_with_direction_and_until(
                 "to": {"kind": "RUN", "id": str(run.id)},
                 "type": None,
             }
-            for run in runs
+            for run in sorted(runs, key=lambda x: x.id)
         ]
         + [
             {
@@ -170,16 +207,16 @@ async def test_get_job_lineage_with_direction_and_until(
                 "to": {"kind": "OPERATION", "id": str(operation.id)},
                 "type": None,
             }
-            for operation in operations
+            for operation in sorted(operations, key=lambda x: x.id)
         ]
         + [
             {
                 "kind": "INTERACTION",
-                "from": {"kind": "DATASET", "id": dataset.id},
-                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "from": {"kind": "DATASET", "id": interaction.dataset_id},
+                "to": {"kind": "OPERATION", "id": str(interaction.operation_id)},
                 "type": "READ",
             }
-            for operation, dataset in zip(operations, datasets)
+            for interaction in interactions
         ],
         "nodes": [
             {
@@ -205,7 +242,7 @@ async def test_get_job_lineage_with_direction_and_until(
                     "addresses": [{"url": address.url} for address in dataset.location.addresses],
                 },
             }
-            for dataset in datasets
+            for dataset in sorted(datasets, key=lambda x: x.id)
         ]
         + [
             {
@@ -224,7 +261,7 @@ async def test_get_job_lineage_with_direction_and_until(
                 "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "end_reason": run.end_reason,
             }
-            for run in runs
+            for run in sorted(runs, key=lambda x: x.id)
         ]
         + [
             {
@@ -239,6 +276,347 @@ async def test_get_job_lineage_with_direction_and_until(
                 "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             }
-            for operation in operations
+            for operation in sorted(operations, key=lambda x: x.id)
+        ],
+    }
+
+
+async def test_get_job_lineage_with_depth(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    lineage_with_depth: LINEAGE_FIXTURE_ANNOTATION,
+):
+    all_jobs, all_runs, all_operations, all_datasets, all_interactions = lineage_with_depth
+
+    # There is no guarantee that first job will have any interactions with APPEND type,
+    # so we need to search for any job
+    some_interaction = next(
+        interaction for interaction in all_interactions if interaction.type == InteractionType.APPEND
+    )
+    some_operation = next(operation for operation in all_operations if operation.id == some_interaction.operation_id)
+    some_run = next(run for run in all_runs if run.id == some_operation.run_id)
+    some_job = next(job for job in all_jobs if job.id == some_run.job_id)
+
+    # Go job -> runs -> operations
+    first_level_runs = [run for run in all_runs if run.job_id == some_job.id]
+    first_level_run_ids = {run.id for run in first_level_runs}
+    first_level_operations = [operation for operation in all_operations if operation.run_id in first_level_run_ids]
+    first_level_operation_ids = {operation.id for operation in first_level_operations}
+    assert first_level_operations
+
+    # Go operations[first level] -> datasets[second level]
+    first_level_interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.operation_id in first_level_operation_ids and interaction.type == InteractionType.APPEND
+    ]
+    first_level_dataset_ids = {interaction.dataset_id for interaction in first_level_interactions}
+    first_level_datasets = [dataset for dataset in all_datasets if dataset.id in first_level_dataset_ids]
+    assert first_level_datasets
+
+    # Go datasets[second level] -> operations[second level]
+    second_level_interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.dataset_id in first_level_dataset_ids and interaction.type == InteractionType.READ
+    ]
+    second_level_operation_ids = {
+        interaction.operation_id for interaction in second_level_interactions
+    } - first_level_operation_ids
+    second_level_operations = [operation for operation in all_operations if operation.id in second_level_operation_ids]
+    assert second_level_operations
+
+    # Go operations[second level] -> datasets[third level]
+    # There are more levels in this graph, but we stop here
+    third_level_interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.operation_id in second_level_operation_ids and interaction.type == InteractionType.APPEND
+    ]
+    third_level_dataset_ids = {
+        interaction.dataset_id for interaction in third_level_interactions
+    } - first_level_dataset_ids
+    third_level_datasets = [dataset for dataset in all_datasets if dataset.id in third_level_dataset_ids]
+    assert third_level_datasets
+
+    dataset_ids = first_level_dataset_ids | third_level_dataset_ids
+    datasets = [dataset for dataset in all_datasets if dataset.id in dataset_ids]
+
+    operation_ids = first_level_operation_ids | second_level_operation_ids
+    operations = [operation for operation in all_operations if operation.id in operation_ids]
+
+    run_ids = {operation.run_id for operation in operations}
+    runs = [run for run in all_runs if run.id in run_ids]
+
+    job_ids = {run.job_id for run in runs}
+    jobs = [job for job in all_jobs if job.id in job_ids]
+
+    jobs = await enrich_jobs(jobs, async_session)
+    runs = await enrich_runs(runs, async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+
+    since = min(run.created_at for run in runs)
+    response = await test_client.get(
+        "v1/lineage",
+        params={
+            "since": since.isoformat(),
+            "point_kind": "JOB",
+            "point_id": some_job.id,
+            "direction": "FROM",
+            "depth": 3,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+                "type": None,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "RUN", "id": str(operation.run_id)},
+                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "type": None,
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "to": {"kind": "DATASET", "id": interaction.dataset_id},
+                "type": "APPEND",
+            }
+            for interaction in first_level_interactions
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "DATASET", "id": interaction.dataset_id},
+                "to": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "type": "READ",
+            }
+            for interaction in second_level_interactions
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "to": {"kind": "DATASET", "id": interaction.dataset_id},
+                "type": "APPEND",
+            }
+            for interaction in third_level_interactions
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "location": {
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                },
+            }
+            for job in sorted(jobs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.value,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "OPERATION",
+                "id": str(operation.id),
+                "run_id": str(operation.run_id),
+                "name": operation.name,
+                "status": operation.status.value,
+                "type": operation.type.value,
+                "position": operation.position,
+                "description": operation.description,
+                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ],
+    }
+
+
+async def test_get_job_lineage_with_depth_ignore_cycles(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    lineage_with_same_job: LINEAGE_FIXTURE_ANNOTATION,
+):
+    [job], runs, operations, all_datasets, all_interactions = lineage_with_same_job
+
+    # Go operations[first level] -> datasets[second level]
+    first_level_interactions = [
+        interaction for interaction in all_interactions if interaction.type == InteractionType.APPEND
+    ]
+    first_level_dataset_ids = {interaction.dataset_id for interaction in first_level_interactions}
+    first_level_datasets = [dataset for dataset in all_datasets if dataset.id in first_level_dataset_ids]
+    first_level_operation_ids = {interaction.operation_id for interaction in first_level_interactions}
+    assert first_level_datasets
+
+    # The there is a cycle dataset[second level] -> operation[first level], so there is only one level of lineage.
+    second_level_interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.dataset_id in first_level_dataset_ids and interaction.type == InteractionType.READ
+    ]
+    second_level_operation_ids = {
+        interaction.operation_id for interaction in second_level_interactions
+    } - first_level_operation_ids
+    assert not second_level_operation_ids
+
+    [job] = await enrich_jobs([job], async_session)
+    runs = await enrich_runs(runs, async_session)
+    datasets = await enrich_datasets(first_level_datasets, async_session)
+
+    since = min(run.created_at for run in runs)
+    response = await test_client.get(
+        "v1/lineage",
+        params={
+            "since": since.isoformat(),
+            "point_kind": "JOB",
+            "point_id": str(job.id),
+            "direction": "FROM",
+            "depth": 3,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+                "type": None,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "RUN", "id": str(operation.run_id)},
+                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "type": None,
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "to": {"kind": "DATASET", "id": interaction.dataset_id},
+                "type": "APPEND",
+            }
+            for interaction in first_level_interactions
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "DATASET", "id": interaction.dataset_id},
+                "to": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "type": "READ",
+            }
+            for interaction in second_level_interactions
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "location": {
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.value,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "OPERATION",
+                "id": str(operation.id),
+                "run_id": str(operation.run_id),
+                "name": operation.name,
+                "status": operation.status.value,
+                "type": operation.type.value,
+                "position": operation.position,
+                "description": operation.description,
+                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
         ],
     }

--- a/tests/test_server/test_lineage/test_operation_lineage.py
+++ b/tests/test_server/test_lineage/test_operation_lineage.py
@@ -5,7 +5,14 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from data_rentgen.db.models import Dataset, Interaction, Job, Operation, Run
+from data_rentgen.db.models import (
+    Dataset,
+    Interaction,
+    InteractionType,
+    Job,
+    Operation,
+    Run,
+)
 from tests.test_server.utils.enrich import enrich_datasets, enrich_jobs, enrich_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
@@ -43,7 +50,7 @@ async def test_get_operation_lineage(
                 "to": {"kind": "RUN", "id": str(run.id)},
                 "type": None,
             }
-            for run in runs
+            for run in sorted(runs, key=lambda x: x.id)
         ]
         + [
             {
@@ -73,7 +80,7 @@ async def test_get_operation_lineage(
                     "addresses": [{"url": address.url} for address in job.location.addresses],
                 },
             }
-            for job in jobs
+            for job in sorted(jobs, key=lambda x: x.id)
         ]
         + [
             {
@@ -87,7 +94,7 @@ async def test_get_operation_lineage(
                     "addresses": [{"url": address.url} for address in dataset.location.addresses],
                 },
             }
-            for dataset in datasets
+            for dataset in sorted(datasets, key=lambda x: x.id)
         ]
         + [
             {
@@ -106,7 +113,7 @@ async def test_get_operation_lineage(
                 "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "end_reason": run.end_reason,
             }
-            for run in runs
+            for run in sorted(runs, key=lambda x: x.id)
         ]
         + [
             {
@@ -128,16 +135,35 @@ async def test_get_operation_lineage(
 async def test_get_operation_lineage_with_direction_and_until(
     test_client: AsyncClient,
     async_session: AsyncSession,
-    lineage_with_same_operation: LINEAGE_FIXTURE_ANNOTATION,
+    lineage: LINEAGE_FIXTURE_ANNOTATION,
 ):
-    jobs, runs, [operation], datasets, _ = lineage_with_same_operation
+    all_jobs, all_runs, all_operations, all_datasets, all_interactions = lineage
 
-    jobs = await enrich_jobs(jobs, async_session)
-    runs = await enrich_runs(runs, async_session)
-    datasets = await enrich_datasets(datasets, async_session)
+    # There is no guarantee that first operation will have any interactions with READ type,
+    # so we need to search for any operation
+    some_interaction = next(interaction for interaction in all_interactions if interaction.type == InteractionType.READ)
+    operation = next(operation for operation in all_operations if operation.id == some_interaction.operation_id)
 
-    since = min(run.created_at for run in runs)
+    run = next(run for run in all_runs if run.id == operation.run_id)
+    job = next(job for job in all_jobs if job.id == run.job_id)
+
+    since = operation.created_at
     until = since + timedelta(seconds=1)
+
+    interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.type == InteractionType.READ
+        and interaction.operation_id == operation.id
+        and since <= interaction.created_at <= until
+    ]
+    assert interactions
+    dataset_ids = {interaction.dataset_id for interaction in interactions}
+    datasets = [dataset for dataset in all_datasets if dataset.id in dataset_ids]
+
+    [job] = await enrich_jobs([job], async_session)
+    [run] = await enrich_runs([run], async_session)
+    datasets = await enrich_datasets(datasets, async_session)
 
     response = await test_client.get(
         "v1/lineage",
@@ -158,10 +184,7 @@ async def test_get_operation_lineage_with_direction_and_until(
                 "from": {"kind": "JOB", "id": run.job_id},
                 "to": {"kind": "RUN", "id": str(run.id)},
                 "type": None,
-            }
-            for run in runs
-        ]
-        + [
+            },
             {
                 "kind": "PARENT",
                 "from": {"kind": "RUN", "id": str(operation.run_id)},
@@ -172,11 +195,11 @@ async def test_get_operation_lineage_with_direction_and_until(
         + [
             {
                 "kind": "INTERACTION",
-                "from": {"kind": "DATASET", "id": dataset.id},
-                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "from": {"kind": "DATASET", "id": interaction.dataset_id},
+                "to": {"kind": "OPERATION", "id": str(interaction.operation_id)},
                 "type": "READ",
             }
-            for dataset in datasets
+            for interaction in interactions
         ],
         "nodes": [
             {
@@ -188,8 +211,7 @@ async def test_get_operation_lineage_with_direction_and_until(
                     "name": job.location.name,
                     "addresses": [{"url": address.url} for address in job.location.addresses],
                 },
-            }
-            for job in jobs
+            },
         ]
         + [
             {
@@ -203,7 +225,191 @@ async def test_get_operation_lineage_with_direction_and_until(
                     "addresses": [{"url": address.url} for address in dataset.location.addresses],
                 },
             }
-            for dataset in datasets
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.value,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            },
+            {
+                "kind": "OPERATION",
+                "id": str(operation.id),
+                "run_id": str(operation.run_id),
+                "name": operation.name,
+                "status": operation.status.value,
+                "type": operation.type.value,
+                "position": operation.position,
+                "description": operation.description,
+                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            },
+        ],
+    }
+
+
+async def test_get_operation_lineage_with_depth(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    lineage_with_depth: LINEAGE_FIXTURE_ANNOTATION,
+):
+    all_jobs, all_runs, all_operations, all_datasets, all_interactions = lineage_with_depth
+
+    # There is no guarantee that first operation will have any interactions with APPEND type,
+    # so we need to search for any operation
+    some_interaction = next(
+        interaction for interaction in all_interactions if interaction.type == InteractionType.APPEND
+    )
+    some_operation = next(operation for operation in all_operations if operation.id == some_interaction.operation_id)
+
+    # Go operations[first level] -> datasets[second level]
+    first_level_interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.operation_id == some_operation.id and interaction.type == InteractionType.APPEND
+    ]
+    first_level_dataset_ids = {interaction.dataset_id for interaction in first_level_interactions}
+    first_level_datasets = [dataset for dataset in all_datasets if dataset.id in first_level_dataset_ids]
+    assert first_level_datasets
+
+    # Go datasets[second level] -> operations[second level]
+    second_level_interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.dataset_id in first_level_dataset_ids and interaction.type == InteractionType.READ
+    ]
+    second_level_operation_ids = {interaction.operation_id for interaction in second_level_interactions} - {
+        some_operation.id,
+    }
+    second_level_operations = [operation for operation in all_operations if operation.id in second_level_operation_ids]
+    assert second_level_operations
+
+    # Go operations[second level] -> datasets[third level]
+    # There are more levels in this graph, but we stop here
+    third_level_interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.operation_id in second_level_operation_ids and interaction.type == InteractionType.APPEND
+    ]
+    third_level_dataset_ids = {
+        interaction.dataset_id for interaction in third_level_interactions
+    } - first_level_dataset_ids
+    third_level_datasets = [dataset for dataset in all_datasets if dataset.id in third_level_dataset_ids]
+    assert third_level_datasets
+
+    dataset_ids = first_level_dataset_ids | third_level_dataset_ids
+    datasets = [dataset for dataset in all_datasets if dataset.id in dataset_ids]
+
+    operation_ids = {some_operation.id} | second_level_operation_ids
+    operations = [operation for operation in all_operations if operation.id in operation_ids]
+
+    run_ids = {operation.run_id for operation in operations}
+    runs = [run for run in all_runs if run.id in run_ids]
+
+    job_ids = {run.job_id for run in runs}
+    jobs = [job for job in all_jobs if job.id in job_ids]
+
+    jobs = await enrich_jobs(jobs, async_session)
+    runs = await enrich_runs(runs, async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+
+    since = min(run.created_at for run in runs)
+    response = await test_client.get(
+        "v1/lineage",
+        params={
+            "since": since.isoformat(),
+            "point_kind": "OPERATION",
+            "point_id": str(some_operation.id),
+            "direction": "FROM",
+            "depth": 3,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+                "type": None,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "RUN", "id": str(operation.run_id)},
+                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "type": None,
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "to": {"kind": "DATASET", "id": interaction.dataset_id},
+                "type": "APPEND",
+            }
+            for interaction in first_level_interactions
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "DATASET", "id": interaction.dataset_id},
+                "to": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "type": "READ",
+            }
+            for interaction in second_level_interactions
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "to": {"kind": "DATASET", "id": interaction.dataset_id},
+                "type": "APPEND",
+            }
+            for interaction in third_level_interactions
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "location": {
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                },
+            }
+            for job in sorted(jobs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
         ]
         + [
             {
@@ -222,9 +428,128 @@ async def test_get_operation_lineage_with_direction_and_until(
                 "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "end_reason": run.end_reason,
             }
-            for run in runs
+            for run in sorted(runs, key=lambda x: x.id)
         ]
         + [
+            {
+                "kind": "OPERATION",
+                "id": str(operation.id),
+                "run_id": str(operation.run_id),
+                "name": operation.name,
+                "status": operation.status.value,
+                "type": operation.type.value,
+                "position": operation.position,
+                "description": operation.description,
+                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ],
+    }
+
+
+async def test_get_operation_lineage_with_depth_ignore_cycles(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    lineage_with_same_operation: LINEAGE_FIXTURE_ANNOTATION,
+):
+    [job], [run], [operation], datasets, _ = lineage_with_same_operation
+
+    # The there is a cycle dataset -> operation, so there is only one level of lineage.
+    # All relations should be in the response, without duplicates.
+
+    [job] = await enrich_jobs([job], async_session)
+    [run] = await enrich_runs([run], async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+
+    response = await test_client.get(
+        "v1/lineage",
+        params={
+            "since": run.created_at.isoformat(),
+            "point_kind": "OPERATION",
+            "point_id": str(operation.id),
+            "direction": "FROM",
+            "depth": 3,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+                "type": None,
+            },
+            {
+                "kind": "PARENT",
+                "from": {"kind": "RUN", "id": str(operation.run_id)},
+                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "type": None,
+            },
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "OPERATION", "id": str(operation.id)},
+                "to": {"kind": "DATASET", "id": dataset.id},
+                "type": "APPEND",
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "DATASET", "id": dataset.id},
+                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "type": "READ",
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "location": {
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.value,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            },
             {
                 "kind": "OPERATION",
                 "id": str(operation.id),

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -5,7 +5,14 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from data_rentgen.db.models import Dataset, Interaction, Job, Operation, Run
+from data_rentgen.db.models import (
+    Dataset,
+    Interaction,
+    InteractionType,
+    Job,
+    Operation,
+    Run,
+)
 from tests.test_server.utils.enrich import enrich_datasets, enrich_jobs, enrich_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
@@ -51,7 +58,7 @@ async def test_get_run_lineage(
                 "to": {"kind": "OPERATION", "id": str(operation.id)},
                 "type": None,
             }
-            for operation in operations
+            for operation in sorted(operations, key=lambda x: x.id)
         ]
         + [
             {
@@ -73,7 +80,7 @@ async def test_get_run_lineage(
                     "addresses": [{"url": address.url} for address in job.location.addresses],
                 },
             }
-            for job in jobs
+            for job in sorted(jobs, key=lambda x: x.id)
         ]
         + [
             {
@@ -87,7 +94,7 @@ async def test_get_run_lineage(
                     "addresses": [{"url": address.url} for address in dataset.location.addresses],
                 },
             }
-            for dataset in datasets
+            for dataset in sorted(datasets, key=lambda x: x.id)
         ]
         + [
             {
@@ -120,7 +127,7 @@ async def test_get_run_lineage(
                 "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             }
-            for operation in operations
+            for operation in sorted(operations, key=lambda x: x.id)
         ],
     }
 
@@ -128,17 +135,43 @@ async def test_get_run_lineage(
 async def test_get_run_lineage_with_direction_and_until(
     test_client: AsyncClient,
     async_session: AsyncSession,
-    lineage_with_same_run: LINEAGE_FIXTURE_ANNOTATION,
+    lineage: LINEAGE_FIXTURE_ANNOTATION,
 ):
-    jobs, runs, all_operations, datasets, _ = lineage_with_same_run
+    all_jobs, all_runs, all_operations, all_datasets, all_interactions = lineage
 
-    jobs = await enrich_jobs(jobs, async_session)
-    [run] = await enrich_runs(runs, async_session)
-    datasets = await enrich_datasets(datasets, async_session)
+    # There is no guarantee that first run will have any interactions with READ type,
+    # so we need to search for any run
+    some_interaction = next(interaction for interaction in all_interactions if interaction.type == InteractionType.READ)
+    some_operation = next(operation for operation in all_operations if operation.id == some_interaction.operation_id)
+    run = next(run for run in all_runs if run.id == some_operation.run_id)
+    job = next(job for job in all_jobs if job.id == run.job_id)
 
     since = run.created_at
     until = since + timedelta(seconds=1)
-    operations = [operation for operation in all_operations if since <= operation.created_at <= until]
+
+    operations = [
+        operation
+        for operation in all_operations
+        if operation.run_id == run.id and since <= operation.created_at <= until
+    ]
+    operation_ids = {operation.id for operation in operations}
+    assert operations
+
+    interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.type == InteractionType.READ
+        and interaction.operation_id in operation_ids
+        and since <= interaction.created_at <= until
+    ]
+    assert interactions
+
+    dataset_ids = {interaction.dataset_id for interaction in interactions}
+    datasets = [dataset for dataset in all_datasets if dataset.id in dataset_ids]
+
+    [job] = await enrich_jobs([job], async_session)
+    [run] = await enrich_runs([run], async_session)
+    datasets = await enrich_datasets(datasets, async_session)
 
     response = await test_client.get(
         "v1/lineage",
@@ -168,16 +201,16 @@ async def test_get_run_lineage_with_direction_and_until(
                 "to": {"kind": "OPERATION", "id": str(operation.id)},
                 "type": None,
             }
-            for operation in operations
+            for operation in sorted(operations, key=lambda x: x.id)
         ]
         + [
             {
                 "kind": "INTERACTION",
-                "from": {"kind": "DATASET", "id": dataset.id},
-                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "from": {"kind": "DATASET", "id": interaction.dataset_id},
+                "to": {"kind": "OPERATION", "id": str(interaction.operation_id)},
                 "type": "READ",
             }
-            for operation, dataset in zip(operations, datasets)
+            for interaction in interactions
         ],
         "nodes": [
             {
@@ -189,8 +222,7 @@ async def test_get_run_lineage_with_direction_and_until(
                     "name": job.location.name,
                     "addresses": [{"url": address.url} for address in job.location.addresses],
                 },
-            }
-            for job in jobs
+            },
         ]
         + [
             {
@@ -204,7 +236,7 @@ async def test_get_run_lineage_with_direction_and_until(
                     "addresses": [{"url": address.url} for address in dataset.location.addresses],
                 },
             }
-            for dataset in datasets
+            for dataset in sorted(datasets, key=lambda x: x.id)
         ]
         + [
             {
@@ -237,6 +269,337 @@ async def test_get_run_lineage_with_direction_and_until(
                 "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             }
-            for operation in operations
+            for operation in sorted(operations, key=lambda x: x.id)
+        ],
+    }
+
+
+async def test_get_run_lineage_with_depth(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    lineage_with_depth: LINEAGE_FIXTURE_ANNOTATION,
+):
+    all_jobs, all_runs, all_operations, all_datasets, all_interactions = lineage_with_depth
+
+    # There is no guarantee that first run will have any interactions with APPEND type,
+    # so we need to search for any run
+    some_interaction = next(
+        interaction for interaction in all_interactions if interaction.type == InteractionType.APPEND
+    )
+    some_operation = next(operation for operation in all_operations if operation.id == some_interaction.operation_id)
+    some_run = next(run for run in all_runs if run.id == some_operation.run_id)
+
+    # Go operations[first level] -> datasets[second level]
+    first_level_operations = [operation for operation in all_operations if operation.run_id == some_run.id]
+    first_level_operation_ids = {operation.id for operation in first_level_operations}
+    first_level_interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.operation_id in first_level_operation_ids and interaction.type == InteractionType.APPEND
+    ]
+    first_level_dataset_ids = {interaction.dataset_id for interaction in first_level_interactions}
+    first_level_datasets = [dataset for dataset in all_datasets if dataset.id in first_level_dataset_ids]
+    assert first_level_datasets
+
+    # Go datasets[second level] -> operations[second level]
+    second_level_interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.dataset_id in first_level_dataset_ids and interaction.type == InteractionType.READ
+    ]
+    second_level_operation_ids = {
+        interaction.operation_id for interaction in second_level_interactions
+    } - first_level_operation_ids
+    second_level_operations = [operation for operation in all_operations if operation.id in second_level_operation_ids]
+    assert second_level_operations
+
+    # Go operations[second level] -> datasets[third level]
+    # There are more levels in this graph, but we stop here
+    third_level_interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.operation_id in second_level_operation_ids and interaction.type == InteractionType.APPEND
+    ]
+    third_level_dataset_ids = {
+        interaction.dataset_id for interaction in third_level_interactions
+    } - first_level_dataset_ids
+    third_level_datasets = [dataset for dataset in all_datasets if dataset.id in third_level_dataset_ids]
+    assert third_level_datasets
+
+    dataset_ids = first_level_dataset_ids | third_level_dataset_ids
+    datasets = [dataset for dataset in all_datasets if dataset.id in dataset_ids]
+
+    operation_ids = first_level_operation_ids | second_level_operation_ids
+    operations = [operation for operation in all_operations if operation.id in operation_ids]
+
+    run_ids = {operation.run_id for operation in operations}
+    runs = [run for run in all_runs if run.id in run_ids]
+
+    job_ids = {run.job_id for run in runs}
+    jobs = [job for job in all_jobs if job.id in job_ids]
+
+    jobs = await enrich_jobs(jobs, async_session)
+    runs = await enrich_runs(runs, async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+
+    response = await test_client.get(
+        "v1/lineage",
+        params={
+            "since": some_run.created_at.isoformat(),
+            "point_kind": "RUN",
+            "point_id": str(some_run.id),
+            "direction": "FROM",
+            "depth": 3,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+                "type": None,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "RUN", "id": str(operation.run_id)},
+                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "type": None,
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "to": {"kind": "DATASET", "id": interaction.dataset_id},
+                "type": "APPEND",
+            }
+            for interaction in first_level_interactions
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "DATASET", "id": interaction.dataset_id},
+                "to": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "type": "READ",
+            }
+            for interaction in second_level_interactions
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "to": {"kind": "DATASET", "id": interaction.dataset_id},
+                "type": "APPEND",
+            }
+            for interaction in third_level_interactions
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "location": {
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                },
+            }
+            for job in sorted(jobs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.value,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "OPERATION",
+                "id": str(operation.id),
+                "run_id": str(operation.run_id),
+                "name": operation.name,
+                "status": operation.status.value,
+                "type": operation.type.value,
+                "position": operation.position,
+                "description": operation.description,
+                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ],
+    }
+
+
+async def test_get_run_lineage_with_depth_ignore_cycles(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    lineage_with_same_run: LINEAGE_FIXTURE_ANNOTATION,
+):
+    [job], [run], operations, all_datasets, all_interactions = lineage_with_same_run
+
+    first_level_interactions = [
+        interaction for interaction in all_interactions if interaction.type == InteractionType.APPEND
+    ]
+    first_level_dataset_ids = {interaction.dataset_id for interaction in first_level_interactions}
+    first_level_datasets = [dataset for dataset in all_datasets if dataset.id in first_level_dataset_ids]
+    first_level_operation_ids = {interaction.operation_id for interaction in first_level_interactions}
+    assert first_level_datasets
+
+    # The there is a cycle dataset -> operation, so there is only one level of lineage.
+    # All relations should be in the response, without duplicates.
+    second_level_interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.dataset_id in first_level_dataset_ids and interaction.type == InteractionType.READ
+    ]
+    second_level_operation_ids = {
+        interaction.operation_id for interaction in second_level_interactions
+    } - first_level_operation_ids
+    assert not second_level_operation_ids
+
+    [job] = await enrich_jobs([job], async_session)
+    [run] = await enrich_runs([run], async_session)
+    datasets = await enrich_datasets(first_level_datasets, async_session)
+
+    response = await test_client.get(
+        "v1/lineage",
+        params={
+            "since": run.created_at.isoformat(),
+            "point_kind": "RUN",
+            "point_id": str(run.id),
+            "direction": "FROM",
+            "depth": 3,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+                "type": None,
+            },
+        ]
+        + [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "RUN", "id": str(operation.run_id)},
+                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "type": None,
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "to": {"kind": "DATASET", "id": interaction.dataset_id},
+                "type": "APPEND",
+            }
+            for interaction in first_level_interactions
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "DATASET", "id": interaction.dataset_id},
+                "to": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "type": "READ",
+            }
+            for interaction in second_level_interactions
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "location": {
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.value,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            },
+        ]
+        + [
+            {
+                "kind": "OPERATION",
+                "id": str(operation.id),
+                "run_id": str(operation.run_id),
+                "name": operation.name,
+                "status": operation.status.value,
+                "type": operation.type.value,
+                "position": operation.position,
+                "description": operation.description,
+                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
         ],
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

* Add `depth=1..3` option to lineage endpoint. Depth if number of relations in a graph e.g. `Operation` -> `Dataset` -> `Operation`. Currently depth is checked only for operation <-> dataset relations.
* Rewrite `LineageService` methods to recursively call each other to get lineage of specific depth.
* To avoid reading the same object/relation twice from database (e.g. cyclic graph), a `IdsToSkip` class was implemented, which contains set if ids to skip while traversing graph.
* Replace `list[obj]` with `dict[id, object]` in `LineageServiceResult`, to avoid adding the same object twice to a lineage response. Also sort all nodes by id, to make lineage response consistent (for tests).
* Add tests with max depth (=3) and with cyclic graph.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
