### PR TITLE
[DOP-18998] Handle dataset symlinks in lineage endpoint

### DIFF
--- a/data_rentgen/server/api/v1/router/lineage.py
+++ b/data_rentgen/server/api/v1/router/lineage.py
@@ -79,6 +79,16 @@ async def get_lineage(
         )
         response.nodes.append(OperationResponseV1.model_validate(operation))
 
+    for symlink_id in sorted(lineage.dataset_symlinks):
+        dataset_symlink = lineage.dataset_symlinks[symlink_id]
+        relation = LineageRelationv1(
+            kind=LineageRelationKindV1.SYMLINK,
+            type=dataset_symlink.type,
+            from_=LineageEntityV1(kind=LineageEntityKindV1.DATASET, id=dataset_symlink.from_dataset_id),
+            to=LineageEntityV1(kind=LineageEntityKindV1.DATASET, id=dataset_symlink.to_dataset_id),
+        )
+        response.relations.append(relation)
+
     for interaction in lineage.interactions:
         operation_item = LineageEntityV1(kind=LineageEntityKindV1.OPERATION, id=interaction.operation_id)
         dataset_item = LineageEntityV1(kind=LineageEntityKindV1.DATASET, id=interaction.dataset_id)

--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -44,6 +44,7 @@ class LineageDirectionV1(str, Enum):
 class LineageRelationKindV1(str, Enum):
     PARENT = "PARENT"
     INTERACTION = "INTERACTION"
+    SYMLINK = "SYMLINK"
 
     def __str__(self) -> str:
         return self.value

