### PR TITLE
[DOP-20137] Fix missing job.type in API responses

### DIFF
--- a/data_rentgen/server/schemas/v1/job.py
+++ b/data_rentgen/server/schemas/v1/job.py
@@ -16,6 +16,7 @@ class JobResponseV1(BaseModel):
     id: int = Field(description="Job id")
     location: LocationResponseV1 = Field(description="Corresponding Location")
     name: str = Field(description="Job name")
+    type: str = Field(description="Job type")
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tests/test_server/test_get_jobs.py
+++ b/tests/test_server/test_get_jobs.py
@@ -67,6 +67,7 @@ async def test_get_jobs_by_one_id(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -107,6 +108,7 @@ async def test_get_jobs_by_multiple_ids(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -143,6 +145,7 @@ async def test_get_jobs_no_filters(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,

--- a/tests/test_server/test_lineage/test_dataset_lineage.py
+++ b/tests/test_server/test_lineage/test_dataset_lineage.py
@@ -129,6 +129,7 @@ async def test_get_dataset_lineage(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -248,6 +249,7 @@ async def test_get_dataset_lineage_with_direction_and_until(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -416,6 +418,7 @@ async def test_get_dataset_lineage_with_depth(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -542,6 +545,7 @@ async def test_get_dataset_lineage_with_depth_ignore_cycles(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -700,6 +704,7 @@ async def test_get_dataset_lineage_with_symlinks(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,

--- a/tests/test_server/test_lineage/test_job_lineage.py
+++ b/tests/test_server/test_lineage/test_job_lineage.py
@@ -70,6 +70,7 @@ async def test_get_job_lineage_no_runs(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -110,6 +111,7 @@ async def test_get_job_lineage_no_operations(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -151,6 +153,7 @@ async def test_get_job_lineage_no_inputs_outputs(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -215,6 +218,7 @@ async def test_get_job_lineage(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -368,6 +372,7 @@ async def test_get_job_lineage_with_direction_and_until(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -539,6 +544,7 @@ async def test_get_job_lineage_with_depth(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -675,6 +681,7 @@ async def test_get_job_lineage_with_depth_ignore_cycles(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -835,6 +842,7 @@ async def test_get_job_lineage_with_symlinks(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,

--- a/tests/test_server/test_lineage/test_operation_lineage.py
+++ b/tests/test_server/test_lineage/test_operation_lineage.py
@@ -85,6 +85,7 @@ async def test_get_operation_lineage_no_inputs_outputs(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -176,6 +177,7 @@ async def test_get_operation_lineage(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -303,6 +305,7 @@ async def test_get_operation_lineage_with_direction_and_until(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -463,6 +466,7 @@ async def test_get_operation_lineage_with_depth(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -585,6 +589,7 @@ async def test_get_operation_lineage_with_depth_ignore_cycles(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -729,6 +734,7 @@ async def test_get_operation_lineage_with_symlinks(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -79,6 +79,7 @@ async def test_get_run_lineage_no_operations(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -142,6 +143,7 @@ async def test_get_run_lineage_no_inputs_outputs(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -212,6 +214,7 @@ async def test_get_run_lineage(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -309,6 +312,7 @@ async def test_get_run_lineage_with_operation_granularity(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -443,6 +447,7 @@ async def test_get_run_lineage_with_direction_and_until(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -571,6 +576,7 @@ async def test_get_run_lineage_with_direction_and_until_and_operation_granularit
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "type": job.location.type,
                     "name": job.location.name,
@@ -723,6 +729,7 @@ async def test_get_run_lineage_with_depth(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -874,6 +881,7 @@ async def test_get_run_lineage_with_depth_and_operation_granularity(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -999,6 +1007,7 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -1117,6 +1126,7 @@ async def test_get_run_lineage_with_depth_ignore_cycles_with_operation_granulari
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -1261,6 +1271,7 @@ async def test_get_run_lineage_with_symlinks(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -1400,6 +1411,7 @@ async def test_get_run_lineage_with_symlinks_and_operation_granularity(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,

--- a/tests/test_server/test_search/test_job.py
+++ b/tests/test_server/test_search/test_job.py
@@ -51,6 +51,7 @@ async def test_job_search_in_addres_url(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -85,6 +86,7 @@ async def test_job_search_in_location_name(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -133,6 +135,7 @@ async def test_job_search_in_job_name(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,
@@ -177,6 +180,7 @@ async def test_job_search_in_location_name_and_address_url(
                 "kind": "JOB",
                 "id": job.id,
                 "name": job.name,
+                "type": job.type,
                 "location": {
                     "name": job.location.name,
                     "type": job.location.type,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

There is a field `job.type` in database table, but it was missing in REST API response schema. Fixed.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
