### PR TITLE
[DOP-20849] Make since field mandatory in runs search

### DIFF
--- a/data_rentgen/server/schemas/v1/run.py
+++ b/data_rentgen/server/schemas/v1/run.py
@@ -104,7 +104,7 @@ class RunsQueryV1(PaginateQueryV1):
         return value
 
     @model_validator(mode="after")
-    def _check_fields(self):
+    def _check_fields(self):  # noqa: WPS238
         if not any([self.run_id, self.job_id, self.parent_run_id, self.search_query]):
             raise ValueError(
                 "input should contain either 'run_id', 'job_id', 'parent_run_id' or 'search_query' field",
@@ -113,4 +113,6 @@ class RunsQueryV1(PaginateQueryV1):
             raise ValueError("'job_id' can be passed only with 'since'")
         if self.parent_run_id and not self.since:
             raise ValueError("'parent_run_id' can be passed only with 'since'")
+        if self.search_query and not self.since:
+            raise ValueError("'search_query' can be passed only with 'since'")
         return self

--- a/tests/test_server/test_datasets/test_search_datasets.py
+++ b/tests/test_server/test_datasets/test_search_datasets.py
@@ -207,3 +207,28 @@ async def test_search_datasets_by_location_name_and_address_url(
     # At this case the order is unstable
     response_diff = DeepDiff(expected_response, response.json(), ignore_order=True)
     assert not response_diff, f"Response diff: {response_diff.to_json()}"
+
+
+async def test_search_datasets_no_results(
+    test_client: AsyncClient,
+    datasets_search: dict[str, Dataset],
+) -> None:
+    response = await test_client.get(
+        "/v1/datasets",
+        params={"search_query": "not-found"},
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "meta": {
+            "has_next": False,
+            "has_previous": False,
+            "next_page": None,
+            "page": 1,
+            "page_size": 20,
+            "pages_count": 1,
+            "previous_page": None,
+            "total_count": 0,
+        },
+        "items": [],
+    }

--- a/tests/test_server/test_jobs/test_search_jobs.py
+++ b/tests/test_server/test_jobs/test_search_jobs.py
@@ -197,3 +197,28 @@ async def test_search_jobs_by_location_name_and_address_url(
     # At this case the order is unstable
     response_diff = DeepDiff(expected_response, response.json(), ignore_order=True)
     assert not response_diff, f"Response diff: {response_diff.to_json()}"
+
+
+async def test_search_jobs_no_results(
+    test_client: AsyncClient,
+    jobs_search: dict[str, Job],
+) -> None:
+    response = await test_client.get(
+        "/v1/jobs",
+        params={"search_query": "not-found"},
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "meta": {
+            "has_next": False,
+            "has_previous": False,
+            "next_page": None,
+            "page": 1,
+            "page_size": 20,
+            "pages_count": 1,
+            "previous_page": None,
+            "total_count": 0,
+        },
+        "items": [],
+    }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Since now, field `since` is mandatory if user passed `search_query` to `GET /v1/runs`. This allows narrowing access to specific partition of `run` table, instead of scanning all partitions.
This is especially useful while searching by query which appears in most of rows of the table.

Also added negative test cases for search endpoints.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
