### PR TITLE
[DOP-20055] Merge /entries with /entries/search

### DIFF
--- a/data_rentgen/db/repositories/dataset.py
+++ b/data_rentgen/db/repositories/dataset.py
@@ -3,7 +3,7 @@
 from string import punctuation
 from typing import Sequence
 
-from sqlalchemy import any_, desc, func, select, union
+from sqlalchemy import CompoundSelect, Select, any_, desc, func, select, union
 from sqlalchemy.orm import selectinload
 
 from data_rentgen.db.models import Address, Dataset, Location
@@ -27,11 +27,63 @@ class DatasetRepository(Repository[Dataset]):
             return await self._create(dataset, location_id)
         return await self._update(result, dataset)
 
-    async def paginate(self, page: int, page_size: int, dataset_ids: Sequence[int]) -> PaginationDTO[Dataset]:
-        query = select(Dataset).options(selectinload(Dataset.location).selectinload(Location.addresses))
+    async def paginate(
+        self,
+        page: int,
+        page_size: int,
+        dataset_ids: Sequence[int],
+        search_query: str | None,
+    ) -> PaginationDTO[Dataset]:
+        where = []
         if dataset_ids:
-            query = query.where(Dataset.id == any_(dataset_ids))  # type: ignore[arg-type]
-        return await self._paginate_by_query(order_by=[Dataset.name], page=page, page_size=page_size, query=query)
+            where.append(Dataset.id == any_(dataset_ids))  # type: ignore[arg-type]
+
+        query: Select | CompoundSelect
+        if search_query:
+            # For more accurate full-text search, we create a tsquery by combining the `search_query` "as is" with
+            # a modified version of it using the '||' operator.
+            # The "as is" version is used so that an exact match with the query has the highest rank.
+            # The modified version is needed because, in some cases, PostgreSQL tokenizes words joined by punctuation marks
+            # (e.g., `database.schema.table`) as a single word. By replacing punctuation with spaces using `translate`,
+            # we split such strings into separate words, allowing us to search by parts of the name.
+            ts_query = select(
+                func.plainto_tsquery("english", search_query).op("||")(
+                    func.plainto_tsquery("english", search_query.translate(ts_query_punctuation_map)),
+                ),
+            ).scalar_subquery()
+
+            dataset_stmt = (
+                select(Dataset, func.ts_rank(Dataset.search_vector, ts_query).label("search_rank"))
+                .join(Location, Dataset.location_id == Location.id)
+                .join(Address, Location.id == Address.location_id)
+                .where(Dataset.search_vector.op("@@")(ts_query), *where)
+            )
+            location_stmt = (
+                select(Dataset, func.ts_rank(Location.search_vector, ts_query).label("search_rank"))
+                .join(Address, Location.id == Address.location_id)
+                .join(Dataset, Location.id == Dataset.location_id)
+                .where(Location.search_vector.op("@@")(ts_query), *where)
+            )
+            address_stmt = (
+                select(Dataset, func.ts_rank(Address.search_vector, ts_query).label("search_rank"))
+                .join(Location, Address.location_id == Location.id)
+                .join(Dataset, Location.id == Dataset.location_id)
+                .where(Address.search_vector.op("@@")(ts_query), *where)
+            )
+            query = union(dataset_stmt, location_stmt, address_stmt)
+            order_by = [desc("search_rank"), Dataset.name]
+        else:
+            query = select(Dataset).where(*where)
+            order_by = [Dataset.name]
+
+        options = [selectinload(Dataset.location).selectinload(Location.addresses)]
+        return await self._paginate_by_query(
+            query=query,
+            order_by=order_by,
+            options=options,
+            page=page,
+            page_size=page_size,
+        )
 
     async def list_by_ids(self, dataset_ids: Sequence[int]) -> list[Dataset]:
         if not dataset_ids:
@@ -43,47 +95,6 @@ class DatasetRepository(Repository[Dataset]):
         )
         result = await self._session.scalars(query)
         return list(result.all())
