### PR TITLE
[DOP-19494] Replace id IN () with id = ANY ()

### DIFF
--- a/data_rentgen/db/repositories/dataset_symlink.py
+++ b/data_rentgen/db/repositories/dataset_symlink.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Iterable
+from typing import Sequence
 
-from sqlalchemy import or_, select
+from sqlalchemy import any_, or_, select
 
 from data_rentgen.db.models.dataset_symlink import DatasetSymlink, DatasetSymlinkType
 from data_rentgen.db.repositories.base import Repository
@@ -27,14 +27,14 @@ class DatasetSymlinkRepository(Repository[DatasetSymlink]):
             return await self._create(from_dataset_id, to_dataset_id, symlink_type)
         return await self._update(result, symlink_type)
 
-    async def list_by_dataset_ids(self, dataset_ids: Iterable[int]) -> list[DatasetSymlink]:
+    async def list_by_dataset_ids(self, dataset_ids: Sequence[int]) -> list[DatasetSymlink]:
         if not dataset_ids:
             return []
 
         query = select(DatasetSymlink).where(
             or_(
-                DatasetSymlink.from_dataset_id.in_(dataset_ids),
-                DatasetSymlink.to_dataset_id.in_(dataset_ids),
+                DatasetSymlink.from_dataset_id == any_(dataset_ids),  # type: ignore[arg-type]
+                DatasetSymlink.to_dataset_id == any_(dataset_ids),  # type: ignore[arg-type]
             ),
         )
         scalars = await self._session.scalars(query)

--- a/data_rentgen/db/repositories/input.py
+++ b/data_rentgen/db/repositories/input.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
-from typing import Iterable
+from typing import Sequence
 from uuid import UUID
 
-from sqlalchemy import and_, select
+from sqlalchemy import and_, any_, select
 
 from data_rentgen.db.models import Input
 from data_rentgen.db.repositories.base import Repository
@@ -46,8 +46,11 @@ class InputRepository(Repository[Input]):
 
     async def list_by_operation_ids(
         self,
-        operation_ids: Iterable[UUID],
+        operation_ids: Sequence[UUID],
     ) -> list[Input]:
+        if not operation_ids:
+            return []
+
         # Input created_at is always the same as operation's created_at.
         # do not use `tuple_(Input.created_at, Input.operation_id).in_(...),
         # as this is too complex filter for Postgres to make an optimal query plan
@@ -56,20 +59,23 @@ class InputRepository(Repository[Input]):
         query = select(Input).where(
             Input.created_at >= min_created_at,
             Input.created_at <= max_created_at,
-            Input.operation_id.in_(operation_ids),
+            Input.operation_id == any_(operation_ids),  # type: ignore[arg-type]
         )
         result = await self._session.scalars(query)
         return list(result.all())
 
     async def list_by_dataset_ids(
         self,
-        dataset_ids: Iterable[int],
+        dataset_ids: Sequence[int],
         since: datetime,
         until: datetime | None,
     ) -> list[Input]:
+        if not dataset_ids:
+            return []
+
         filters = [
             Input.created_at >= since,
-            Input.dataset_id.in_(dataset_ids),
+            Input.dataset_id == any_(dataset_ids),  # type: ignore[arg-type]
         ]
         if until:
             filters.append(Input.created_at <= until)

--- a/data_rentgen/db/repositories/location.py
+++ b/data_rentgen/db/repositories/location.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
-from sqlalchemy import select
+from sqlalchemy import any_, select
 from sqlalchemy.orm import selectinload
 
 from data_rentgen.db.models import Address, Location
@@ -24,7 +24,10 @@ class LocationRepository(Repository[Location]):
         by_addresses = (
             select(Location)
             .join(Location.addresses)
-            .where(Location.type == location.type, Address.url.in_(location.addresses))
+            .where(
+                Location.type == location.type,
+                Address.url == any_(location.addresses),  # type: ignore[arg-type]
+            )
         )
         statement = (
             select(Location).from_statement(by_name.union(by_addresses)).options(selectinload(Location.addresses))

--- a/tests/test_server/test_lineage/test_operation_lineage.py
+++ b/tests/test_server/test_lineage/test_operation_lineage.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 
 import pytest
@@ -19,6 +19,110 @@ from tests.test_server.utils.enrich import enrich_datasets, enrich_jobs, enrich_
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
 LINEAGE_FIXTURE_ANNOTATION = tuple[list[Job], list[Run], list[Operation], list[Dataset], list[Input], list[Output]]
+
+
+@pytest.mark.parametrize("direction", ["DOWNSTREAM", "UPSTREAM"])
+async def test_get_operation_lineage_unknown_id(
+    test_client: AsyncClient,
+    new_operation: Operation,
+    direction: str,
+):
+    response = await test_client.get(
+        "v1/lineage",
+        params={
+            "since": datetime.now(tz=timezone.utc).isoformat(),
+            "point_kind": "OPERATION",
+            "point_id": str(new_operation.id),
+            "direction": direction,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [],
+        "nodes": [],
+    }
+
+
+@pytest.mark.parametrize("direction", ["DOWNSTREAM", "UPSTREAM"])
+async def test_get_operation_lineage_no_inputs_outputs(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    job: Job,
+    run: Run,
+    operation: Operation,
+    direction: str,
+):
+    response = await test_client.get(
+        "v1/lineage",
+        params={
+            "since": datetime.now(tz=timezone.utc).isoformat(),
+            "point_kind": "OPERATION",
+            "point_id": str(operation.id),
+            "direction": direction,
+        },
+    )
+
+    [job] = await enrich_jobs([job], async_session)
+    [run] = await enrich_runs([run], async_session)
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+                "type": None,
+            },
+            {
+                "kind": "PARENT",
+                "from": {"kind": "RUN", "id": str(operation.run_id)},
+                "to": {"kind": "OPERATION", "id": str(operation.id)},
+                "type": None,
+            },
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "location": {
+                    "type": job.location.type,
+                    "name": job.location.name,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                },
+            },
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.value,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            },
+            {
+                "kind": "OPERATION",
+                "id": str(operation.id),
+                "run_id": str(operation.run_id),
+                "name": operation.name,
+                "status": operation.status.value,
+                "type": operation.type.value,
+                "position": operation.position,
+                "description": operation.description,
+                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            },
+        ],
+    }
 
 
 async def test_get_operation_lineage(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Using `WHERE id IN (...)` syntax has a flaw - if there are different number of items in this list, SQLAlchemy will produce different SELECT queries, like:
```
... WHERE id IN (%(id1)s, %(id2)s)
... WHERE id IN (%(id1)s, %(id2)s, %id(3)s)
... WHERE id IN (%(id1)s, %(id2)s, %id(3)s, ..., %id(50)s)
```

This prevents SQLAlchemy from using already compiled query from the cache.

Instead replace it with syntax:
```
... WHERE id = ANY (%(ids)s)
```
In this case `ids` is a list of values, passed directly to Postgres, and thus fixes cache misses.

Also add test cases when lineage is requested for an object with no relations/inputs/outputs.
Previously some of those were failing. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