--- a/tests/test_server/test_lineage/test_job_lineage.py
+++ b/tests/test_server/test_lineage/test_job_lineage.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from data_rentgen.db.models import (
     Dataset,
+    DatasetSymlink,
     Interaction,
     InteractionType,
     Job,
@@ -558,6 +559,168 @@ async def test_get_job_lineage_with_depth_ignore_cycles(
                 "type": "READ",
             }
             for interaction in second_level_interactions
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "location": {
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.value,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "OPERATION",
+                "id": str(operation.id),
+                "run_id": str(operation.run_id),
+                "name": operation.name,
+                "status": operation.status.value,
+                "type": operation.type.value,
+                "position": operation.position,
+                "description": operation.description,
+                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ],
+    }
+
+
+async def test_get_job_lineage_with_symlinks(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    lineage_with_symlinks: tuple[
+        list[Job],
+        list[Run],
+        list[Operation],
+        list[Dataset],
+        list[DatasetSymlink],
+        list[Interaction],
+    ],
+):
+    all_jobs, all_runs, all_operations, all_datasets, all_dataset_symlinks, all_interactions = lineage_with_symlinks
+
+    some_interaction = next(interaction for interaction in all_interactions if interaction.type == InteractionType.READ)
+    some_operation = next(operation for operation in all_operations if operation.id == some_interaction.operation_id)
+    some_run = next(run for run in all_runs if run.id == some_operation.run_id)
+    job = next(job for job in all_jobs if job.id == some_run.job_id)
+
+    runs = [run for run in all_runs if run.job_id == job.id]
+    run_ids = {run.id for run in runs}
+    assert runs
+
+    operations = [operation for operation in all_operations if operation.run_id in run_ids]
+    operation_ids = {operation.id for operation in operations}
+    assert operations
+
+    interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.operation_id in operation_ids and interaction.type == InteractionType.APPEND
+    ]
+    dataset_ids = {interaction.dataset_id for interaction in interactions}
+
+    # Dataset from symlinks appear only as SYMLINK location, but not as INTERACTION, because of depth=1
+    dataset_symlinks = [
+        dataset_symlink
+        for dataset_symlink in all_dataset_symlinks
+        if dataset_symlink.from_dataset_id in dataset_ids or dataset_symlink.to_dataset_id in dataset_ids
+    ]
+    dataset_ids_from_symlink = {dataset_symlink.from_dataset_id for dataset_symlink in dataset_symlinks}
+    dataset_ids_to_symlink = {dataset_symlink.to_dataset_id for dataset_symlink in dataset_symlinks}
+    dataset_ids = dataset_ids | dataset_ids_from_symlink | dataset_ids_to_symlink
+    datasets = [dataset for dataset in all_datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    [job] = await enrich_jobs([job], async_session)
+    runs = await enrich_runs(runs, async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+
+    since = min(run.created_at for run in runs)
+    response = await test_client.get(
+        "v1/lineage",
+        params={
+            "since": since.isoformat(),
+            "point_kind": "RUN",
+            "point_id": str(some_run.id),
+            "direction": "FROM",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+                "type": None,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "RUN", "id": str(operation.run_id)},
+                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "type": None,
+            }
+            for operation in sorted(operations, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "SYMLINK",
+                "from": {"kind": "DATASET", "id": symlink.from_dataset_id},
+                "to": {"kind": "DATASET", "id": symlink.to_dataset_id},
+                "type": symlink.type.value,
+            }
+            for symlink in sorted(dataset_symlinks, key=lambda x: (x.from_dataset_id, x.to_dataset_id))
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "to": {"kind": "DATASET", "id": interaction.dataset_id},
+                "type": "APPEND",
+            }
+            for interaction in interactions
         ],
         "nodes": [
             {

--- a/tests/test_server/test_lineage/test_operation_lineage.py
+++ b/tests/test_server/test_lineage/test_operation_lineage.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from data_rentgen.db.models import (
     Dataset,
+    DatasetSymlink,
     Interaction,
     InteractionType,
     Job,
@@ -506,6 +507,154 @@ async def test_get_operation_lineage_with_depth_ignore_cycles(
                 "type": "READ",
             }
             for dataset in sorted(datasets, key=lambda x: x.id)
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "location": {
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.value,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            },
+            {
+                "kind": "OPERATION",
+                "id": str(operation.id),
+                "run_id": str(operation.run_id),
+                "name": operation.name,
+                "status": operation.status.value,
+                "type": operation.type.value,
+                "position": operation.position,
+                "description": operation.description,
+                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            },
+        ],
+    }
+
+
+async def test_get_operation_lineage_with_symlinks(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    lineage_with_symlinks: tuple[
+        list[Job],
+        list[Run],
+        list[Operation],
+        list[Dataset],
+        list[DatasetSymlink],
+        list[Interaction],
+    ],
+):
+    all_jobs, all_runs, all_operations, all_datasets, all_dataset_symlinks, all_interactions = lineage_with_symlinks
+    dataset = all_datasets[0]
+
+    # Get operation which interacted with a specific dataset.
+    # Dataset from symlinks appear only as SYMLINK location, but not as INTERACTION, because of depth=1
+    interactions = [
+        interaction
+        for interaction in all_interactions
+        if interaction.dataset_id == dataset.id and interaction.type == InteractionType.APPEND
+    ]
+    assert interactions
+
+    operation_ids = {interaction.operation_id for interaction in interactions}
+    operation = next(operation for operation in all_operations if operation.id in operation_ids)
+
+    run = next(run for run in all_runs if run.id == operation.run_id)
+    job = next(job for job in all_jobs if job.id == run.job_id)
+
+    dataset_symlinks = [
+        dataset_symlink
+        for dataset_symlink in all_dataset_symlinks
+        if dataset_symlink.from_dataset_id == dataset.id or dataset_symlink.to_dataset_id == dataset.id
+    ]
+    dataset_ids_from_symlink = {dataset_symlink.from_dataset_id for dataset_symlink in dataset_symlinks}
+    dataset_ids_to_symlink = {dataset_symlink.to_dataset_id for dataset_symlink in dataset_symlinks}
+    dataset_ids = {dataset.id} | dataset_ids_from_symlink | dataset_ids_to_symlink
+    datasets = [dataset for dataset in all_datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    [job] = await enrich_jobs([job], async_session)
+    [run] = await enrich_runs([run], async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+
+    response = await test_client.get(
+        "v1/lineage",
+        params={
+            "since": run.created_at.isoformat(),
+            "point_kind": "OPERATION",
+            "point_id": str(operation.id),
+            "direction": "FROM",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+                "type": None,
+            },
+            {
+                "kind": "PARENT",
+                "from": {"kind": "RUN", "id": str(operation.run_id)},
+                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "type": None,
+            },
+        ]
+        + [
+            {
+                "kind": "SYMLINK",
+                "from": {"kind": "DATASET", "id": symlink.from_dataset_id},
+                "to": {"kind": "DATASET", "id": symlink.to_dataset_id},
+                "type": symlink.type.value,
+            }
+            for symlink in sorted(dataset_symlinks, key=lambda x: (x.from_dataset_id, x.to_dataset_id))
+        ]
+        + [
+            {
+                "kind": "INTERACTION",
+                "from": {"kind": "OPERATION", "id": str(interaction.operation_id)},
+                "to": {"kind": "DATASET", "id": interaction.dataset_id},
+                "type": "APPEND",
+            }
+            for interaction in interactions
         ],
         "nodes": [
             {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Collect dataset symlinks and handle them just like original dataset. For example, if user requested to build lineage from a Hive table, include table's HDFS location as alternative source for lineage. Same for other direction - if operation appended data to HDFS location, add Hive table to a lineage.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