-
-    async def search(self, search_query: str, page: int, page_size: int) -> PaginationDTO[Dataset]:
-        # For more accurate full-text search, we create a tsquery by combining the `search_query` "as is" with
-        # a modified version of it using the '||' operator.
-        # The "as is" version is used so that an exact match with the query has the highest rank.
-        # The modified version is needed because, in some cases, PostgreSQL tokenizes words joined by punctuation marks
-        # (e.g., `database.schema.table`) as a single word. By replacing punctuation with spaces using `translate`,
-        # we split such strings into separate words, allowing us to search by parts of the name.
-
-        ts_query = select(
-            func.plainto_tsquery("english", search_query).op("||")(
-                func.plainto_tsquery("english", search_query.translate(ts_query_punctuation_map)),
-            ),
-        ).scalar_subquery()
-        base_stmt = select(Dataset.id)
-        dataset_stmt = (
-            base_stmt.add_columns((func.ts_rank(Dataset.search_vector, ts_query)).label("search_rank"))
-            .join(Location, Dataset.location_id == Location.id)
-            .join(Address, Location.id == Address.location_id)
-            .where(Dataset.search_vector.op("@@")(ts_query))
-        )
-        location_stmt = (
-            base_stmt.add_columns((func.ts_rank(Location.search_vector, ts_query)).label("search_rank"))
-            .join(Address, Location.id == Address.location_id)
-            .join(Dataset, Location.id == Dataset.location_id)
-            .where(Location.search_vector.op("@@")(ts_query))
-        )
-        address_stmt = (
-            base_stmt.add_columns((func.ts_rank(Address.search_vector, ts_query)).label("search_rank"))
-            .join(Location, Address.location_id == Location.id)
-            .join(Dataset, Location.id == Dataset.location_id)
-            .where(Address.search_vector.op("@@")(ts_query))
-        )
-        union_query = union(dataset_stmt, location_stmt, address_stmt).order_by(desc("search_rank"))
-
-        results = await self._session.execute(
-            union_query.limit(page_size).offset((page - 1) * page_size),
-        )
-        results = results.all()  # type: ignore[assignment]
-        dataset_ids = [result.id for result in results]
-        return await self.paginate(page=page, page_size=page_size, dataset_ids=dataset_ids)
 
     async def _get(self, location_id: int, name: str) -> Dataset | None:
         statement = select(Dataset).where(Dataset.location_id == location_id, Dataset.name == name)

--- a/data_rentgen/db/repositories/input.py
+++ b/data_rentgen/db/repositories/input.py
@@ -86,7 +86,7 @@ class InputRepository(Repository[Input]):
             return []
 
         min_run_created_at = extract_timestamp_from_uuid(min(run_ids))
-        min_created_at = min(min_run_created_at, since.astimezone(timezone.utc))
+        min_created_at = max(min_run_created_at, since.astimezone(timezone.utc))
 
         query = self._get_select(granularity).where(
             Input.created_at >= min_created_at,

--- a/data_rentgen/db/repositories/job.py
+++ b/data_rentgen/db/repositories/job.py
@@ -3,7 +3,7 @@
 from string import punctuation
 from typing import Sequence
 
-from sqlalchemy import any_, desc, func, select, union
+from sqlalchemy import CompoundSelect, Select, any_, desc, func, select, union
 from sqlalchemy.orm import selectinload
 
 from data_rentgen.db.models import Address, Job, JobType, Location
@@ -14,11 +14,64 @@ ts_query_punctuation_map = str.maketrans(punctuation, " " * len(punctuation))
 
 
 class JobRepository(Repository[Job]):
-    async def paginate(self, page: int, page_size: int, job_ids: Sequence[int]) -> PaginationDTO[Job]:
-        query = select(Job).options(selectinload(Job.location).selectinload(Location.addresses))
+    async def paginate(
+        self,
+        page: int,
+        page_size: int,
+        job_ids: Sequence[int],
+        search_query: str | None,
+    ) -> PaginationDTO[Job]:
+        where = []
         if job_ids:
-            query = query.where(Job.id == any_(job_ids))  # type: ignore[arg-type]
-        return await self._paginate_by_query(order_by=[Job.name], page=page, page_size=page_size, query=query)
+            where.append(Job.id == any_(job_ids))  # type: ignore[arg-type]
+
+        query: Select | CompoundSelect
+        if search_query:
+            # For more accurate full-text search, we create a tsquery by combining the `search_query` "as is" with
+            # a modified version of it using the '||' operator.
+            # The "as is" version is used so that an exact match with the query has the highest rank.
+            # The modified version is needed because, in some cases, PostgreSQL tokenizes words joined by punctuation marks
+            # (e.g., `database.schema.table`) as a single word. By replacing punctuation with spaces using `translate`,
+            # we split such strings into separate words, allowing us to search by parts of the name.
+            ts_query = select(
+                func.plainto_tsquery("english", search_query).op("||")(
+                    func.plainto_tsquery("english", search_query.translate(ts_query_punctuation_map)),
+                ),
+            ).scalar_subquery()
+
+            job_stmt = (
+                select(Job, func.ts_rank(Job.search_vector, ts_query).label("search_rank"))
+                .join(Location, Job.location_id == Location.id)
+                .join(Address, Location.id == Address.location_id)
+                .where(Job.search_vector.op("@@")(ts_query), *where)
+            )
+            location_stmt = (
+                select(Job, func.ts_rank(Location.search_vector, ts_query).label("search_rank"))
+                .join(Address, Location.id == Address.location_id)
+                .join(Job, Location.id == Job.location_id)
+                .where(Location.search_vector.op("@@")(ts_query), *where)
+            )
+            address_stmt = (
+                select(Job, func.ts_rank(Address.search_vector, ts_query).label("search_rank"))
+                .join(Location, Address.location_id == Location.id)
+                .join(Job, Location.id == Job.location_id)
+                .where(Address.search_vector.op("@@")(ts_query), *where)
+            )
+
+            query = union(job_stmt, location_stmt, address_stmt)
+            order_by = [desc("search_rank"), Job.name]
+        else:
+            query = select(Job).where(*where)
+            order_by = [Job.name]
+
+        options = [selectinload(Job.location).selectinload(Location.addresses)]
+        return await self._paginate_by_query(
+            query=query,
+            order_by=order_by,
+            options=options,
+            page=page,
+            page_size=page_size,
+        )
 
     async def create_or_update(self, job: JobDTO, location_id: int) -> Job:
         result = await self._get(location_id, job.name)
@@ -42,47 +95,6 @@ class JobRepository(Repository[Job]):
         )
         result = await self._session.scalars(query)
         return list(result.all())
