### PR TITLE
[DOP-20048] Split lineage endpoint

### DIFF
--- a/data_rentgen/server/api/v1/router/__init__.py
+++ b/data_rentgen/server/api/v1/router/__init__.py
@@ -4,13 +4,11 @@ from fastapi import APIRouter
 
 from data_rentgen.server.api.v1.router.dataset import router as dataset_router
 from data_rentgen.server.api.v1.router.job import router as job_router
-from data_rentgen.server.api.v1.router.lineage import router as lineage_router
 from data_rentgen.server.api.v1.router.operation import router as operation_router
 from data_rentgen.server.api.v1.router.run import router as run_router
 
 router = APIRouter(prefix="/v1")
 router.include_router(dataset_router)
 router.include_router(job_router)
-router.include_router(lineage_router)
 router.include_router(operation_router)
 router.include_router(run_router)

--- a/data_rentgen/server/api/v1/router/dataset.py
+++ b/data_rentgen/server/api/v1/router/dataset.py
@@ -2,16 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from data_rentgen.server.errors import get_error_responses
 from data_rentgen.server.errors.schemas import InvalidRequestSchema
 from data_rentgen.server.schemas.v1 import (
+    DatasetLineageQueryV1,
     DatasetPaginateQueryV1,
     DatasetResponseV1,
+    LineageResponseV1,
     PageResponseV1,
     SearchPaginateQueryV1,
 )
+from data_rentgen.server.services import LineageService
+from data_rentgen.server.utils.lineage_response import build_lineage_response
 from data_rentgen.services import UnitOfWork
 
 router = APIRouter(prefix="/datasets", tags=["Datasets"], responses=get_error_responses(include={InvalidRequestSchema}))
@@ -41,3 +45,19 @@ async def search_datasets(
         search_query=pagination_args.search_query,
     )
     return PageResponseV1[DatasetResponseV1].from_pagination(pagination)
+
+
+@router.get("/lineage", summary="Get Dataset lineage graph")
+async def get_dataset_lineage(
+    pagination_args: Annotated[DatasetLineageQueryV1, Query()],
+    lineage_service: Annotated[LineageService, Depends()],
+) -> LineageResponseV1:
+    lineage = await lineage_service.get_lineage_by_datasets(
+        point_ids=[pagination_args.point_id],  # type: ignore[list-item]
+        direction=pagination_args.direction,
+        since=pagination_args.since,
+        until=pagination_args.until,
+        depth=pagination_args.depth,
+    )
+
+    return await build_lineage_response(lineage)

