### PR TITLE
[DOP-19494] Optimize queries

### DIFF
--- a/data_rentgen/db/models/address.py
+++ b/data_rentgen/db/models/address.py
@@ -43,5 +43,6 @@ class Address(Base):
         TSVECTOR,
         Computed("to_tsvector('english'::regconfig, url || ' ' || (translate(url, '/.', '  ')))", persisted=True),
         nullable=False,
+        deferred=True,
         doc="Full-text search vector",
     )

--- a/data_rentgen/db/models/dataset.py
+++ b/data_rentgen/db/models/dataset.py
@@ -49,5 +49,6 @@ class Dataset(Base):
         TSVECTOR,
         Computed("to_tsvector('english'::regconfig, name || ' ' || (translate(name, '/.', '  ')))", persisted=True),
         nullable=False,
+        deferred=True,
         doc="Full-text search vector",
     )

--- a/data_rentgen/db/models/job.py
+++ b/data_rentgen/db/models/job.py
@@ -61,5 +61,6 @@ class Job(Base):
         TSVECTOR,
         Computed("to_tsvector('english'::regconfig, name || ' ' || (translate(name, '/.', '  ')))", persisted=True),
         nullable=False,
+        deferred=True,
         doc="Full-text search vector",
     )

--- a/data_rentgen/db/models/location.py
+++ b/data_rentgen/db/models/location.py
@@ -48,5 +48,6 @@ class Location(Base):
             persisted=True,
         ),
         nullable=False,
+        deferred=True,
         doc="Full-text search vector",
     )

--- a/data_rentgen/db/models/run.py
+++ b/data_rentgen/db/models/run.py
@@ -144,5 +144,6 @@ class Run(Base):
             persisted=True,
         ),
         nullable=True,
+        deferred=True,
         doc="Full-text search vector",
     )

--- a/data_rentgen/db/repositories/base.py
+++ b/data_rentgen/db/repositories/base.py
@@ -53,18 +53,6 @@ class Repository(ABC, Generic[Model]):
             page_size=page_size,
         )
 
-    async def _count(
-        self,
-        where: list[SQLColumnExpression] | None = None,
-    ) -> int:
-        model_type = self.model_type()
-        query: Select = select(func.count()).select_from(model_type)
-        if where:
-            query = query.where(*where)
-
-        result = await self._session.scalars(query)
-        return result.one()
-
     async def _lock(
         self,
         *keys: Any,

--- a/data_rentgen/db/repositories/input.py
+++ b/data_rentgen/db/repositories/input.py
@@ -48,7 +48,9 @@ class InputRepository(Repository[Input]):
         self,
         operation_ids: Iterable[UUID],
     ) -> list[Input]:
-        # Input created_at is always the same as operation's created_at
+        # Input created_at is always the same as operation's created_at.
+        # do not use `tuple_(Input.created_at, Input.operation_id).in_(...),
+        # as this is too complex filter for Postgres to make an optimal query plan
         min_created_at = extract_timestamp_from_uuid(min(operation_ids))
         max_created_at = extract_timestamp_from_uuid(max(operation_ids))
         query = select(Input).where(

--- a/data_rentgen/db/repositories/input.py
+++ b/data_rentgen/db/repositories/input.py
@@ -24,8 +24,8 @@ class InputRepository(Repository[Input]):
         dataset_id: int,
         schema_id: int | None,
     ) -> Input:
-        # `created_at' and `id` fields of input should correlate with `operation.id`,
-        # to avoid scanning all partitions and speed up insert queries
+        # `created_at' field of input should be the same as operation's,
+        # to avoid scanning all partitions and speed up queries
         created_at = extract_timestamp_from_uuid(operation_id)
 
         # instead of using UniqueConstraint on multiple fields, one of which (schema_id) can be NULL,
@@ -47,16 +47,15 @@ class InputRepository(Repository[Input]):
     async def list_by_operation_ids(
         self,
         operation_ids: Iterable[UUID],
-        since: datetime,
-        until: datetime | None,
     ) -> list[Input]:
-        filters = [
-            Input.created_at >= since,
+        # Input created_at is always the same as operation's created_at
+        min_created_at = extract_timestamp_from_uuid(min(operation_ids))
+        max_created_at = extract_timestamp_from_uuid(max(operation_ids))
+        query = select(Input).where(
+            Input.created_at >= min_created_at,
+            Input.created_at <= max_created_at,
             Input.operation_id.in_(operation_ids),
-        ]
-        if until:
-            filters.append(Input.created_at <= until)
-        query = select(Input).where(and_(*filters))
+        )
         result = await self._session.scalars(query)
         return list(result.all())
 

--- a/data_rentgen/db/repositories/output.py
+++ b/data_rentgen/db/repositories/output.py
@@ -24,8 +24,8 @@ class OutputRepository(Repository[Output]):
         dataset_id: int,
         schema_id: int | None,
     ) -> Output:
-        # `created_at' and `id` fields of output should correlate with `operation.id`,
-        # to avoid scanning all partitions and speed up insert queries
+        # `created_at' field of output should be the same as operation's,
+        # to avoid scanning all partitions and speed up queries
         created_at = extract_timestamp_from_uuid(operation_id)
 
         # instead of using UniqueConstraint on multiple fields, one of which (schema_id) can be NULL,
@@ -47,16 +47,15 @@ class OutputRepository(Repository[Output]):
     async def list_by_operation_ids(
         self,
         operation_ids: Iterable[UUID],
-        since: datetime,
-        until: datetime | None,
     ) -> list[Output]:
-        filters = [
-            Output.created_at >= since,
+        # Output created_at is always the same as operation's created_at
+        min_created_at = extract_timestamp_from_uuid(min(operation_ids))
+        max_created_at = extract_timestamp_from_uuid(max(operation_ids))
+        query = select(Output).where(
+            Output.created_at >= min_created_at,
+            Output.created_at <= max_created_at,
             Output.operation_id.in_(operation_ids),
-        ]
-        if until:
-            filters.append(Output.created_at <= until)
-        query = select(Output).where(and_(*filters))
+        )
         result = await self._session.scalars(query)
         return list(result.all())
 

--- a/data_rentgen/db/repositories/output.py
+++ b/data_rentgen/db/repositories/output.py
@@ -49,6 +49,8 @@ class OutputRepository(Repository[Output]):
         operation_ids: Iterable[UUID],
     ) -> list[Output]:
         # Output created_at is always the same as operation's created_at
+        # do not use `tuple_(Output.created_at, Output.operation_id).in_(...),
+        # as this is too complex filter for Postgres to make an optimal query plan
         min_created_at = extract_timestamp_from_uuid(min(operation_ids))
         max_created_at = extract_timestamp_from_uuid(max(operation_ids))
         query = select(Output).where(

--- a/data_rentgen/server/services/lineage.py
+++ b/data_rentgen/server/services/lineage.py
@@ -106,17 +106,9 @@ class LineageService:
         inputs = []
         outputs = []
         if direction == LineageDirectionV1.DOWNSTREAM:
-            outputs = await self._uow.output.list_by_operation_ids(
-                operation_ids,
-                since,
-                until,
-            )
+            outputs = await self._uow.output.list_by_operation_ids(operation_ids)
         else:
-            inputs = await self._uow.input.list_by_operation_ids(
-                operation_ids,
-                since,
-                until,
-            )
+            inputs = await self._uow.input.list_by_operation_ids(operation_ids)
 
         # Return only operations which have at least one input or output
         operation_ids = {input.operation_id for input in inputs} | {output.operation_id for output in outputs}
@@ -204,17 +196,9 @@ class LineageService:
         inputs = []
         outputs = []
         if direction == LineageDirectionV1.DOWNSTREAM:
-            outputs = await self._uow.output.list_by_operation_ids(
-                operation_ids,
-                since,
-                until,
-            )
+            outputs = await self._uow.output.list_by_operation_ids(operation_ids)
         else:
-            inputs = await self._uow.input.list_by_operation_ids(
-                operation_ids,
-                since,
-                until,
-            )
+            inputs = await self._uow.input.list_by_operation_ids(operation_ids)
 
         # Return only operations which have at least one input or output
         operation_ids = {input.operation_id for input in inputs} | {output.operation_id for output in outputs}
@@ -298,17 +282,9 @@ class LineageService:
         inputs = []
         outputs = []
         if direction == LineageDirectionV1.DOWNSTREAM:
-            outputs = await self._uow.output.list_by_operation_ids(
-                operations_by_id.keys(),
-                since,
-                until,
-            )
+            outputs = await self._uow.output.list_by_operation_ids(operations_by_id)
         else:
-            inputs = await self._uow.input.list_by_operation_ids(
-                operations_by_id.keys(),
-                since,
-                until,
-            )
+            inputs = await self._uow.input.list_by_operation_ids(operations_by_id)
 
         ids_to_skip = ids_to_skip or IdsToSkip()
         run_ids = {operation.run_id for operation in operations}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

* `search_vector` is not returned by any API call, exclude it from SELECT queries
* If depth>1, the same operation is first selected in `depth=3`, then operation_ids is passed to call with `depth=2` to select the same operation and its run/job. Avoid doing the same query twice.
* Input/output's `created_at` is always the same as operations's created at. So instead of user specified since/until, use min and max `created_at` of operations. This leads to searching data is a more narrow slice of a table.
* Add max limit for operation and run `created_at` field, to avoid scanning partitions there is no data for sure.

Each case is implemented in s separated commit, to simplify a review process.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [ ] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