-
-    async def search(self, search_query: str, page: int, page_size: int) -> PaginationDTO[Job]:
-        # For more accurate full-text search, we create a tsquery by combining the `search_query` "as is" with
-        # a modified version of it using the '||' operator.
-        # The "as is" version is used so that an exact match with the query has the highest rank.
-        # The modified version is needed because, in some cases, PostgreSQL tokenizes words joined by punctuation marks
-        # (e.g., `database.schema.table`) as a single word. By replacing punctuation with spaces using `translate`,
-        # we split such strings into separate words, allowing us to search by parts of the name.
-
-        ts_query = select(
-            func.plainto_tsquery("english", search_query).op("||")(
-                func.plainto_tsquery("english", search_query.translate(ts_query_punctuation_map)),
-            ),
-        ).scalar_subquery()
-        base_stmt = select(Job.id)
-        job_stmt = (
-            base_stmt.add_columns((func.ts_rank(Job.search_vector, ts_query)).label("search_rank"))
-            .join(Location, Job.location_id == Location.id)
-            .join(Address, Location.id == Address.location_id)
-            .where(Job.search_vector.op("@@")(ts_query))
-        )
-        location_stmt = (
-            base_stmt.add_columns((func.ts_rank(Location.search_vector, ts_query)).label("search_rank"))
-            .join(Address, Location.id == Address.location_id)
-            .join(Job, Location.id == Job.location_id)
-            .where(Location.search_vector.op("@@")(ts_query))
-        )
-        address_stmt = (
-            base_stmt.add_columns((func.ts_rank(Address.search_vector, ts_query)).label("search_rank"))
-            .join(Location, Address.location_id == Location.id)
-            .join(Job, Location.id == Job.location_id)
-            .where(Address.search_vector.op("@@")(ts_query))
-        )
-        union_query = union(job_stmt, location_stmt, address_stmt).order_by(desc("search_rank"))
-
-        results = await self._session.execute(
-            union_query.limit(page_size).offset((page - 1) * page_size),
-        )
-        results = results.all()  # type: ignore[assignment]
-        job_ids = [result.id for result in results]
-        return await self.paginate(page=page, page_size=page_size, job_ids=job_ids)
 
     async def _get(self, location_id: int, name: str) -> Job | None:
         statement = select(Job).where(Job.location_id == location_id, Job.name == name)

--- a/data_rentgen/db/repositories/output.py
+++ b/data_rentgen/db/repositories/output.py
@@ -86,7 +86,7 @@ class OutputRepository(Repository[Output]):
             return []
 
         min_run_created_at = extract_timestamp_from_uuid(min(run_ids))