--- a/data_rentgen/server/api/v1/router/dataset.py
+++ b/data_rentgen/server/api/v1/router/dataset.py
@@ -53,7 +53,7 @@ async def get_dataset_lineage(
     lineage_service: Annotated[LineageService, Depends()],
 ) -> LineageResponseV1:
     lineage = await lineage_service.get_lineage_by_datasets(
-        point_ids=[pagination_args.point_id],  # type: ignore[list-item]
+        start_node_ids=[pagination_args.start_node_id],  # type: ignore[list-item]
         direction=pagination_args.direction,
         since=pagination_args.since,
         until=pagination_args.until,

--- a/data_rentgen/server/api/v1/router/job.py
+++ b/data_rentgen/server/api/v1/router/job.py
@@ -54,7 +54,7 @@ async def get_jobs_lineage(
     lineage_service: Annotated[LineageService, Depends()],
 ) -> LineageResponseV1:
     lineage = await lineage_service.get_lineage_by_jobs(
-        point_ids=[pagination_args.point_id],  # type: ignore[list-item]
+        start_node_ids=[pagination_args.start_node_id],  # type: ignore[list-item]
         direction=pagination_args.direction,
         since=pagination_args.since,
         until=pagination_args.until,

--- a/data_rentgen/server/api/v1/router/job.py
+++ b/data_rentgen/server/api/v1/router/job.py
@@ -2,16 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from data_rentgen.server.errors import get_error_responses
 from data_rentgen.server.errors.schemas import InvalidRequestSchema
 from data_rentgen.server.schemas.v1 import (
+    JobLineageQueryV1,
     JobPaginateQueryV1,
     JobResponseV1,
+    LineageResponseV1,
     PageResponseV1,
     SearchPaginateQueryV1,
 )
+from data_rentgen.server.services import LineageService
+from data_rentgen.server.utils.lineage_response import build_lineage_response
 from data_rentgen.services import UnitOfWork
 
 router = APIRouter(prefix="/jobs", tags=["Jobs"], responses=get_error_responses(include={InvalidRequestSchema}))
@@ -42,3 +46,19 @@ async def search_jobs(
     )
 
     return PageResponseV1[JobResponseV1].from_pagination(pagination)
+
+
+@router.get("/lineage", summary="Get Jobs lineage graph")
+async def get_jobs_lineage(
+    pagination_args: Annotated[JobLineageQueryV1, Query()],
+    lineage_service: Annotated[LineageService, Depends()],
+) -> LineageResponseV1:
+    lineage = await lineage_service.get_lineage_by_jobs(
+        point_ids=[pagination_args.point_id],  # type: ignore[list-item]
+        direction=pagination_args.direction,
+        since=pagination_args.since,
+        until=pagination_args.until,
+        depth=pagination_args.depth,
+    )
+
+    return await build_lineage_response(lineage)

--- a/data_rentgen/server/api/v1/router/operation.py
+++ b/data_rentgen/server/api/v1/router/operation.py
@@ -52,7 +52,7 @@ async def get_jobs_lineage(
     lineage_service: Annotated[LineageService, Depends()],
 ) -> LineageResponseV1:
     lineage = await lineage_service.get_lineage_by_operations(
-        point_ids=[pagination_args.point_id],  # type: ignore[list-item]
+        start_node_ids=[pagination_args.start_node_id],  # type: ignore[list-item]
         direction=pagination_args.direction,
         since=pagination_args.since,
         until=pagination_args.until,

--- a/data_rentgen/server/api/v1/router/operation.py
+++ b/data_rentgen/server/api/v1/router/operation.py
@@ -2,15 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from data_rentgen.server.errors import get_error_responses
 from data_rentgen.server.errors.schemas import InvalidRequestSchema
 from data_rentgen.server.schemas.v1 import (
+    LineageResponseV1,
+    OperationLineageQueryV1,
     OperationQueryV1,
     OperationResponseV1,
     PageResponseV1,
 )
+from data_rentgen.server.services.lineage import LineageService
+from data_rentgen.server.utils.lineage_response import build_lineage_response
 from data_rentgen.services import UnitOfWork
 
 router = APIRouter(
@@ -40,3 +44,19 @@ async def operations(
             until=pagination_args.until,
         )
     return PageResponseV1[OperationResponseV1].from_pagination(pagination)
+
+
+@router.get("/lineage", summary="Get Operations lineage graph")
+async def get_jobs_lineage(
+    pagination_args: Annotated[OperationLineageQueryV1, Query()],
+    lineage_service: Annotated[LineageService, Depends()],
+) -> LineageResponseV1:
+    lineage = await lineage_service.get_lineage_by_operations(
+        point_ids=[pagination_args.point_id],  # type: ignore[list-item]
+        direction=pagination_args.direction,
+        since=pagination_args.since,
+        until=pagination_args.until,
+        depth=pagination_args.depth,
+    )
+
+    return await build_lineage_response(lineage)

--- a/data_rentgen/server/api/v1/router/run.py
+++ b/data_rentgen/server/api/v1/router/run.py
@@ -2,16 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from data_rentgen.server.errors import get_error_responses
 from data_rentgen.server.errors.schemas import InvalidRequestSchema
 from data_rentgen.server.schemas.v1 import (
+    LineageResponseV1,
     PageResponseV1,
+    RunLineageQueryV1,
     RunResponseV1,
     RunsQueryV1,
     SearchPaginateQueryV1,
 )
+from data_rentgen.server.services import LineageService
+from data_rentgen.server.utils.lineage_response import build_lineage_response
 from data_rentgen.services import UnitOfWork
 
 router = APIRouter(prefix="/runs", tags=["Runs"], responses=get_error_responses(include={InvalidRequestSchema}))
@@ -59,3 +63,19 @@ async def search_runss(
     )
 
     return PageResponseV1[RunResponseV1].from_pagination(pagination)
+
+
+@router.get("/lineage", summary="Get Runs lineage graph")
+async def get_jobs_lineage(
+    pagination_args: Annotated[RunLineageQueryV1, Query()],
+    lineage_service: Annotated[LineageService, Depends()],
+) -> LineageResponseV1:
+    lineage = await lineage_service.get_lineage_by_runs(
+        point_ids=[pagination_args.point_id],  # type: ignore[list-item]
+        direction=pagination_args.direction,
+        since=pagination_args.since,
+        until=pagination_args.until,
+        depth=pagination_args.depth,
+    )
+
+    return await build_lineage_response(lineage)

--- a/data_rentgen/server/api/v1/router/run.py
+++ b/data_rentgen/server/api/v1/router/run.py
@@ -71,7 +71,7 @@ async def get_jobs_lineage(
     lineage_service: Annotated[LineageService, Depends()],
 ) -> LineageResponseV1:
     lineage = await lineage_service.get_lineage_by_runs(
-        point_ids=[pagination_args.point_id],  # type: ignore[list-item]
+        start_node_ids=[pagination_args.start_node_id],  # type: ignore[list-item]
         direction=pagination_args.direction,
         since=pagination_args.since,
         until=pagination_args.until,

--- a/data_rentgen/server/schemas/v1/__init__.py
+++ b/data_rentgen/server/schemas/v1/__init__.py
@@ -7,13 +7,16 @@ from data_rentgen.server.schemas.v1.dataset import (
 )
 from data_rentgen.server.schemas.v1.job import JobPaginateQueryV1, JobResponseV1
 from data_rentgen.server.schemas.v1.lineage import (
+    DatasetLineageQueryV1,
+    JobLineageQueryV1,
     LineageDirectionV1,
     LineageEntityKindV1,
     LineageEntityV1,
-    LineageQueryV1,
     LineageRelationKindV1,
     LineageRelationv1,
     LineageResponseV1,
+    OperationLineageQueryV1,
+    RunLineageQueryV1,
 )
 from data_rentgen.server.schemas.v1.location import LocationResponseV1
 from data_rentgen.server.schemas.v1.operation import (
@@ -33,10 +36,11 @@ __all__ = [
     "AddressResponseV1",
     "RunResponseV1",
     "RunsQueryV1",
+    "RunLineageQueryV1",
     "UserResponseV1",
     "DatasetPaginateQueryV1",
     "DatasetResponseV1",
-    "LineageQueryV1",
+    "DatasetLineageQueryV1",
     "LineageDirectionV1",
     "LineageEntityV1",
     "LineageEntityKindV1",
@@ -48,8 +52,10 @@ __all__ = [
     "PageResponseV1",
     "OperationQueryV1",
     "OperationResponseV1",
+    "OperationLineageQueryV1",
     "JobResponseV1",
     "JobPaginateQueryV1",
+    "JobLineageQueryV1",
     "PaginateQueryV1",
     "SearchPaginateQueryV1",
 ]

--- a/data_rentgen/server/schemas/v1/dataset.py
+++ b/data_rentgen/server/schemas/v1/dataset.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from typing import Literal
 
 from fastapi import Query

--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -79,19 +79,19 @@ class BaseLineageQueryV1(BaseModel):
 
 
 class DatasetLineageQueryV1(BaseLineageQueryV1):
-    point_id: int = Field(description="Dataset id", examples=[42])
+    start_node_id: int = Field(description="Dataset id", examples=[42])
 
 
 class JobLineageQueryV1(BaseLineageQueryV1):
-    point_id: int = Field(description="Job id", examples=[42])
+    start_node_id: int = Field(description="Job id", examples=[42])
 
 
 class OperationLineageQueryV1(BaseLineageQueryV1):
-    point_id: UUID = Field(description="Operation id", examples=["00000000-0000-0000-0000-000000000000"])
+    start_node_id: UUID = Field(description="Operation id", examples=["00000000-0000-0000-0000-000000000000"])
 
 
 class RunLineageQueryV1(BaseLineageQueryV1):
-    point_id: UUID = Field(description="Run id", examples=["00000000-0000-0000-0000-000000000000"])
+    start_node_id: UUID = Field(description="Run id", examples=["00000000-0000-0000-0000-000000000000"])
 
 
 class LineageRelationv1(BaseModel):

--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -3,15 +3,7 @@
 from datetime import datetime
 from enum import Enum
 
-from fastapi import Query
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    ValidationInfo,
-    field_validator,
-    model_validator,
-)
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 
 from data_rentgen.server.schemas.v1.dataset import DatasetResponseV1
 from data_rentgen.server.schemas.v1.job import JobResponseV1
@@ -55,37 +47,26 @@ class LineageEntityV1(BaseModel):
     model_config = ConfigDict(from_attributes=True, use_enum_values=True)
 
 
-class LineageQueryV1(BaseModel):
+class BaseLineageQueryV1(BaseModel):
     since: datetime = Field(
-        Query(description="", examples=["2008-09-15T15:53:00+05:00"]),
+        description="",
+        examples=["2008-09-15T15:53:00+05:00"],
     )
     until: datetime | None = Field(
-        Query(
-            default=None,
-            description="",
-            examples=["2008-09-15T15:53:00+05:00"],
-        ),
-    )
-    point_kind: LineageEntityKindV1 = Field(
-        Query(description="Type of the Lineage start point", examples=["JOB", "DATASET"]),
-    )
-    point_id: int | UUID = Field(
-        Query(
-            description="Id of the Lineage start point",
-            examples=[42, "01913217-b761-7b1a-bb52-489da9c8b9c8"],
-        ),
+        default=None,
+        description="",
+        examples=["2008-09-15T15:53:00+05:00"],
     )
     direction: LineageDirectionV1 = Field(
-        Query(description="Direction of the lineage", examples=["DOWNSTREAM", "UPSTREAM"]),
+        description="Direction of the lineage",
+        examples=["DOWNSTREAM", "UPSTREAM"],
     )
     depth: int = Field(
-        Query(
-            default=1,
-            ge=1,
-            le=3,
-            description="Depth of the lineage",
-            examples=[1, 3],
-        ),
+        default=1,
+        ge=1,
+        le=3,
+        description="Depth of the lineage",
+        examples=[1, 3],
     )
 
     @field_validator("until", mode="after")
@@ -96,21 +77,21 @@ class LineageQueryV1(BaseModel):
             raise ValueError("'since' should be less than 'until'")
         return value
 
-    @model_validator(mode="after")
-    def _check_ids(self):
-        from uuid import UUID as OLD_UUID
 
-        if self.point_kind in {LineageEntityKindV1.JOB, LineageEntityKindV1.DATASET} and not isinstance(
-            self.point_id,
-            int,
-        ):
-            raise ValueError(f"'point_id' should be int for '{self.point_kind}' kind")
-        elif self.point_kind in {LineageEntityKindV1.RUN, LineageEntityKindV1.OPERATION} and not isinstance(
-            self.point_id,
-            OLD_UUID,
-        ):
-            raise ValueError(f"'point_id' should be UUIDv7 for '{self.point_kind}' kind")
-        return self
+class DatasetLineageQueryV1(BaseLineageQueryV1):
+    point_id: int = Field(description="Dataset id", examples=[42])
+
+
+class JobLineageQueryV1(BaseLineageQueryV1):
+    point_id: int = Field(description="Job id", examples=[42])
+
+
+class OperationLineageQueryV1(BaseLineageQueryV1):
+    point_id: UUID = Field(description="Operation id", examples=["00000000-0000-0000-0000-000000000000"])
+
+
+class RunLineageQueryV1(BaseLineageQueryV1):
+    point_id: UUID = Field(description="Run id", examples=["00000000-0000-0000-0000-000000000000"])
 
 
 class LineageRelationv1(BaseModel):

--- a/data_rentgen/server/services/lineage.py
+++ b/data_rentgen/server/services/lineage.py
@@ -76,7 +76,7 @@ class LineageService:
 
     async def get_lineage_by_jobs(
         self,
-        point_ids: list[int],
+        start_node_ids: list[int],
         direction: LineageDirectionV1,
         since: datetime,
         until: datetime | None,
@@ -85,13 +85,13 @@ class LineageService:
         if logger.isEnabledFor(logging.INFO):
             logger.info(
                 "Get lineage by jobs %r, with direction %s, since %s, until %s, depth %s",
-                sorted(point_ids),
+                sorted(start_node_ids),
                 direction,
                 since,
                 until,
                 depth,
             )
-        jobs = await self._uow.job.list_by_ids(point_ids)
+        jobs = await self._uow.job.list_by_ids(start_node_ids)
         if not jobs:
             logger.info("No jobs found")
             return LineageServiceResult()
@@ -133,7 +133,7 @@ class LineageService:
         if depth > 1:
             result.merge(
                 await self.get_lineage_by_datasets(
-                    point_ids=dataset_ids,
+                    start_node_ids=dataset_ids,
                     direction=direction,
                     since=since,
                     until=until,
@@ -169,7 +169,7 @@ class LineageService:
 
     async def get_lineage_by_runs(
         self,
-        point_ids: list[UUID],
+        start_node_ids: list[UUID],
         direction: LineageDirectionV1,
         since: datetime,
         until: datetime | None,
@@ -178,14 +178,14 @@ class LineageService:
         if logger.isEnabledFor(logging.INFO):
             logger.info(
                 "Get lineage by runs %r, with direction %s, since %s, until %s, depth %s",
-                sorted(point_ids),
+                sorted(start_node_ids),
                 direction,
                 since,
                 until,
                 depth,
             )
 
-        runs = await self._uow.run.list_by_ids(point_ids)
+        runs = await self._uow.run.list_by_ids(start_node_ids)
         if not runs:
             logger.info("No runs found")
             return LineageServiceResult()
@@ -223,7 +223,7 @@ class LineageService:
             # datasets and symlinks will be populated by nested call
             result.merge(
                 await self.get_lineage_by_datasets(
-                    point_ids=dataset_ids,
+                    start_node_ids=dataset_ids,
                     direction=direction,
                     since=since,
                     until=until,
@@ -258,7 +258,7 @@ class LineageService:
 
     async def get_lineage_by_operations(
         self,
-        point_ids: list[UUID],
+        start_node_ids: list[UUID],
         direction: LineageDirectionV1,
         since: datetime,
         until: datetime | None,
@@ -268,14 +268,14 @@ class LineageService:
         if logger.isEnabledFor(logging.INFO):
             logger.info(
                 "Get lineage by operations %r, with direction %s, since %s, until %s, depth %s",
-                sorted(point_ids),
+                sorted(start_node_ids),
                 direction,
                 since,
                 until,
                 depth,
             )
 
-        operations = await self._uow.operation.list_by_ids(point_ids)
+        operations = await self._uow.operation.list_by_ids(start_node_ids)
         if not operations:
             logger.info("No operations found")
             return LineageServiceResult()
@@ -313,7 +313,7 @@ class LineageService:
             # datasets and symlinks will be populated by nested call
             result.merge(
                 await self.get_lineage_by_datasets(
-                    point_ids=dataset_ids_to_fetch,
+                    start_node_ids=dataset_ids_to_fetch,
                     direction=direction,
                     since=since,
                     until=until,
@@ -351,7 +351,7 @@ class LineageService:
 
     async def get_lineage_by_datasets(
         self,
-        point_ids: list[int],
+        start_node_ids: list[int],
         direction: LineageDirectionV1,
         since: datetime,
         until: datetime | None,
@@ -361,21 +361,21 @@ class LineageService:
         if logger.isEnabledFor(logging.INFO):
             logger.info(
                 "Get lineage by datasets %r, with direction %s, since %s, until %s, depth %s",
-                sorted(point_ids),
+                sorted(start_node_ids),
                 direction,
                 since,
                 until,
                 depth,
             )
 
-        datasets = await self._uow.dataset.list_by_ids(point_ids)
+        datasets = await self._uow.dataset.list_by_ids(start_node_ids)
         if not datasets:
             logger.info("No datasets found")
             return LineageServiceResult()
 
         datasets_by_id = {dataset.id: dataset for dataset in datasets}
 
-        # Threat dataset symlinks like they are specified in `point_ids`
+        # Threat dataset symlinks like they are specified in `start_node_ids`
         ids_to_skip = ids_to_skip or IdsToSkip()
         extra_datasets, dataset_symlinks = await self._extend_datasets_with_symlinks(
             sorted(datasets_by_id.keys()),
@@ -419,7 +419,7 @@ class LineageService:
             # operations, runs and jobs will be populated by nested call
             result.merge(
                 await self.get_lineage_by_operations(
-                    point_ids=operation_ids_to_fetch,
+                    start_node_ids=operation_ids_to_fetch,
                     direction=direction,
                     since=since,
                     until=until,

--- a/data_rentgen/server/utils/lineage_response.py
+++ b/data_rentgen/server/utils/lineage_response.py
@@ -1,53 +1,21 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
-from typing import Annotated
-
-from fastapi import APIRouter, Depends
-
-from data_rentgen.server.errors import get_error_responses
-from data_rentgen.server.errors.schemas import InvalidRequestSchema
 from data_rentgen.server.schemas.v1 import (
     DatasetResponseV1,
     JobResponseV1,
     LineageEntityKindV1,
     LineageEntityV1,
-    LineageQueryV1,
     LineageRelationKindV1,
     LineageRelationv1,
     LineageResponseV1,
     OperationResponseV1,
     RunResponseV1,
 )
-from data_rentgen.server.services import LineageService
-
-router = APIRouter(prefix="/lineage", tags=["Lineage"], responses=get_error_responses(include={InvalidRequestSchema}))
+from data_rentgen.server.services.lineage import LineageServiceResult
 
 
-@router.get("", summary="Lineage graph")
-async def get_lineage(
-    pagination_args: Annotated[LineageQueryV1, Depends()],
-    lineage_service: Annotated[LineageService, Depends()],
-) -> LineageResponseV1:
-    match pagination_args.point_kind:
-        case LineageEntityKindV1.OPERATION:
-            get_lineage_method = lineage_service.get_lineage_by_operations  # type: ignore[assignment]
-        case LineageEntityKindV1.DATASET:
-            get_lineage_method = lineage_service.get_lineage_by_datasets  # type: ignore[assignment]
-        case LineageEntityKindV1.RUN:
-            get_lineage_method = lineage_service.get_lineage_by_runs  # type: ignore[assignment]
-        case LineageEntityKindV1.JOB:
-            get_lineage_method = lineage_service.get_lineage_by_jobs  # type: ignore[assignment]
-
-    lineage = await get_lineage_method(
-        point_ids=[pagination_args.point_id],  # type: ignore[list-item]
-        direction=pagination_args.direction,
-        since=pagination_args.since,
-        until=pagination_args.until,
-        depth=pagination_args.depth,
-    )
-
+async def build_lineage_response(lineage: LineageServiceResult) -> LineageResponseV1:
     response = LineageResponseV1()
-
     for job_id in sorted(lineage.jobs):
         job = lineage.jobs[job_id]
         response.nodes.append(JobResponseV1.model_validate(job))

--- a/poetry.lock
+++ b/poetry.lock
@@ -65,13 +65,13 @@ files = [
 
 [[package]]
 name = "alembic"
-version = "1.13.2"
+version = "1.13.3"
 description = "A database migration tool for SQLAlchemy."
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "alembic-1.13.2-py3-none-any.whl", hash = "sha256:6b8733129a6224a9a711e17c99b08462dbf7cc9670ba8f2e2ae9af860ceb1953"},
-    {file = "alembic-1.13.2.tar.gz", hash = "sha256:1ff0ae32975f4fd96028c39ed9bb3c867fe3af956bd7bb37343b54c9fe7445ef"},
+    {file = "alembic-1.13.3-py3-none-any.whl", hash = "sha256:908e905976d15235fae59c9ac42c4c5b75cfcefe3d27c0fbf7ae15a37715d80e"},
+    {file = "alembic-1.13.3.tar.gz", hash = "sha256:203503117415561e203aa14541740643a611f641517f0209fcae63e9fa09f1a2"},
 ]
 
 [package.dependencies]
@@ -1966,18 +1966,18 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.9.2"
+version = "2.8.2"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic-2.9.2-py3-none-any.whl", hash = "sha256:f048cec7b26778210e28a0459867920654d48e5e62db0958433636cde4254f12"},
-    {file = "pydantic-2.9.2.tar.gz", hash = "sha256:d155cef71265d1e9807ed1c32b4c8deec042a44a50a4188b25ac67ecd81a9c0f"},
+    {file = "pydantic-2.8.2-py3-none-any.whl", hash = "sha256:73ee9fddd406dc318b885c7a2eab8a6472b68b8fb5ba8150949fc3db939f23c8"},
+    {file = "pydantic-2.8.2.tar.gz", hash = "sha256:6f62c13d067b0755ad1c21a34bdd06c0c12625a22b0fc09c6b149816604f7c2a"},
 ]
 
 [package.dependencies]
-annotated-types = ">=0.6.0"
-pydantic-core = "2.23.4"
+annotated-types = ">=0.4.0"
+pydantic-core = "2.20.1"
 typing-extensions = [
     {version = ">=4.6.1", markers = "python_version < \"3.13\""},
     {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
@@ -1985,104 +1985,103 @@ typing-extensions = [
 
 [package.extras]
 email = ["email-validator (>=2.0.0)"]
-timezone = ["tzdata"]
 
 [[package]]
 name = "pydantic-core"
-version = "2.23.4"
+version = "2.20.1"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic_core-2.23.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:b10bd51f823d891193d4717448fab065733958bdb6a6b351967bd349d48d5c9b"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4fc714bdbfb534f94034efaa6eadd74e5b93c8fa6315565a222f7b6f42ca1166"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63e46b3169866bd62849936de036f901a9356e36376079b05efa83caeaa02ceb"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed1a53de42fbe34853ba90513cea21673481cd81ed1be739f7f2efb931b24916"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cfdd16ab5e59fc31b5e906d1a3f666571abc367598e3e02c83403acabc092e07"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:255a8ef062cbf6674450e668482456abac99a5583bbafb73f9ad469540a3a232"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a7cd62e831afe623fbb7aabbb4fe583212115b3ef38a9f6b71869ba644624a2"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f09e2ff1f17c2b51f2bc76d1cc33da96298f0a036a137f5440ab3ec5360b624f"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e38e63e6f3d1cec5a27e0afe90a085af8b6806ee208b33030e65b6516353f1a3"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0dbd8dbed2085ed23b5c04afa29d8fd2771674223135dc9bc937f3c09284d071"},
-    {file = "pydantic_core-2.23.4-cp310-none-win32.whl", hash = "sha256:6531b7ca5f951d663c339002e91aaebda765ec7d61b7d1e3991051906ddde119"},
-    {file = "pydantic_core-2.23.4-cp310-none-win_amd64.whl", hash = "sha256:7c9129eb40958b3d4500fa2467e6a83356b3b61bfff1b414c7361d9220f9ae8f"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:77733e3892bb0a7fa797826361ce8a9184d25c8dffaec60b7ffe928153680ba8"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b84d168f6c48fabd1f2027a3d1bdfe62f92cade1fb273a5d68e621da0e44e6d"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df49e7a0861a8c36d089c1ed57d308623d60416dab2647a4a17fe050ba85de0e"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ff02b6d461a6de369f07ec15e465a88895f3223eb75073ffea56b84d9331f607"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:996a38a83508c54c78a5f41456b0103c30508fed9abcad0a59b876d7398f25fd"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d97683ddee4723ae8c95d1eddac7c192e8c552da0c73a925a89fa8649bf13eea"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:216f9b2d7713eb98cb83c80b9c794de1f6b7e3145eef40400c62e86cee5f4e1e"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6f783e0ec4803c787bcea93e13e9932edab72068f68ecffdf86a99fd5918878b"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d0776dea117cf5272382634bd2a5c1b6eb16767c223c6a5317cd3e2a757c61a0"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d5f7a395a8cf1621939692dba2a6b6a830efa6b3cee787d82c7de1ad2930de64"},
-    {file = "pydantic_core-2.23.4-cp311-none-win32.whl", hash = "sha256:74b9127ffea03643e998e0c5ad9bd3811d3dac8c676e47db17b0ee7c3c3bf35f"},
-    {file = "pydantic_core-2.23.4-cp311-none-win_amd64.whl", hash = "sha256:98d134c954828488b153d88ba1f34e14259284f256180ce659e8d83e9c05eaa3"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f3e0da4ebaef65158d4dfd7d3678aad692f7666877df0002b8a522cdf088f231"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f69a8e0b033b747bb3e36a44e7732f0c99f7edd5cea723d45bc0d6e95377ffee"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:723314c1d51722ab28bfcd5240d858512ffd3116449c557a1336cbe3919beb87"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bb2802e667b7051a1bebbfe93684841cc9351004e2badbd6411bf357ab8d5ac8"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d18ca8148bebe1b0a382a27a8ee60350091a6ddaf475fa05ef50dc35b5df6327"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33e3d65a85a2a4a0dc3b092b938a4062b1a05f3a9abde65ea93b233bca0e03f2"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:128585782e5bfa515c590ccee4b727fb76925dd04a98864182b22e89a4e6ed36"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:68665f4c17edcceecc112dfed5dbe6f92261fb9d6054b47d01bf6371a6196126"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:20152074317d9bed6b7a95ade3b7d6054845d70584216160860425f4fbd5ee9e"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:9261d3ce84fa1d38ed649c3638feefeae23d32ba9182963e465d58d62203bd24"},
-    {file = "pydantic_core-2.23.4-cp312-none-win32.whl", hash = "sha256:4ba762ed58e8d68657fc1281e9bb72e1c3e79cc5d464be146e260c541ec12d84"},
-    {file = "pydantic_core-2.23.4-cp312-none-win_amd64.whl", hash = "sha256:97df63000f4fea395b2824da80e169731088656d1818a11b95f3b173747b6cd9"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7530e201d10d7d14abce4fb54cfe5b94a0aefc87da539d0346a484ead376c3cc"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df933278128ea1cd77772673c73954e53a1c95a4fdf41eef97c2b779271bd0bd"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cb3da3fd1b6a5d0279a01877713dbda118a2a4fc6f0d821a57da2e464793f05"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42c6dcb030aefb668a2b7009c85b27f90e51e6a3b4d5c9bc4c57631292015b0d"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:696dd8d674d6ce621ab9d45b205df149399e4bb9aa34102c970b721554828510"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2971bb5ffe72cc0f555c13e19b23c85b654dd2a8f7ab493c262071377bfce9f6"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8394d940e5d400d04cad4f75c0598665cbb81aecefaca82ca85bd28264af7f9b"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0dff76e0602ca7d4cdaacc1ac4c005e0ce0dcfe095d5b5259163a80d3a10d327"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7d32706badfe136888bdea71c0def994644e09fff0bfe47441deaed8e96fdbc6"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed541d70698978a20eb63d8c5d72f2cc6d7079d9d90f6b50bad07826f1320f5f"},
-    {file = "pydantic_core-2.23.4-cp313-none-win32.whl", hash = "sha256:3d5639516376dce1940ea36edf408c554475369f5da2abd45d44621cb616f769"},
-    {file = "pydantic_core-2.23.4-cp313-none-win_amd64.whl", hash = "sha256:5a1504ad17ba4210df3a045132a7baeeba5a200e930f57512ee02909fc5c4cb5"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:d4488a93b071c04dc20f5cecc3631fc78b9789dd72483ba15d423b5b3689b555"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:81965a16b675b35e1d09dd14df53f190f9129c0202356ed44ab2728b1c905658"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ffa2ebd4c8530079140dd2d7f794a9d9a73cbb8e9d59ffe24c63436efa8f271"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:61817945f2fe7d166e75fbfb28004034b48e44878177fc54d81688e7b85a3665"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:29d2c342c4bc01b88402d60189f3df065fb0dda3654744d5a165a5288a657368"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5e11661ce0fd30a6790e8bcdf263b9ec5988e95e63cf901972107efc49218b13"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d18368b137c6295db49ce7218b1a9ba15c5bc254c96d7c9f9e924a9bc7825ad"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ec4e55f79b1c4ffb2eecd8a0cfba9955a2588497d96851f4c8f99aa4a1d39b12"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:374a5e5049eda9e0a44c696c7ade3ff355f06b1fe0bb945ea3cac2bc336478a2"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5c364564d17da23db1106787675fc7af45f2f7b58b4173bfdd105564e132e6fb"},
-    {file = "pydantic_core-2.23.4-cp38-none-win32.whl", hash = "sha256:d7a80d21d613eec45e3d41eb22f8f94ddc758a6c4720842dc74c0581f54993d6"},
-    {file = "pydantic_core-2.23.4-cp38-none-win_amd64.whl", hash = "sha256:5f5ff8d839f4566a474a969508fe1c5e59c31c80d9e140566f9a37bba7b8d556"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:a4fa4fc04dff799089689f4fd502ce7d59de529fc2f40a2c8836886c03e0175a"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0a7df63886be5e270da67e0966cf4afbae86069501d35c8c1b3b6c168f42cb36"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dcedcd19a557e182628afa1d553c3895a9f825b936415d0dbd3cd0bbcfd29b4b"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f54b118ce5de9ac21c363d9b3caa6c800341e8c47a508787e5868c6b79c9323"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:86d2f57d3e1379a9525c5ab067b27dbb8a0642fb5d454e17a9ac434f9ce523e3"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:de6d1d1b9e5101508cb37ab0d972357cac5235f5c6533d1071964c47139257df"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1278e0d324f6908e872730c9102b0112477a7f7cf88b308e4fc36ce1bdb6d58c"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9a6b5099eeec78827553827f4c6b8615978bb4b6a88e5d9b93eddf8bb6790f55"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:e55541f756f9b3ee346b840103f32779c695a19826a4c442b7954550a0972040"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a5c7ba8ffb6d6f8f2ab08743be203654bb1aaa8c9dcb09f82ddd34eadb695605"},
-    {file = "pydantic_core-2.23.4-cp39-none-win32.whl", hash = "sha256:37b0fe330e4a58d3c58b24d91d1eb102aeec675a3db4c292ec3928ecd892a9a6"},
-    {file = "pydantic_core-2.23.4-cp39-none-win_amd64.whl", hash = "sha256:1498bec4c05c9c787bde9125cfdcc63a41004ff167f495063191b863399b1a29"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:f455ee30a9d61d3e1a15abd5068827773d6e4dc513e795f380cdd59932c782d5"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1e90d2e3bd2c3863d48525d297cd143fe541be8bbf6f579504b9712cb6b643ec"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e203fdf807ac7e12ab59ca2bfcabb38c7cf0b33c41efeb00f8e5da1d86af480"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e08277a400de01bc72436a0ccd02bdf596631411f592ad985dcee21445bd0068"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f220b0eea5965dec25480b6333c788fb72ce5f9129e8759ef876a1d805d00801"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:d06b0c8da4f16d1d1e352134427cb194a0a6e19ad5db9161bf32b2113409e728"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:ba1a0996f6c2773bd83e63f18914c1de3c9dd26d55f4ac302a7efe93fb8e7433"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:9a5bce9d23aac8f0cf0836ecfc033896aa8443b501c58d0602dbfd5bd5b37753"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:78ddaaa81421a29574a682b3179d4cf9e6d405a09b99d93ddcf7e5239c742e21"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:883a91b5dd7d26492ff2f04f40fbb652de40fcc0afe07e8129e8ae779c2110eb"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88ad334a15b32a791ea935af224b9de1bf99bcd62fabf745d5f3442199d86d59"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:233710f069d251feb12a56da21e14cca67994eab08362207785cf8c598e74577"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:19442362866a753485ba5e4be408964644dd6a09123d9416c54cd49171f50744"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:624e278a7d29b6445e4e813af92af37820fafb6dcc55c012c834f9e26f9aaaef"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f5ef8f42bec47f21d07668a043f077d507e5bf4e668d5c6dfe6aaba89de1a5b8"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:aea443fffa9fbe3af1a9ba721a87f926fe548d32cab71d188a6ede77d0ff244e"},
-    {file = "pydantic_core-2.23.4.tar.gz", hash = "sha256:2584f7cf844ac4d970fba483a717dbe10c1c1c96a969bf65d61ffe94df1b2863"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3acae97ffd19bf091c72df4d726d552c473f3576409b2a7ca36b2f535ffff4a3"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41f4c96227a67a013e7de5ff8f20fb496ce573893b7f4f2707d065907bffdbd6"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f239eb799a2081495ea659d8d4a43a8f42cd1fe9ff2e7e436295c38a10c286a"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53e431da3fc53360db73eedf6f7124d1076e1b4ee4276b36fb25514544ceb4a3"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f1f62b2413c3a0e846c3b838b2ecd6c7a19ec6793b2a522745b0869e37ab5bc1"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d41e6daee2813ecceea8eda38062d69e280b39df793f5a942fa515b8ed67953"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d482efec8b7dc6bfaedc0f166b2ce349df0011f5d2f1f25537ced4cfc34fd98"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e93e1a4b4b33daed65d781a57a522ff153dcf748dee70b40c7258c5861e1768a"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e7c4ea22b6739b162c9ecaaa41d718dfad48a244909fe7ef4b54c0b530effc5a"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4f2790949cf385d985a31984907fecb3896999329103df4e4983a4a41e13e840"},
+    {file = "pydantic_core-2.20.1-cp310-none-win32.whl", hash = "sha256:5e999ba8dd90e93d57410c5e67ebb67ffcaadcea0ad973240fdfd3a135506250"},
+    {file = "pydantic_core-2.20.1-cp310-none-win_amd64.whl", hash = "sha256:512ecfbefef6dac7bc5eaaf46177b2de58cdf7acac8793fe033b24ece0b9566c"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d2a8fa9d6d6f891f3deec72f5cc668e6f66b188ab14bb1ab52422fe8e644f312"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:175873691124f3d0da55aeea1d90660a6ea7a3cfea137c38afa0a5ffabe37b88"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37eee5b638f0e0dcd18d21f59b679686bbd18917b87db0193ae36f9c23c355fc"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25e9185e2d06c16ee438ed39bf62935ec436474a6ac4f9358524220f1b236e43"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:150906b40ff188a3260cbee25380e7494ee85048584998c1e66df0c7a11c17a6"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ad4aeb3e9a97286573c03df758fc7627aecdd02f1da04516a86dc159bf70121"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3f3ed29cd9f978c604708511a1f9c2fdcb6c38b9aae36a51905b8811ee5cbf1"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b0dae11d8f5ded51699c74d9548dcc5938e0804cc8298ec0aa0da95c21fff57b"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:faa6b09ee09433b87992fb5a2859efd1c264ddc37280d2dd5db502126d0e7f27"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9dc1b507c12eb0481d071f3c1808f0529ad41dc415d0ca11f7ebfc666e66a18b"},
+    {file = "pydantic_core-2.20.1-cp311-none-win32.whl", hash = "sha256:fa2fddcb7107e0d1808086ca306dcade7df60a13a6c347a7acf1ec139aa6789a"},
+    {file = "pydantic_core-2.20.1-cp311-none-win_amd64.whl", hash = "sha256:40a783fb7ee353c50bd3853e626f15677ea527ae556429453685ae32280c19c2"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:595ba5be69b35777474fa07f80fc260ea71255656191adb22a8c53aba4479231"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a4f55095ad087474999ee28d3398bae183a66be4823f753cd7d67dd0153427c9"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9aa05d09ecf4c75157197f27cdc9cfaeb7c5f15021c6373932bf3e124af029f"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e97fdf088d4b31ff4ba35db26d9cc472ac7ef4a2ff2badeabf8d727b3377fc52"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bc633a9fe1eb87e250b5c57d389cf28998e4292336926b0b6cdaee353f89a237"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d573faf8eb7e6b1cbbcb4f5b247c60ca8be39fe2c674495df0eb4318303137fe"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26dc97754b57d2fd00ac2b24dfa341abffc380b823211994c4efac7f13b9e90e"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:33499e85e739a4b60c9dac710c20a08dc73cb3240c9a0e22325e671b27b70d24"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bebb4d6715c814597f85297c332297c6ce81e29436125ca59d1159b07f423eb1"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:516d9227919612425c8ef1c9b869bbbee249bc91912c8aaffb66116c0b447ebd"},
+    {file = "pydantic_core-2.20.1-cp312-none-win32.whl", hash = "sha256:469f29f9093c9d834432034d33f5fe45699e664f12a13bf38c04967ce233d688"},
+    {file = "pydantic_core-2.20.1-cp312-none-win_amd64.whl", hash = "sha256:035ede2e16da7281041f0e626459bcae33ed998cca6a0a007a5ebb73414ac72d"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:0827505a5c87e8aa285dc31e9ec7f4a17c81a813d45f70b1d9164e03a813a686"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19c0fa39fa154e7e0b7f82f88ef85faa2a4c23cc65aae2f5aea625e3c13c735a"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa223cd1e36b642092c326d694d8bf59b71ddddc94cdb752bbbb1c5c91d833b"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c336a6d235522a62fef872c6295a42ecb0c4e1d0f1a3e500fe949415761b8a19"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7eb6a0587eded33aeefea9f916899d42b1799b7b14b8f8ff2753c0ac1741edac"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:70c8daf4faca8da5a6d655f9af86faf6ec2e1768f4b8b9d0226c02f3d6209703"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9fa4c9bf273ca41f940bceb86922a7667cd5bf90e95dbb157cbb8441008482c"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:11b71d67b4725e7e2a9f6e9c0ac1239bbc0c48cce3dc59f98635efc57d6dac83"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:270755f15174fb983890c49881e93f8f1b80f0b5e3a3cc1394a255706cabd203"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:c81131869240e3e568916ef4c307f8b99583efaa60a8112ef27a366eefba8ef0"},
+    {file = "pydantic_core-2.20.1-cp313-none-win32.whl", hash = "sha256:b91ced227c41aa29c672814f50dbb05ec93536abf8f43cd14ec9521ea09afe4e"},
+    {file = "pydantic_core-2.20.1-cp313-none-win_amd64.whl", hash = "sha256:65db0f2eefcaad1a3950f498aabb4875c8890438bc80b19362cf633b87a8ab20"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:4745f4ac52cc6686390c40eaa01d48b18997cb130833154801a442323cc78f91"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a8ad4c766d3f33ba8fd692f9aa297c9058970530a32c728a2c4bfd2616d3358b"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41e81317dd6a0127cabce83c0c9c3fbecceae981c8391e6f1dec88a77c8a569a"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04024d270cf63f586ad41fff13fde4311c4fc13ea74676962c876d9577bcc78f"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eaad4ff2de1c3823fddf82f41121bdf453d922e9a238642b1dedb33c4e4f98ad"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26ab812fa0c845df815e506be30337e2df27e88399b985d0bb4e3ecfe72df31c"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c5ebac750d9d5f2706654c638c041635c385596caf68f81342011ddfa1e5598"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2aafc5a503855ea5885559eae883978c9b6d8c8993d67766ee73d82e841300dd"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4868f6bd7c9d98904b748a2653031fc9c2f85b6237009d475b1008bfaeb0a5aa"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:aa2f457b4af386254372dfa78a2eda2563680d982422641a85f271c859df1987"},
+    {file = "pydantic_core-2.20.1-cp38-none-win32.whl", hash = "sha256:225b67a1f6d602de0ce7f6c1c3ae89a4aa25d3de9be857999e9124f15dab486a"},
+    {file = "pydantic_core-2.20.1-cp38-none-win_amd64.whl", hash = "sha256:6b507132dcfc0dea440cce23ee2182c0ce7aba7054576efc65634f080dbe9434"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:b03f7941783b4c4a26051846dea594628b38f6940a2fdc0df00b221aed39314c"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1eedfeb6089ed3fad42e81a67755846ad4dcc14d73698c120a82e4ccf0f1f9f6"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:635fee4e041ab9c479e31edda27fcf966ea9614fff1317e280d99eb3e5ab6fe2"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:77bf3ac639c1ff567ae3b47f8d4cc3dc20f9966a2a6dd2311dcc055d3d04fb8a"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ed1b0132f24beeec5a78b67d9388656d03e6a7c837394f99257e2d55b461611"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6514f963b023aeee506678a1cf821fe31159b925c4b76fe2afa94cc70b3222b"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10d4204d8ca33146e761c79f83cc861df20e7ae9f6487ca290a97702daf56006"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2d036c7187b9422ae5b262badb87a20a49eb6c5238b2004e96d4da1231badef1"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9ebfef07dbe1d93efb94b4700f2d278494e9162565a54f124c404a5656d7ff09"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6b9d9bb600328a1ce523ab4f454859e9d439150abb0906c5a1983c146580ebab"},
+    {file = "pydantic_core-2.20.1-cp39-none-win32.whl", hash = "sha256:784c1214cb6dd1e3b15dd8b91b9a53852aed16671cc3fbe4786f4f1db07089e2"},
+    {file = "pydantic_core-2.20.1-cp39-none-win_amd64.whl", hash = "sha256:d2fe69c5434391727efa54b47a1e7986bb0186e72a41b203df8f5b0a19a4f669"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:a45f84b09ac9c3d35dfcf6a27fd0634d30d183205230a0ebe8373a0e8cfa0906"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d02a72df14dfdbaf228424573a07af10637bd490f0901cee872c4f434a735b94"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2b27e6af28f07e2f195552b37d7d66b150adbaa39a6d327766ffd695799780f"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:084659fac3c83fd674596612aeff6041a18402f1e1bc19ca39e417d554468482"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:242b8feb3c493ab78be289c034a1f659e8826e2233786e36f2893a950a719bb6"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:38cf1c40a921d05c5edc61a785c0ddb4bed67827069f535d794ce6bcded919fc"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:e0bbdd76ce9aa5d4209d65f2b27fc6e5ef1312ae6c5333c26db3f5ade53a1e99"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:254ec27fdb5b1ee60684f91683be95e5133c994cc54e86a0b0963afa25c8f8a6"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:407653af5617f0757261ae249d3fba09504d7a71ab36ac057c938572d1bc9331"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:c693e916709c2465b02ca0ad7b387c4f8423d1db7b4649c551f27a529181c5ad"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b5ff4911aea936a47d9376fd3ab17e970cc543d1b68921886e7f64bd28308d1"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:177f55a886d74f1808763976ac4efd29b7ed15c69f4d838bbd74d9d09cf6fa86"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:964faa8a861d2664f0c7ab0c181af0bea66098b1919439815ca8803ef136fc4e"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:4dd484681c15e6b9a977c785a345d3e378d72678fd5f1f3c0509608da24f2ac0"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f6d6cff3538391e8486a431569b77921adfcdef14eb18fbf19b7c0a5294d4e6a"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a6d511cc297ff0883bc3708b465ff82d7560193169a8b93260f74ecb0a5e08a7"},
+    {file = "pydantic_core-2.20.1.tar.gz", hash = "sha256:26ca695eeee5f9f1aeeb211ffc12f10bcb6f71e2989988fda61dabd65db878d4"},
 ]
 
 [package.dependencies]
@@ -2848,13 +2847,13 @@ url = ["furl (>=0.4.1)"]
 
 [[package]]
 name = "starlette"
-version = "0.38.5"
+version = "0.38.6"
 description = "The little ASGI library that shines."
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "starlette-0.38.5-py3-none-any.whl", hash = "sha256:632f420a9d13e3ee2a6f18f437b0a9f1faecb0bc42e1942aa2ea0e379a4c4206"},
-    {file = "starlette-0.38.5.tar.gz", hash = "sha256:04a92830a9b6eb1442c766199d62260c3d4dc9c4f9188360626b1e0273cb7077"},
+    {file = "starlette-0.38.6-py3-none-any.whl", hash = "sha256:4517a1409e2e73ee4951214ba012052b9e16f60e90d73cfb06192c19203bbb05"},
+    {file = "starlette-0.38.6.tar.gz", hash = "sha256:863a1588f5574e70a821dadefb41e4881ea451a47a3cd1b4df359d4ffefe5ead"},
 ]
 
 [package.dependencies]
@@ -3259,4 +3258,4 @@ server = ["alembic", "asgi-correlation-id", "coloredlogs", "fastapi", "pydantic-
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "979cf519ba387d4c26ef1112233a6d5b38256b1914121d3258a38402c72f97d6"
+content-hash = "dacaa551b0ce77da590b3432f210252b3157d166f2b9eea05ae082abb34ffd27"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-pydantic = "^2.9.2"
+pydantic = "~2.8.0"
 typing-extensions = "^4.12.2"
 pydantic-settings = {version = "^2.5.2", optional = true}
 alembic = {version = "^1.13.2", optional = true}

--- a/tests/test_server/test_lineage/test_dataset_lineage.py
+++ b/tests/test_server/test_lineage/test_dataset_lineage.py
@@ -21,7 +21,7 @@ async def test_get_dataset_lineage_unknown_id(
     direction: str,
 ):
     response = await test_client.get(
-        "v1/lineage",
+        "v1/datasets/lineage",
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "DATASET",
@@ -45,7 +45,7 @@ async def test_get_dataset_lineage_no_relations(
     direction: str,
 ):
     response = await test_client.get(
-        "v1/lineage",
+        "v1/datasets/lineage",
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "DATASET",

--- a/tests/test_server/test_lineage/test_dataset_lineage.py
+++ b/tests/test_server/test_lineage/test_dataset_lineage.py
@@ -89,10 +89,9 @@ async def test_get_dataset_lineage(
 
     since = min(run.created_at for run in runs)
     response = await test_client.get(
-        "v1/lineage",
+        "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
-            "point_kind": "DATASET",
             "point_id": dataset.id,
             "direction": "DOWNSTREAM",
         },
@@ -208,11 +207,10 @@ async def test_get_dataset_lineage_with_direction_and_until(
     operations = [operation for operation in all_operations if since <= operation.created_at <= until]
 
     response = await test_client.get(
-        "v1/lineage",
+        "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
             "until": until.isoformat(),
-            "point_kind": "DATASET",
             "point_id": dataset.id,
             "direction": "UPSTREAM",
         },
@@ -368,10 +366,9 @@ async def test_get_dataset_lineage_with_depth(
 
     since = min(run.created_at for run in runs)
     response = await test_client.get(
-        "v1/lineage",
+        "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
-            "point_kind": "DATASET",
             "point_id": first_level_dataset.id,
             "direction": "DOWNSTREAM",
             "depth": 3,
@@ -495,10 +492,9 @@ async def test_get_dataset_lineage_with_depth_ignore_cycles(
 
     since = min(run.created_at for run in runs)
     response = await test_client.get(
-        "v1/lineage",
+        "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
-            "point_kind": "DATASET",
             "point_id": dataset.id,
             "direction": "DOWNSTREAM",
             "depth": 3,
@@ -655,10 +651,9 @@ async def test_get_dataset_lineage_with_symlinks(
 
     since = min(run.created_at for run in runs)
     response = await test_client.get(
-        "v1/lineage",
+        "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
-            "point_kind": "DATASET",
             "point_id": initial_dataset.id,
             "direction": "DOWNSTREAM",
         },

--- a/tests/test_server/test_lineage/test_dataset_lineage.py
+++ b/tests/test_server/test_lineage/test_dataset_lineage.py
@@ -25,7 +25,7 @@ async def test_get_dataset_lineage_unknown_id(
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "DATASET",
-            "point_id": new_dataset.id,
+            "start_node_id": new_dataset.id,
             "direction": direction,
         },
     )
@@ -49,7 +49,7 @@ async def test_get_dataset_lineage_no_relations(
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "DATASET",
-            "point_id": dataset.id,
+            "start_node_id": dataset.id,
             "direction": direction,
         },
     )
@@ -92,7 +92,7 @@ async def test_get_dataset_lineage(
         "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
-            "point_id": dataset.id,
+            "start_node_id": dataset.id,
             "direction": "DOWNSTREAM",
         },
     )
@@ -211,7 +211,7 @@ async def test_get_dataset_lineage_with_direction_and_until(
         params={
             "since": since.isoformat(),
             "until": until.isoformat(),
-            "point_id": dataset.id,
+            "start_node_id": dataset.id,
             "direction": "UPSTREAM",
         },
     )
@@ -369,7 +369,7 @@ async def test_get_dataset_lineage_with_depth(
         "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
-            "point_id": first_level_dataset.id,
+            "start_node_id": first_level_dataset.id,
             "direction": "DOWNSTREAM",
             "depth": 3,
         },
@@ -495,7 +495,7 @@ async def test_get_dataset_lineage_with_depth_ignore_cycles(
         "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
-            "point_id": dataset.id,
+            "start_node_id": dataset.id,
             "direction": "DOWNSTREAM",
             "depth": 3,
         },
@@ -629,7 +629,7 @@ async def test_get_dataset_lineage_with_symlinks(
     datasets = [dataset for dataset in all_datasets if dataset.id in dataset_ids]
     assert datasets
 
-    # Threat all datasets from symlinks like they were passed as `point_id`
+    # Threat all datasets from symlinks like they were passed as `start_node_id`
     inputs = [input for input in all_inputs if input.dataset_id in dataset_ids]
     assert inputs
 
@@ -654,7 +654,7 @@ async def test_get_dataset_lineage_with_symlinks(
         "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
-            "point_id": initial_dataset.id,
+            "start_node_id": initial_dataset.id,
             "direction": "DOWNSTREAM",
         },
     )

--- a/tests/test_server/test_lineage/test_get_lineage_request_validators.py
+++ b/tests/test_server/test_lineage/test_get_lineage_request_validators.py
@@ -39,7 +39,7 @@ async def test_get_lineage_no_filter(test_client: AsyncClient, entity_kind: str)
                     "code": "missing",
                     "context": {},
                     "input": {"depth": 1},
-                    "location": ["query", "point_id"],
+                    "location": ["query", "start_node_id"],
                     "message": "Field required",
                 },
             ],
@@ -49,7 +49,7 @@ async def test_get_lineage_no_filter(test_client: AsyncClient, entity_kind: str)
 
 
 @pytest.mark.parametrize(
-    "entity_kind, point_id",
+    "entity_kind, start_node_id",
     [
         ("operations", generate_new_uuid()),
         ("datasets", 1),
@@ -60,7 +60,7 @@ async def test_get_lineage_no_filter(test_client: AsyncClient, entity_kind: str)
 )
 async def test_get_lineage_missing_id(
     entity_kind: str,
-    point_id: str,
+    start_node_id: str,
     test_client: AsyncClient,
 ):
     since = datetime.now()
@@ -69,7 +69,7 @@ async def test_get_lineage_missing_id(
         f"v1/{entity_kind}/lineage",
         params={
             "since": since.isoformat(),
-            "point_id": point_id,
+            "start_node_id": start_node_id,
             "direction": "DOWNSTREAM",
         },
     )
@@ -82,13 +82,13 @@ async def test_get_lineage_missing_id(
 
 
 @pytest.mark.parametrize(
-    "entity_kind, point_id",
+    "entity_kind, start_node_id",
     [("datasets", generate_new_uuid()), ("jobs", generate_new_uuid())],
     ids=["datasets", "jobs"],
 )
-async def test_get_lineage_point_id_int_type_validation(
+async def test_get_lineage_start_node_id_int_type_validation(
     entity_kind: str,
-    point_id: str,
+    start_node_id: str,
     test_client: AsyncClient,
 ):
     since = datetime.now(tz=timezone.utc)
@@ -96,7 +96,7 @@ async def test_get_lineage_point_id_int_type_validation(
         f"v1/{entity_kind}/lineage",
         params={
             "since": since.isoformat(),
-            "point_id": point_id,
+            "start_node_id": start_node_id,
             "direction": "DOWNSTREAM",
         },
     )
@@ -109,10 +109,10 @@ async def test_get_lineage_point_id_int_type_validation(
                 {
                     "code": "int_parsing",
                     "context": {},
-                    "input": str(point_id),
+                    "input": str(start_node_id),
                     "location": [
                         "query",
-                        "point_id",
+                        "start_node_id",
                     ],
                     "message": f"Input should be a valid integer, unable to parse string as an integer",
                 },
@@ -123,13 +123,13 @@ async def test_get_lineage_point_id_int_type_validation(
 
 
 @pytest.mark.parametrize(
-    "entity_kind, point_id",
+    "entity_kind, start_node_id",
     [("operations", 1), ("runs", 1)],
     ids=["operations", "runs"],
 )
-async def test_get_lineage_point_id_uuid_type_validation(
+async def test_get_lineage_start_node_id_uuid_type_validation(
     entity_kind: str,
-    point_id: int,
+    start_node_id: int,
     test_client: AsyncClient,
 ):
     since = datetime.now(tz=timezone.utc)
@@ -137,7 +137,7 @@ async def test_get_lineage_point_id_uuid_type_validation(
         f"v1/{entity_kind}/lineage",
         params={
             "since": since.isoformat(),
-            "point_id": point_id,
+            "start_node_id": start_node_id,
             "direction": "DOWNSTREAM",
         },
     )
@@ -153,7 +153,7 @@ async def test_get_lineage_point_id_uuid_type_validation(
                     "input": "1",
                     "location": [
                         "query",
-                        "point_id",
+                        "start_node_id",
                     ],
                     "message": "Value error, badly formed hexadecimal UUID string",
                 },
@@ -172,7 +172,7 @@ async def test_get_lineage_until_less_than_since(test_client: AsyncClient):
         params={
             "since": since.isoformat(),
             "until": until.isoformat(),
-            "point_id": str(generate_new_uuid()),
+            "start_node_id": str(generate_new_uuid()),
             "direction": "DOWNSTREAM",
         },
     )
@@ -215,7 +215,7 @@ async def test_get_lineage_depth_out_of_bounds(
         "v1/runs/lineage",
         params={
             "since": since.isoformat(),
-            "point_id": str(generate_new_uuid()),
+            "start_node_id": str(generate_new_uuid()),
             "direction": "DOWNSTREAM",
             "depth": depth,
         },

--- a/tests/test_server/test_lineage/test_get_lineage_request_validators.py
+++ b/tests/test_server/test_lineage/test_get_lineage_request_validators.py
@@ -24,21 +24,21 @@ async def test_get_lineage_no_filter(test_client: AsyncClient, entity_kind: str)
                 {
                     "code": "missing",
                     "context": {},
-                    "input": None,
+                    "input": {"depth": 1},
                     "location": ["query", "since"],
                     "message": "Field required",
                 },
                 {
                     "code": "missing",
                     "context": {},
-                    "input": None,
+                    "input": {"depth": 1},
                     "location": ["query", "direction"],
                     "message": "Field required",
                 },
                 {
                     "code": "missing",
                     "context": {},
-                    "input": None,
+                    "input": {"depth": 1},
                     "location": ["query", "point_id"],
                     "message": "Field required",
                 },
@@ -148,14 +148,14 @@ async def test_get_lineage_point_id_uuid_type_validation(
             "code": "invalid_request",
             "details": [
                 {
-                    "code": "uuid_parsing",
+                    "code": "value_error",
                     "context": {},
                     "input": "1",
                     "location": [
                         "query",
                         "point_id",
                     ],
-                    "message": "Input should be a valid UUID, invalid length: expected length 32 for simple format, found 1",
+                    "message": "Value error, badly formed hexadecimal UUID string",
                 },
             ],
             "message": "Invalid request",
@@ -168,7 +168,7 @@ async def test_get_lineage_until_less_than_since(test_client: AsyncClient):
     until = since - timedelta(days=1)
 
     response = await test_client.get(
-        f"v1/runs/lineage",
+        "v1/runs/lineage",
         params={
             "since": since.isoformat(),
             "until": until.isoformat(),
@@ -184,11 +184,11 @@ async def test_get_lineage_until_less_than_since(test_client: AsyncClient):
             "message": "Invalid request",
             "details": [
                 {
-                    "location": ["until"],
+                    "location": ["query", "until"],
                     "code": "value_error",
                     "message": "Value error, 'since' should be less than 'until'",
                     "context": {},
-                    "input": until.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                    "input": until.isoformat(),
                 },
             ],
         },

--- a/tests/test_server/test_lineage/test_get_lineage_request_validators.py
+++ b/tests/test_server/test_lineage/test_get_lineage_request_validators.py
@@ -9,8 +9,12 @@ from data_rentgen.db.utils.uuid import generate_new_uuid
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
 
-async def test_get_lineage_no_filter(test_client: AsyncClient):
-    response = await test_client.get("v1/lineage")
+@pytest.mark.parametrize(
+    "entity_kind",
+    ["operations", "datasets", "runs", "jobs"],
+)
+async def test_get_lineage_no_filter(test_client: AsyncClient, entity_kind: str):
+    response = await test_client.get(f"v1/{entity_kind}/lineage")
 
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     assert response.json() == {
@@ -28,7 +32,7 @@ async def test_get_lineage_no_filter(test_client: AsyncClient):
                     "code": "missing",
                     "context": {},
                     "input": None,
-                    "location": ["query", "point_kind"],
+                    "location": ["query", "direction"],
                     "message": "Field required",
                 },
                 {
@@ -38,13 +42,6 @@ async def test_get_lineage_no_filter(test_client: AsyncClient):
                     "location": ["query", "point_id"],
                     "message": "Field required",
                 },
-                {
-                    "code": "missing",
-                    "context": {},
-                    "input": None,
-                    "location": ["query", "direction"],
-                    "message": "Field required",
-                },
             ],
             "message": "Invalid request",
         },
@@ -52,27 +49,26 @@ async def test_get_lineage_no_filter(test_client: AsyncClient):
 
 
 @pytest.mark.parametrize(
-    "point_kind, point_id",
+    "entity_kind, point_id",
     [
-        ("OPERATION", generate_new_uuid()),
-        ("DATASET", 1),
-        ("RUN", generate_new_uuid()),
-        ("JOB", 1),
+        ("operations", generate_new_uuid()),
+        ("datasets", 1),
+        ("runs", generate_new_uuid()),
+        ("jobs", 1),
     ],
-    ids=["OPERATION", "DATASET", "RUN", "JOB"],
+    ids=["operations", "datasets", "runs", "jobs"],
 )
 async def test_get_lineage_missing_id(
-    point_kind: str,
+    entity_kind: str,
     point_id: str,
     test_client: AsyncClient,
 ):
     since = datetime.now()
 
     response = await test_client.get(
-        "v1/lineage",
+        f"v1/{entity_kind}/lineage",
         params={
             "since": since.isoformat(),
-            "point_kind": point_kind,
             "point_id": point_id,
             "direction": "DOWNSTREAM",
         },
@@ -86,21 +82,20 @@ async def test_get_lineage_missing_id(
 
 
 @pytest.mark.parametrize(
-    "point_kind, point_id",
-    [("DATASET", generate_new_uuid()), ("JOB", generate_new_uuid())],
-    ids=["DATASET", "JOB"],
+    "entity_kind, point_id",
+    [("datasets", generate_new_uuid()), ("jobs", generate_new_uuid())],
+    ids=["datasets", "jobs"],
 )
 async def test_get_lineage_point_id_int_type_validation(
-    point_kind: str,
+    entity_kind: str,
     point_id: str,
     test_client: AsyncClient,
 ):
     since = datetime.now(tz=timezone.utc)
     response = await test_client.get(
-        "v1/lineage",
+        f"v1/{entity_kind}/lineage",
         params={
             "since": since.isoformat(),
-            "point_kind": point_kind,
             "point_id": point_id,
             "direction": "DOWNSTREAM",
         },
@@ -112,18 +107,14 @@ async def test_get_lineage_point_id_int_type_validation(
             "code": "invalid_request",
             "details": [
                 {
-                    "code": "value_error",
+                    "code": "int_parsing",
                     "context": {},
-                    "input": {
-                        "depth": 1,
-                        "direction": "DOWNSTREAM",
-                        "point_id": f"{point_id}",
-                        "point_kind": f"{point_kind}",
-                        "since": since.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                        "until": None,
-                    },
-                    "location": [],
-                    "message": f"Value error, 'point_id' should be int for '{point_kind}' kind",
+                    "input": str(point_id),
+                    "location": [
+                        "query",
+                        "point_id",
+                    ],
+                    "message": f"Input should be a valid integer, unable to parse string as an integer",
                 },
             ],
             "message": "Invalid request",
@@ -132,21 +123,20 @@ async def test_get_lineage_point_id_int_type_validation(
 
 
 @pytest.mark.parametrize(
-    "point_kind, point_id",
-    [("OPERATION", 1), ("RUN", 1)],
-    ids=["OPERATION", "RUN"],
+    "entity_kind, point_id",
+    [("operations", 1), ("runs", 1)],
+    ids=["operations", "runs"],
 )
 async def test_get_lineage_point_id_uuid_type_validation(
-    point_kind: str,
+    entity_kind: str,
     point_id: int,
     test_client: AsyncClient,
 ):
     since = datetime.now(tz=timezone.utc)
     response = await test_client.get(
-        "v1/lineage",
+        f"v1/{entity_kind}/lineage",
         params={
             "since": since.isoformat(),
-            "point_kind": point_kind,
             "point_id": point_id,
             "direction": "DOWNSTREAM",
         },
@@ -158,18 +148,14 @@ async def test_get_lineage_point_id_uuid_type_validation(
             "code": "invalid_request",
             "details": [
                 {
-                    "code": "value_error",
+                    "code": "uuid_parsing",
                     "context": {},
-                    "input": {
-                        "depth": 1,
-                        "direction": "DOWNSTREAM",
-                        "point_id": point_id,
-                        "point_kind": f"{point_kind}",
-                        "since": since.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                        "until": None,
-                    },
-                    "location": [],
-                    "message": f"Value error, 'point_id' should be UUIDv7 for '{point_kind}' kind",
+                    "input": "1",
+                    "location": [
+                        "query",
+                        "point_id",
+                    ],
+                    "message": "Input should be a valid UUID, invalid length: expected length 32 for simple format, found 1",
                 },
             ],
             "message": "Invalid request",
@@ -182,11 +168,10 @@ async def test_get_lineage_until_less_than_since(test_client: AsyncClient):
     until = since - timedelta(days=1)
 
     response = await test_client.get(
-        "v1/lineage",
+        f"v1/runs/lineage",
         params={
             "since": since.isoformat(),
             "until": until.isoformat(),
-            "point_kind": "RUN",
             "point_id": str(generate_new_uuid()),
             "direction": "DOWNSTREAM",
         },
@@ -227,10 +212,9 @@ async def test_get_lineage_depth_out_of_bounds(
 ):
     since = datetime.now(tz=timezone.utc)
     response = await test_client.get(
-        "v1/lineage",
+        "v1/runs/lineage",
         params={
             "since": since.isoformat(),
-            "point_kind": "RUN",
             "point_id": str(generate_new_uuid()),
             "direction": "DOWNSTREAM",
             "depth": depth,

--- a/tests/test_server/test_lineage/test_job_lineage.py
+++ b/tests/test_server/test_lineage/test_job_lineage.py
@@ -28,7 +28,7 @@ async def test_get_job_lineage_unknown_id(
     direction: str,
 ):
     response = await test_client.get(
-        "v1/lineage",
+        "v1/jobs/lineage",
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "JOB",
@@ -52,7 +52,7 @@ async def test_get_job_lineage_no_runs(
     direction: str,
 ):
     response = await test_client.get(
-        "v1/lineage",
+        "v1/jobs/lineage",
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "JOB",
@@ -91,7 +91,7 @@ async def test_get_job_lineage_no_operations(
     direction: str,
 ):
     response = await test_client.get(
-        "v1/lineage",
+        "v1/jobs/lineage",
         params={
             "since": run.created_at.isoformat(),
             "point_kind": "JOB",
@@ -133,7 +133,7 @@ async def test_get_job_lineage_no_inputs_outputs(
     direction: str,
 ):
     response = await test_client.get(
-        "v1/lineage",
+        "v1/jobs/lineage",
         params={
             "since": run.created_at.isoformat(),
             "point_kind": "JOB",

--- a/tests/test_server/test_lineage/test_job_lineage.py
+++ b/tests/test_server/test_lineage/test_job_lineage.py
@@ -177,10 +177,9 @@ async def test_get_job_lineage(
     datasets = await enrich_datasets(datasets, async_session)
 
     response = await test_client.get(
-        "v1/lineage",
+        "v1/jobs/lineage",
         params={
             "since": runs[0].created_at.isoformat(),
-            "point_kind": "JOB",
             "point_id": job.id,
             "direction": "DOWNSTREAM",
         },
@@ -330,11 +329,10 @@ async def test_get_job_lineage_with_direction_and_until(
     datasets = await enrich_datasets(datasets, async_session)
 
     response = await test_client.get(
-        "v1/lineage",
+        "v1/jobs/lineage",
         params={
             "since": since.isoformat(),
             "until": until.isoformat(),
-            "point_kind": "JOB",
             "point_id": job.id,
             "direction": "UPSTREAM",
         },
@@ -493,10 +491,9 @@ async def test_get_job_lineage_with_depth(
 
     since = min(run.created_at for run in runs)
     response = await test_client.get(
-        "v1/lineage",
+        "v1/jobs/lineage",
         params={
             "since": since.isoformat(),
-            "point_kind": "JOB",
             "point_id": some_job.id,
             "direction": "DOWNSTREAM",
             "depth": 3,
@@ -630,10 +627,9 @@ async def test_get_job_lineage_with_depth_ignore_cycles(
 
     since = min(run.created_at for run in runs)
     response = await test_client.get(
-        "v1/lineage",
+        "v1/jobs/lineage",
         params={
             "since": since.isoformat(),
-            "point_kind": "JOB",
             "point_id": job.id,
             "direction": "DOWNSTREAM",
             "depth": 3,
@@ -792,10 +788,9 @@ async def test_get_job_lineage_with_symlinks(
 
     since = min(run.created_at for run in runs)
     response = await test_client.get(
-        "v1/lineage",
+        "v1/jobs/lineage",
         params={
             "since": since.isoformat(),
-            "point_kind": "JOB",
             "point_id": job.id,
             "direction": "DOWNSTREAM",
         },

--- a/tests/test_server/test_lineage/test_job_lineage.py
+++ b/tests/test_server/test_lineage/test_job_lineage.py
@@ -32,7 +32,7 @@ async def test_get_job_lineage_unknown_id(
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "JOB",
-            "point_id": new_job.id,
+            "start_node_id": new_job.id,
             "direction": direction,
         },
     )
@@ -56,7 +56,7 @@ async def test_get_job_lineage_no_runs(
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "JOB",
-            "point_id": job.id,
+            "start_node_id": job.id,
             "direction": direction,
         },
     )
@@ -95,7 +95,7 @@ async def test_get_job_lineage_no_operations(
         params={
             "since": run.created_at.isoformat(),
             "point_kind": "JOB",
-            "point_id": job.id,
+            "start_node_id": job.id,
             "direction": direction,
         },
     )
@@ -137,7 +137,7 @@ async def test_get_job_lineage_no_inputs_outputs(
         params={
             "since": run.created_at.isoformat(),
             "point_kind": "JOB",
-            "point_id": job.id,
+            "start_node_id": job.id,
             "direction": direction,
         },
     )
@@ -180,7 +180,7 @@ async def test_get_job_lineage(
         "v1/jobs/lineage",
         params={
             "since": runs[0].created_at.isoformat(),
-            "point_id": job.id,
+            "start_node_id": job.id,
             "direction": "DOWNSTREAM",
         },
     )
@@ -333,7 +333,7 @@ async def test_get_job_lineage_with_direction_and_until(
         params={
             "since": since.isoformat(),
             "until": until.isoformat(),
-            "point_id": job.id,
+            "start_node_id": job.id,
             "direction": "UPSTREAM",
         },
     )
@@ -494,7 +494,7 @@ async def test_get_job_lineage_with_depth(
         "v1/jobs/lineage",
         params={
             "since": since.isoformat(),
-            "point_id": some_job.id,
+            "start_node_id": some_job.id,
             "direction": "DOWNSTREAM",
             "depth": 3,
         },
@@ -630,7 +630,7 @@ async def test_get_job_lineage_with_depth_ignore_cycles(
         "v1/jobs/lineage",
         params={
             "since": since.isoformat(),
-            "point_id": job.id,
+            "start_node_id": job.id,
             "direction": "DOWNSTREAM",
             "depth": 3,
         },
@@ -791,7 +791,7 @@ async def test_get_job_lineage_with_symlinks(
         "v1/jobs/lineage",
         params={
             "since": since.isoformat(),
-            "point_id": job.id,
+            "start_node_id": job.id,
             "direction": "DOWNSTREAM",
         },
     )

--- a/tests/test_server/test_lineage/test_operation_lineage.py
+++ b/tests/test_server/test_lineage/test_operation_lineage.py
@@ -137,10 +137,9 @@ async def test_get_operation_lineage(
     datasets = await enrich_datasets(datasets, async_session)
 
     response = await test_client.get(
-        "v1/lineage",
+        "v1/operations/lineage",
         params={
             "since": runs[0].created_at.isoformat(),
-            "point_kind": "OPERATION",
             "point_id": str(operation.id),
             "direction": "DOWNSTREAM",
         },
@@ -267,11 +266,10 @@ async def test_get_operation_lineage_with_direction_and_until(
     datasets = await enrich_datasets(datasets, async_session)
 
     response = await test_client.get(
-        "v1/lineage",
+        "v1/operations/lineage",
         params={
             "since": since.isoformat(),
             "until": until.isoformat(),
-            "point_kind": "OPERATION",
             "point_id": str(operation.id),
             "direction": "UPSTREAM",
         },
@@ -415,10 +413,9 @@ async def test_get_operation_lineage_with_depth(
 
     since = min(run.created_at for run in runs)
     response = await test_client.get(
-        "v1/lineage",
+        "v1/operations/lineage",
         params={
             "since": since.isoformat(),
-            "point_kind": "OPERATION",
             "point_id": str(some_operation.id),
             "direction": "DOWNSTREAM",
             "depth": 3,
@@ -542,10 +539,9 @@ async def test_get_operation_lineage_with_depth_ignore_cycles(
     datasets = await enrich_datasets(datasets, async_session)
 
     response = await test_client.get(
-        "v1/lineage",
+        "v1/operations/lineage",
         params={
             "since": run.created_at.isoformat(),
-            "point_kind": "OPERATION",
             "point_id": str(operation.id),
             "direction": "DOWNSTREAM",
             "depth": 3,
@@ -688,10 +684,9 @@ async def test_get_operation_lineage_with_symlinks(
     datasets = await enrich_datasets(datasets, async_session)
 
     response = await test_client.get(
-        "v1/lineage",
+        "v1/operations/lineage",
         params={
             "since": run.created_at.isoformat(),
-            "point_kind": "OPERATION",
             "point_id": str(operation.id),
             "direction": "DOWNSTREAM",
         },

--- a/tests/test_server/test_lineage/test_operation_lineage.py
+++ b/tests/test_server/test_lineage/test_operation_lineage.py
@@ -32,7 +32,7 @@ async def test_get_operation_lineage_unknown_id(
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "OPERATION",
-            "point_id": str(new_operation.id),
+            "start_node_id": str(new_operation.id),
             "direction": direction,
         },
     )
@@ -58,7 +58,7 @@ async def test_get_operation_lineage_no_inputs_outputs(
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "OPERATION",
-            "point_id": str(operation.id),
+            "start_node_id": str(operation.id),
             "direction": direction,
         },
     )
@@ -140,7 +140,7 @@ async def test_get_operation_lineage(
         "v1/operations/lineage",
         params={
             "since": runs[0].created_at.isoformat(),
-            "point_id": str(operation.id),
+            "start_node_id": str(operation.id),
             "direction": "DOWNSTREAM",
         },
     )
@@ -270,7 +270,7 @@ async def test_get_operation_lineage_with_direction_and_until(
         params={
             "since": since.isoformat(),
             "until": until.isoformat(),
-            "point_id": str(operation.id),
+            "start_node_id": str(operation.id),
             "direction": "UPSTREAM",
         },
     )
@@ -416,7 +416,7 @@ async def test_get_operation_lineage_with_depth(
         "v1/operations/lineage",
         params={
             "since": since.isoformat(),
-            "point_id": str(some_operation.id),
+            "start_node_id": str(some_operation.id),
             "direction": "DOWNSTREAM",
             "depth": 3,
         },
@@ -542,7 +542,7 @@ async def test_get_operation_lineage_with_depth_ignore_cycles(
         "v1/operations/lineage",
         params={
             "since": run.created_at.isoformat(),
-            "point_id": str(operation.id),
+            "start_node_id": str(operation.id),
             "direction": "DOWNSTREAM",
             "depth": 3,
         },
@@ -687,7 +687,7 @@ async def test_get_operation_lineage_with_symlinks(
         "v1/operations/lineage",
         params={
             "since": run.created_at.isoformat(),
-            "point_id": str(operation.id),
+            "start_node_id": str(operation.id),
             "direction": "DOWNSTREAM",
         },
     )

--- a/tests/test_server/test_lineage/test_operation_lineage.py
+++ b/tests/test_server/test_lineage/test_operation_lineage.py
@@ -28,7 +28,7 @@ async def test_get_operation_lineage_unknown_id(
     direction: str,
 ):
     response = await test_client.get(
-        "v1/lineage",
+        "v1/operations/lineage",
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "OPERATION",
@@ -54,7 +54,7 @@ async def test_get_operation_lineage_no_inputs_outputs(
     direction: str,
 ):
     response = await test_client.get(
-        "v1/lineage",
+        "v1/operations/lineage",
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "OPERATION",

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -32,7 +32,7 @@ async def test_get_run_lineage_unknown_id(
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "RUN",
-            "point_id": str(new_run.id),
+            "start_node_id": str(new_run.id),
             "direction": direction,
         },
     )
@@ -57,7 +57,7 @@ async def test_get_run_lineage_no_operations(
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "RUN",
-            "point_id": str(run.id),
+            "start_node_id": str(run.id),
             "direction": direction,
         },
     )
@@ -120,7 +120,7 @@ async def test_get_run_lineage_no_inputs_outputs(
         params={
             "since": run.created_at.isoformat(),
             "point_kind": "RUN",
-            "point_id": str(run.id),
+            "start_node_id": str(run.id),
             "direction": direction,
         },
     )
@@ -186,7 +186,7 @@ async def test_get_run_lineage(
         "v1/runs/lineage",
         params={
             "since": run.created_at.isoformat(),
-            "point_id": str(run.id),
+            "start_node_id": str(run.id),
             "direction": "DOWNSTREAM",
         },
     )
@@ -329,7 +329,7 @@ async def test_get_run_lineage_with_direction_and_until(
         params={
             "since": since.isoformat(),
             "until": until.isoformat(),
-            "point_id": str(run.id),
+            "start_node_id": str(run.id),
             "direction": "UPSTREAM",
         },
     )
@@ -481,7 +481,7 @@ async def test_get_run_lineage_with_depth(
         "v1/runs/lineage",
         params={
             "since": some_run.created_at.isoformat(),
-            "point_id": str(some_run.id),
+            "start_node_id": str(some_run.id),
             "direction": "DOWNSTREAM",
             "depth": 3,
         },
@@ -616,7 +616,7 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
         "v1/runs/lineage",
         params={
             "since": run.created_at.isoformat(),
-            "point_id": str(run.id),
+            "start_node_id": str(run.id),
             "direction": "DOWNSTREAM",
             "depth": 3,
         },
@@ -770,7 +770,7 @@ async def test_get_run_lineage_with_symlinks(
         "v1/runs/lineage",
         params={
             "since": run.created_at.isoformat(),
-            "point_id": str(run.id),
+            "start_node_id": str(run.id),
             "direction": "DOWNSTREAM",
         },
     )

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -183,10 +183,9 @@ async def test_get_run_lineage(
     datasets = await enrich_datasets(datasets, async_session)
 
     response = await test_client.get(
-        "v1/lineage",
+        "v1/runs/lineage",
         params={
             "since": run.created_at.isoformat(),
-            "point_kind": "RUN",
             "point_id": str(run.id),
             "direction": "DOWNSTREAM",
         },
@@ -326,11 +325,10 @@ async def test_get_run_lineage_with_direction_and_until(
     datasets = await enrich_datasets(datasets, async_session)
 
     response = await test_client.get(
-        "v1/lineage",
+        "v1/runs/lineage",
         params={
             "since": since.isoformat(),
             "until": until.isoformat(),
-            "point_kind": "RUN",
             "point_id": str(run.id),
             "direction": "UPSTREAM",
         },
@@ -480,10 +478,9 @@ async def test_get_run_lineage_with_depth(
     datasets = await enrich_datasets(datasets, async_session)
 
     response = await test_client.get(
-        "v1/lineage",
+        "v1/runs/lineage",
         params={
             "since": some_run.created_at.isoformat(),
-            "point_kind": "RUN",
             "point_id": str(some_run.id),
             "direction": "DOWNSTREAM",
             "depth": 3,
@@ -616,10 +613,9 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
     datasets = await enrich_datasets(first_level_datasets, async_session)
 
     response = await test_client.get(
-        "v1/lineage",
+        "v1/runs/lineage",
         params={
             "since": run.created_at.isoformat(),
-            "point_kind": "RUN",
             "point_id": str(run.id),
             "direction": "DOWNSTREAM",
             "depth": 3,
@@ -771,10 +767,9 @@ async def test_get_run_lineage_with_symlinks(
     datasets = await enrich_datasets(datasets, async_session)
 
     response = await test_client.get(
-        "v1/lineage",
+        "v1/runs/lineage",
         params={
             "since": run.created_at.isoformat(),
-            "point_kind": "RUN",
             "point_id": str(run.id),
             "direction": "DOWNSTREAM",
         },

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -28,7 +28,7 @@ async def test_get_run_lineage_unknown_id(
     direction: str,
 ):
     response = await test_client.get(
-        "v1/lineage",
+        "v1/runs/lineage",
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "RUN",
@@ -53,7 +53,7 @@ async def test_get_run_lineage_no_operations(
     direction: str,
 ):
     response = await test_client.get(
-        "v1/lineage",
+        "v1/runs/lineage",
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "point_kind": "RUN",
@@ -116,7 +116,7 @@ async def test_get_run_lineage_no_inputs_outputs(
     direction: str,
 ):
     response = await test_client.get(
-        "v1/lineage",
+        "v1/runs/lineage",
         params={
             "since": run.created_at.isoformat(),
             "point_kind": "RUN",


### PR DESCRIPTION
## Change Summary

Split `/v1/lineage` into four different endpoints, for each entity (dataset, operation, run, job)

Remove query class from pydantic request schemas for lineage (https://github.com/fastapi/fastapi/releases/tag/0.115.0).

## Related issue number

[DOP-20059]

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
