### PR TITLE
[DOP-20060] Add granularity for jobs

### DIFF
--- a/data_rentgen/server/api/v1/router/job.py
+++ b/data_rentgen/server/api/v1/router/job.py
@@ -42,8 +42,7 @@ async def get_jobs_lineage(
     lineage = await lineage_service.get_lineage_by_jobs(
         start_node_ids=[query_args.start_node_id],  # type: ignore[list-item]
         direction=query_args.direction,
-        # TODO: add pagination args in DOP-20060
-        granularity="OPERATION",
+        granularity=query_args.granularity,
         since=query_args.since,
         until=query_args.until,
         depth=query_args.depth,

--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -89,6 +89,11 @@ class DatasetLineageQueryV1(BaseLineageQueryV1):
 
 class JobLineageQueryV1(BaseLineageQueryV1):
     start_node_id: int = Field(description="Job id", examples=[42])
+    granularity: Literal["JOB", "RUN"] = Field(
+        description="Granularity of the job lineage",
+        default="JOB",
+        examples=["JOB", "RUN"],
+    )
 
 
 class OperationLineageQueryV1(BaseLineageQueryV1):

--- a/data_rentgen/server/services/lineage.py
+++ b/data_rentgen/server/services/lineage.py
@@ -69,7 +69,6 @@ class IdsToSkip:
         return self
 
 
-# TODO: Add granularity logic: DOP-18988
 class LineageService:
     def __init__(self, uow: Annotated[UnitOfWork, Depends()]):
         self._uow = uow
@@ -125,8 +124,9 @@ class LineageService:
         operations = await self._uow.operation.list_by_ids(sorted(operation_ids))
         operations_by_id = {operation.id: operation for operation in operations}
 
-        # Same for runs
-        run_ids = {operation.run_id for operation in operations} - ids_to_skip.runs
+        input_run_ids = {input.run_id for input in inputs if input.run_id is not None}
+        output_run_ids = {output.run_id for output in outputs if output.run_id is not None}
+        run_ids = input_run_ids | output_run_ids - ids_to_skip.runs
         runs = await self._uow.run.list_by_ids(sorted(run_ids))
         runs_by_id = {run.id: run for run in runs}
 

--- a/tests/test_server/fixtures/factories/operation.py
+++ b/tests/test_server/fixtures/factories/operation.py
@@ -76,7 +76,7 @@ async def operations(
     size, params = request.param
     items = []
     for index in range(size):
-        run = choice(runs)
+        run = runs[index]
         items.append(
             operation_factory(
                 run_id=run.id,

--- a/tests/test_server/fixtures/factories/run.py
+++ b/tests/test_server/fixtures/factories/run.py
@@ -75,7 +75,7 @@ async def run(
         await async_session.commit()
 
 
-@pytest_asyncio.fixture(params=[(5, {})])
+@pytest_asyncio.fixture(params=[(10, {})])
 async def runs(
     request: pytest.FixtureRequest,
     async_session_maker: Callable[[], AsyncContextManager[AsyncSession]],
@@ -86,7 +86,7 @@ async def runs(
     started_at = datetime.now()
     items = [
         run_factory(
-            job_id=choice(jobs).id,
+            job_id=jobs[i // 2].id,
             created_at=started_at + timedelta(seconds=0.1 * i),
             started_by_user_id=user.id,
             **params,

--- a/tests/test_server/test_lineage/test_get_lineage_request_validators.py
+++ b/tests/test_server/test_lineage/test_get_lineage_request_validators.py
@@ -15,7 +15,7 @@ pytestmark = [pytest.mark.server, pytest.mark.asyncio, pytest.mark.lineage]
         ("operations", None),
         ("datasets", None),
         ("runs", "RUN"),
-        ("jobs", None),
+        ("jobs", "JOB"),
     ],
 )
 async def test_get_lineage_no_filter(test_client: AsyncClient, entity_kind: str, granularity: str):


### PR DESCRIPTION
## Change Summary

Add granularity query parameters for jobs endpoint.

*Tests:*
- Updated lineage fixture: Every Operation relates strictly to one Run. Every Job has two child runs.
- Added:
  - test_get_job_lineage_with_run_granularity
  - test_get_job_lineage_with_direction_and_until_and_run_granularity
  - test_get_job_lineage_with_depth_and_run_granularity

## Related issue number

[DOP-20060]

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [ ] My PR is ready to review.