-        min_created_at = min(min_run_created_at, since.astimezone(timezone.utc))
+        min_created_at = max(min_run_created_at, since.astimezone(timezone.utc))
 
         query = self._get_select(granularity).where(
             Output.created_at >= min_created_at,

--- a/data_rentgen/server/api/v1/router/dataset.py
+++ b/data_rentgen/server/api/v1/router/dataset.py
@@ -12,7 +12,6 @@ from data_rentgen.server.schemas.v1 import (
     DatasetResponseV1,
     LineageResponseV1,
     PageResponseV1,
-    SearchPaginateQueryV1,
 )
 from data_rentgen.server.services import LineageService
 from data_rentgen.server.utils.lineage_response import build_lineage_response
@@ -23,42 +22,30 @@ router = APIRouter(prefix="/datasets", tags=["Datasets"], responses=get_error_re
 
 @router.get("", summary="Paginated list of Datasets")
 async def paginate_datasets(
-    pagination_args: Annotated[DatasetPaginateQueryV1, Depends()],
+    query_args: Annotated[DatasetPaginateQueryV1, Depends()],
     unit_of_work: Annotated[UnitOfWork, Depends()],
 ) -> PageResponseV1[DatasetResponseV1]:
     pagination = await unit_of_work.dataset.paginate(
-        page=pagination_args.page,
-        page_size=pagination_args.page_size,
-        dataset_ids=pagination_args.dataset_id,
-    )
-    return PageResponseV1[DatasetResponseV1].from_pagination(pagination)
-
-
-@router.get("/search", summary="Search Datasets")
-async def search_datasets(
-    pagination_args: Annotated[SearchPaginateQueryV1, Depends()],
-    unit_of_work: Annotated[UnitOfWork, Depends()],
-) -> PageResponseV1[DatasetResponseV1]:
-    pagination = await unit_of_work.dataset.search(
-        page=pagination_args.page,
-        page_size=pagination_args.page_size,
-        search_query=pagination_args.search_query,
+        page=query_args.page,
+        page_size=query_args.page_size,
+        dataset_ids=query_args.dataset_id,
+        search_query=query_args.search_query,
     )
     return PageResponseV1[DatasetResponseV1].from_pagination(pagination)
 
 
 @router.get("/lineage", summary="Get Dataset lineage graph")
 async def get_datasets_lineage(
-    pagination_args: Annotated[DatasetLineageQueryV1, Query()],
+    query_args: Annotated[DatasetLineageQueryV1, Query()],
     lineage_service: Annotated[LineageService, Depends()],
 ) -> LineageResponseV1:
     lineage = await lineage_service.get_lineage_by_datasets(
-        start_node_ids=[pagination_args.start_node_id],  # type: ignore[list-item]
-        direction=pagination_args.direction,
+        start_node_ids=[query_args.start_node_id],  # type: ignore[list-item]
+        direction=query_args.direction,
         granularity="OPERATION",
-        since=pagination_args.since,
-        until=pagination_args.until,
-        depth=pagination_args.depth,
+        since=query_args.since,
+        until=query_args.until,
+        depth=query_args.depth,
     )
 
     return await build_lineage_response(lineage)

--- a/data_rentgen/server/api/v1/router/run.py
+++ b/data_rentgen/server/api/v1/router/run.py
@@ -12,7 +12,6 @@ from data_rentgen.server.schemas.v1 import (
     RunLineageQueryV1,
     RunResponseV1,
     RunsQueryV1,
-    SearchPaginateQueryV1,
 )
 from data_rentgen.server.services import LineageService
 from data_rentgen.server.utils.lineage_response import build_lineage_response
@@ -23,60 +22,33 @@ router = APIRouter(prefix="/runs", tags=["Runs"], responses=get_error_responses(
 
 @router.get("", summary="Paginated list of Runs")
 async def runs(
-    pagination_args: Annotated[RunsQueryV1, Depends()],
+    query_args: Annotated[RunsQueryV1, Depends()],
     unit_of_work: Annotated[UnitOfWork, Depends()],
 ) -> PageResponseV1[RunResponseV1]:
-    if pagination_args.run_id:
-        pagination = await unit_of_work.run.pagination_by_id(
-            page=pagination_args.page,
-            page_size=pagination_args.page_size,
-            run_ids=pagination_args.run_id,
-        )
-    elif pagination_args.job_id:
-        pagination = await unit_of_work.run.pagination_by_job_id(
-            page=pagination_args.page,
-            page_size=pagination_args.page_size,
-            job_id=pagination_args.job_id,  # type: ignore[arg-type]
-            since=pagination_args.since,  # type: ignore[arg-type]
-            until=pagination_args.until,
-        )
-    elif pagination_args.parent_run_id:
-        pagination = await unit_of_work.run.pagination_by_parent_run_id(
-            page=pagination_args.page,
-            page_size=pagination_args.page_size,
-            parent_run_id=pagination_args.parent_run_id,  # type: ignore[arg-type]
-            since=pagination_args.since,  # type: ignore[arg-type]
-            until=pagination_args.until,
-        )
-    return PageResponseV1[RunResponseV1].from_pagination(pagination)
-
-
-@router.get("/search", summary="Search Runs")
-async def search_runss(
-    pagination_args: Annotated[SearchPaginateQueryV1, Depends()],
-    unit_of_work: Annotated[UnitOfWork, Depends()],
-) -> PageResponseV1[RunResponseV1]:
-    pagination = await unit_of_work.run.search(
-        page=pagination_args.page,
-        page_size=pagination_args.page_size,
-        search_query=pagination_args.search_query,
+    pagination = await unit_of_work.run.paginate(
+        page=query_args.page,
+        page_size=query_args.page_size,
+        since=query_args.since,
+        until=query_args.until,
+        run_ids=query_args.run_id,
+        job_id=query_args.job_id,
+        parent_run_id=query_args.parent_run_id,
+        search_query=query_args.search_query,
     )
-
     return PageResponseV1[RunResponseV1].from_pagination(pagination)
 
 
 @router.get("/lineage", summary="Get Run lineage graph")
 async def get_runs_lineage(
-    pagination_args: Annotated[RunLineageQueryV1, Query()],
+    query_args: Annotated[RunLineageQueryV1, Query()],
     lineage_service: Annotated[LineageService, Depends()],
 ) -> LineageResponseV1:
     lineage = await lineage_service.get_lineage_by_runs(
-        start_node_ids=[pagination_args.start_node_id],  # type: ignore[list-item]
-        direction=pagination_args.direction,
-        granularity=pagination_args.granularity,
-        since=pagination_args.since,
-        until=pagination_args.until,
-        depth=pagination_args.depth,
+        start_node_ids=[query_args.start_node_id],  # type: ignore[list-item]
+        direction=query_args.direction,
+        granularity=query_args.granularity,
+        since=query_args.since,
+        until=query_args.until,
+        depth=query_args.depth,
     )
-
     return await build_lineage_response(lineage)

--- a/data_rentgen/server/schemas/v1/__init__.py
+++ b/data_rentgen/server/schemas/v1/__init__.py
@@ -27,7 +27,6 @@ from data_rentgen.server.schemas.v1.pagination import (
     PageMetaResponseV1,
     PageResponseV1,
     PaginateQueryV1,
-    SearchPaginateQueryV1,
 )
 from data_rentgen.server.schemas.v1.run import RunResponseV1, RunsQueryV1
 from data_rentgen.server.schemas.v1.user import UserResponseV1
@@ -57,5 +56,4 @@ __all__ = [
     "JobPaginateQueryV1",
     "JobLineageQueryV1",
     "PaginateQueryV1",
-    "SearchPaginateQueryV1",
 ]

--- a/data_rentgen/server/schemas/v1/dataset.py
+++ b/data_rentgen/server/schemas/v1/dataset.py
@@ -25,5 +25,12 @@ class DatasetPaginateQueryV1(PaginateQueryV1):
     """Query params for Dataset paginate request."""
 
     dataset_id: list[int] = Field(Query(default_factory=list), description="Dataset id")
+    search_query: str | None = Field(
+        Query(
+            default=None,
+            min_length=3,
+            description="Search query",
+        ),
+    )
 
     model_config = ConfigDict(extra="forbid")

--- a/data_rentgen/server/schemas/v1/job.py
+++ b/data_rentgen/server/schemas/v1/job.py
@@ -25,5 +25,12 @@ class JobPaginateQueryV1(PaginateQueryV1):
     """Query params for Jobs paginate request."""
 
     job_id: list[int] = Field(Query(default_factory=list), description="Job id")
+    search_query: str | None = Field(
+        Query(
+            default=None,
+            min_length=3,
+            description="Search query",
+        ),
+    )
 
     model_config = ConfigDict(extra="forbid")

--- a/data_rentgen/server/schemas/v1/operation.py
+++ b/data_rentgen/server/schemas/v1/operation.py
@@ -39,12 +39,6 @@ class OperationResponseV1(BaseModel):
 class OperationQueryV1(PaginateQueryV1):
     """Query params for Operations paginate request."""
 
-    operation_id: list[UUID] = Field(
-        Query(
-            default_factory=list,
-            description="Operation ids, for exact match",
-        ),
-    )
     since: datetime | None = Field(
         Query(
             default=None,
@@ -57,6 +51,12 @@ class OperationQueryV1(PaginateQueryV1):
             default=None,
             description="Maximum value of Operation 'created_at' field, in ISO 8601 format",
             examples=["2008-09-15T15:53:00+05:00"],
+        ),
+    )
+    operation_id: list[UUID] = Field(
+        Query(
+            default_factory=list,
+            description="Operation ids, for exact match",
         ),
     )
     run_id: UUID | None = Field(
@@ -78,9 +78,8 @@ class OperationQueryV1(PaginateQueryV1):
 
     @model_validator(mode="after")
     def _check_fields(self):
-        if self.operation_id:
-            if self.run_id or self.since or self.until:
-                raise ValueError("fields 'run_id','since', 'until' cannot be used if 'operation_id' is set")
-        elif not self.run_id or not self.since:
-            raise ValueError("input should contain either 'run_id' and 'since', or 'operation_id' field")
+        if not any([self.operation_id, self.run_id]):
+            raise ValueError("input should contain either 'run_id' or 'operation_id' field")
+        if self.run_id and not self.since:
+            raise ValueError("'run_id' can be passed only with 'since'")
         return self

--- a/data_rentgen/server/schemas/v1/pagination.py
+++ b/data_rentgen/server/schemas/v1/pagination.py
@@ -31,14 +31,6 @@ class PaginateQueryV1(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class SearchPaginateQueryV1(PaginateQueryV1):
-    """Query params for search paginate request."""
-
-    search_query: str = Field(min_length=3, description="Search query")
-
-    model_config = ConfigDict(extra="forbid")
-
-
 class PageResponseV1(BaseModel, Generic[T]):
     """Page response."""
 

--- a/tests/test_server/test_datasets/test_search_datasets.py
+++ b/tests/test_server/test_datasets/test_search_datasets.py
@@ -11,27 +11,6 @@ from tests.test_server.utils.enrich import enrich_datasets
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
 
-async def test_dataset_search_no_query(test_client: AsyncClient) -> None:
-    response = await test_client.get("/v1/datasets/search")
-
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-    assert response.json() == {
-        "error": {
-            "code": "invalid_request",
-            "message": "Invalid request",
-            "details": [
-                {
-                    "location": ["query", "search_query"],
-                    "code": "missing",
-                    "message": "Field required",
-                    "input": None,
-                    "context": {},
-                },
-            ],
-        },
-    }
-
-
 async def test_search_datasets_by_address_url(
     test_client: AsyncClient,
     async_session: AsyncSession,
@@ -41,7 +20,7 @@ async def test_search_datasets_by_address_url(
     datasets = await enrich_datasets([datasets_search["hdfs://my-cluster-namenode:2080"]], async_session)
 
     response = await test_client.get(
-        "/v1/datasets/search",
+        "/v1/datasets",
         params={"search_query": "namenode"},
     )
 
@@ -95,7 +74,7 @@ async def test_search_datasets_by_location_name(
     )
 
     response = await test_client.get(
-        "/v1/datasets/search",
+        "/v1/datasets",
         params={"search_query": "postgres.location"},
     )
 
@@ -141,7 +120,7 @@ async def test_search_datasets_by_dataset_name(
     datasets = await enrich_datasets([datasets_search["postgres.public.location_history"]], async_session)
 
     response = await test_client.get(
-        "/v1/datasets/search",
+        "/v1/datasets",
         params={"search_query": "location_history"},
     )
 
@@ -192,7 +171,7 @@ async def test_search_datasets_by_location_name_and_address_url(
     )
 
     response = await test_client.get(
-        "/v1/datasets/search",
+        "/v1/datasets",
         params={"search_query": "my-cluster"},
     )
 

--- a/tests/test_server/test_jobs/test_search_jobs.py
+++ b/tests/test_server/test_jobs/test_search_jobs.py
@@ -11,26 +11,6 @@ from tests.test_server.utils.enrich import enrich_jobs
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
 
-async def test_job_search_no_query(test_client: AsyncClient) -> None:
-    response = await test_client.get("/v1/jobs/search")
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-    assert response.json() == {
-        "error": {
-            "code": "invalid_request",
-            "message": "Invalid request",
-            "details": [
-                {
-                    "location": ["query", "search_query"],
-                    "code": "missing",
-                    "message": "Field required",
-                    "input": None,
-                    "context": {},
-                },
-            ],
-        },
-    }
-
-
 async def test_search_jobs_by_address_url(
     test_client: AsyncClient,
     async_session: AsyncSession,
@@ -40,7 +20,7 @@ async def test_search_jobs_by_address_url(
     jobs = await enrich_jobs([jobs_search["http://airflow-host:2080"]], async_session)
 
     response = await test_client.get(
-        "/v1/jobs/search",
+        "/v1/jobs",
         params={"search_query": "airflow-host"},
     )
 
@@ -85,7 +65,7 @@ async def test_search_jobs_by_location_name(
     jobs = await enrich_jobs([jobs_search["data-product-host"]], async_session)
 
     response = await test_client.get(
-        "/v1/jobs/search",
+        "/v1/jobs",
         params={"search_query": "data-product"},
     )
 
@@ -134,7 +114,7 @@ async def test_search_jobs_by_job_name(
     )
 
     response = await test_client.get(
-        "/v1/jobs/search",
+        "/v1/jobs",
         params={"search_query": "airflow"},
     )
 
@@ -182,7 +162,7 @@ async def test_search_jobs_by_location_name_and_address_url(
     jobs = await enrich_jobs([jobs_search["my-cluster"], jobs_search["yarn://my_cluster_1"]], async_session)
 
     response = await test_client.get(
-        "/v1/jobs/search",
+        "/v1/jobs",
         params={"search_query": "my-cluster"},
     )
 

--- a/tests/test_server/test_lineage/test_get_lineage_request_validators.py
+++ b/tests/test_server/test_lineage/test_get_lineage_request_validators.py
@@ -53,7 +53,7 @@ async def test_get_lineage_no_filter(test_client: AsyncClient, entity_kind: str,
 
     response = await test_client.get(f"v1/{entity_kind}/lineage")
 
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
     assert response.json() == expected_response
 
 
@@ -110,7 +110,7 @@ async def test_get_lineage_start_node_id_int_type_validation(
         },
     )
 
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
     assert response.json() == {
         "error": {
             "code": "invalid_request",
@@ -151,7 +151,7 @@ async def test_get_lineage_start_node_id_uuid_type_validation(
         },
     )
 
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
     assert response.json() == {
         "error": {
             "code": "invalid_request",
@@ -186,7 +186,7 @@ async def test_get_lineage_until_less_than_since(test_client: AsyncClient):
         },
     )
 
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
     assert response.json() == {
         "error": {
             "code": "invalid_request",
@@ -230,7 +230,7 @@ async def test_get_lineage_depth_out_of_bounds(
         },
     )
 
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
     assert response.json() == {
         "error": {
             "code": "invalid_request",

--- a/tests/test_server/test_operations/test_get_operations.py
+++ b/tests/test_server/test_operations/test_get_operations.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from uuid6 import uuid7
+
+pytestmark = [pytest.mark.server, pytest.mark.asyncio]
+
+
+async def test_get_operations_missing_fields(test_client: AsyncClient):
+    response = await test_client.get("v1/operations")
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
+    assert response.json() == {
+        "error": {
+            "code": "invalid_request",
+            "message": "Invalid request",
+            "details": [
+                {
+                    "location": [],
+                    "code": "value_error",
+                    "message": "Value error, input should contain either 'run_id' or 'operation_id' field",
+                    "context": {},
+                    "input": {
+                        "page": 1,
+                        "page_size": 20,
+                        "since": None,
+                        "until": None,
+                        "operation_id": [],
+                        "run_id": None,
+                    },
+                },
+            ],
+        },
+    }
+
+
+async def test_get_operations_until_less_than_since(
+    test_client: AsyncClient,
+):
+    since = datetime.now(tz=timezone.utc)
+    until = since - timedelta(days=1)
+    response = await test_client.get(
+        "v1/operations",
+        params={
+            "since": since.isoformat(),
+            "until": until.isoformat(),
+            "run_id": str(uuid7()),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
+    assert response.json() == {
+        "error": {
+            "code": "invalid_request",
+            "message": "Invalid request",
+            "details": [
+                {
+                    "location": ["until"],
+                    "code": "value_error",
+                    "message": "Value error, 'since' should be less than 'until'",
+                    "context": {},
+                    "input": until.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                },
+            ],
+        },
+    }

--- a/tests/test_server/test_operations/test_get_operations_by_id.py
+++ b/tests/test_server/test_operations/test_get_operations_by_id.py
@@ -8,34 +8,6 @@ from data_rentgen.db.models import Operation
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
 
-async def test_get_operations_no_filter(test_client: AsyncClient):
-    response = await test_client.get("v1/operations")
-
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-    assert response.json() == {
-        "error": {
-            "code": "invalid_request",
-            "message": "Invalid request",
-            "details": [
-                {
-                    "location": [],
-                    "code": "value_error",
-                    "message": "Value error, input should contain either 'run_id' and 'since', or 'operation_id' field",
-                    "context": {},
-                    "input": {
-                        "page": 1,
-                        "page_size": 20,
-                        "since": None,
-                        "operation_id": [],
-                        "run_id": None,
-                        "until": None,
-                    },
-                },
-            ],
-        },
-    }
-
-
 async def test_get_operations_by_unknown_id(
     test_client: AsyncClient,
     new_operation: Operation,
@@ -108,7 +80,9 @@ async def test_get_operations_by_multiple_ids(
 
     response = await test_client.get(
         "v1/operations",
-        params={"operation_id": [str(operation.id) for operation in selected_operations]},
+        params={
+            "operation_id": [str(operation.id) for operation in selected_operations],
+        },
     )
 
     assert response.status_code == HTTPStatus.OK, response.json()

--- a/tests/test_server/test_runs/test_get_runs.py
+++ b/tests/test_server/test_runs/test_get_runs.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from uuid6 import uuid7
+
+pytestmark = [pytest.mark.server, pytest.mark.asyncio]
+
+
+async def test_get_runs_missing_fields(test_client: AsyncClient):
+    response = await test_client.get("v1/runs")
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
+    assert response.json() == {
+        "error": {
+            "code": "invalid_request",
+            "message": "Invalid request",
+            "details": [
+                {
+                    "location": [],
+                    "code": "value_error",
+                    "message": "Value error, input should contain either 'run_id', 'job_id', 'parent_run_id' or 'search_query' field",
+                    "context": {},
+                    "input": {
+                        "page": 1,
+                        "page_size": 20,
+                        "since": None,
+                        "until": None,
+                        "run_id": [],
+                        "parent_run_id": None,
+                        "job_id": None,
+                        "search_query": None,
+                    },
+                },
+            ],
+        },
+    }
+
+
+async def test_get_runs_by_run_id_until_less_than_since(
+    test_client: AsyncClient,
+):
+    since = datetime.now(tz=timezone.utc)
+    until = since - timedelta(days=1)
+    response = await test_client.get(
+        "v1/runs",
+        params={
+            "since": since.isoformat(),
+            "until": until.isoformat(),
+            "run_id": str(uuid7()),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
+    assert response.json() == {
+        "error": {
+            "code": "invalid_request",
+            "message": "Invalid request",
+            "details": [
+                {
+                    "location": ["until"],
+                    "code": "value_error",
+                    "message": "Value error, 'since' should be less than 'until'",
+                    "context": {},
+                    "input": until.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                },
+            ],
+        },
+    }

--- a/tests/test_server/test_runs/test_search_runs.py
+++ b/tests/test_server/test_runs/test_search_runs.py
@@ -11,26 +11,6 @@ from tests.test_server.utils.enrich import enrich_runs
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
 
-async def test_run_search_no_query(test_client: AsyncClient) -> None:
-    response = await test_client.get("/v1/runs/search")
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-    assert response.json() == {
-        "error": {
-            "code": "invalid_request",
-            "message": "Invalid request",
-            "details": [
-                {
-                    "location": ["query", "search_query"],
-                    "code": "missing",
-                    "message": "Field required",
-                    "input": None,
-                    "context": {},
-                },
-            ],
-        },
-    }
-
-
 async def test_search_runs_by_external_id(
     test_client: AsyncClient,
     async_session: AsyncSession,
@@ -42,7 +22,7 @@ async def test_search_runs_by_external_id(
     )
 
     response = await test_client.get(
-        "/v1/runs/search",
+        "/v1/runs",
         params={"search_query": "1638922609021"},
     )
 
@@ -93,7 +73,7 @@ async def test_search_runs_by_job_name(
     runs = await enrich_runs([runs_search["extract_task_0001"], runs_search["extract_task_0002"]], async_session)
 
     response = await test_client.get(
-        "/v1/runs/search",
+        "/v1/runs",
         params={"search_query": "airflow_dag"},
     )
 
@@ -147,7 +127,7 @@ async def test_search_runs_by_job_type(
     )
 
     response = await test_client.get(
-        "/v1/runs/search",
+        "/v1/runs",
         params={"search_query": "SPARK"},
     )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

* Merge endpoints like `/v1/datasets` and `/v1/datasets/search` to one `/v1/datasets` endpoint
* Make query options for `/v1/runs` and `/v1/operations` less strict - if user passed multiple field, add both of them to search query instead of raising an error. It's up to user if given filters make any sense.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
