### PR TITLE
[DOP-20958] Consume events in batches

### DIFF
--- a/data_rentgen/consumer/extractors/__init__.py
+++ b/data_rentgen/consumer/extractors/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
+from data_rentgen.consumer.extractors.batch import BatchExtractionResult, extract_batch
 from data_rentgen.consumer.extractors.dataset import (
     extract_dataset,
     extract_dataset_aliases,
@@ -24,4 +25,6 @@ __all__ = [
     "extract_input",
     "extract_output",
     "extract_schema",
+    "extract_batch",
+    "BatchExtractionResult",
 ]

--- a/data_rentgen/consumer/extractors/batch.py
+++ b/data_rentgen/consumer/extractors/batch.py
@@ -1,0 +1,252 @@
+# SPDX-FileCopyrightText: 2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from typing import TypeVar
+
+from data_rentgen.consumer.extractors.dataset import extract_dataset_symlinks
+from data_rentgen.consumer.extractors.input import extract_input
+from data_rentgen.consumer.extractors.operation import extract_operation
+from data_rentgen.consumer.extractors.output import extract_output
+from data_rentgen.consumer.extractors.run import extract_run
+from data_rentgen.consumer.openlineage.job_facets.job_type import OpenLineageJobType
+from data_rentgen.consumer.openlineage.run_event import OpenLineageRunEvent
+from data_rentgen.dto import (
+    DatasetDTO,
+    InputDTO,
+    JobDTO,
+    LocationDTO,
+    OperationDTO,
+    OutputDTO,
+    RunDTO,
+    SchemaDTO,
+    UserDTO,
+)
+from data_rentgen.dto.dataset_symlink import DatasetSymlinkDTO
+
+T = TypeVar(
+    "T",
+    LocationDTO,
+    DatasetDTO,
+    DatasetSymlinkDTO,
+    JobDTO,
+    RunDTO,
+    OperationDTO,
+    InputDTO,
+    OutputDTO,
+    SchemaDTO,
+    UserDTO,
+)
+
+
+class BatchExtractionResult:  # noqa: WPS338, WPS214
+    """Track results of batch extraction.
+
+    Calling any ``add_*`` method will add DTO item to the result, including nested DTOs,
+    like ``OperationDTO`` -> ``RunDTO`` -> ``JobDTO`` -> ``LocationDTO``, and so on.
+
+    Each DTO type is tracked separately. DTOs with same ``unique_key`` are merged into one final DTO,
+    by calling ``existing.merge(new)``. The resulting final DTO contains all non-null attributes of original DTOs.
+    Last DTO in the chain has a higher priority than previuos ones.
+    For example ``RunDTO(status=STARTED, started_at=...).merge(RunDTO(status=SUCCEEDED, ended_at=...))``
+    produces final ``RunDTO(status=SUCCEEDED, started_at=..., ended_at=...)``.
+
+    Calling get methods, like ``jobs()``, will return the list of tracked DTOs with resolved
+    cross-links. For example, iterating over ``jobs()`` with return the same objects
+    as in ``[run.job for run in runs()]``.
+    This makes modification of nested DTOs easier, all changes will be reflected in the parent DTOs as well.
+    """
+
+    def __init__(self):
+        self._locations: dict[tuple, LocationDTO] = {}
+        self._datasets: dict[tuple, DatasetDTO] = {}
+        self._dataset_symlinks: dict[tuple, DatasetSymlinkDTO] = {}
+        self._jobs: dict[tuple, JobDTO] = {}
+        self._runs: dict[tuple, RunDTO] = {}
+        self._operations: dict[tuple, OperationDTO] = {}
+        self._inputs: dict[tuple, InputDTO] = {}
+        self._outputs: dict[tuple, OutputDTO] = {}
+        self._schemas: dict[tuple, SchemaDTO] = {}
+        self._users: dict[tuple, UserDTO] = {}
+
+    def __repr__(self):
+        return (
+            "ExtractionResult("  # noqa: WPS237
+            f"locations={len(self._locations)}, "
+            f"datasets={len(self._datasets)}, "
+            f"dataset_symlinks={len(self._dataset_symlinks)}, "
+            f"jobs={len(self._jobs)}, "
+            f"runs={len(self._runs)}, "
+            f"operations={len(self._operations)}, "
+            f"inputs={len(self._inputs)}, "
+            f"outputs={len(self._outputs)}, "
+            f"schemas={len(self._schemas)}, "
+            f"users={len(self._users)}"
+            ")"
+        )
+
+    @staticmethod
+    def _add(context: dict[tuple, T], new_item: T) -> dict[tuple, T]:  # noqa: WPS602
+        if new_item.unique_key in context:
+            context[new_item.unique_key] = context[new_item.unique_key].merge(new_item)
+        else:
+            context[new_item.unique_key] = new_item
+        return context
+
+    def add_location(self, location: LocationDTO):
+        self._add(self._locations, location)
+
+    def add_dataset(self, dataset: DatasetDTO):
+        self._add(self._datasets, dataset)
+        self.add_location(dataset.location)
+
+    def add_dataset_symlink(self, dataset_symlink: DatasetSymlinkDTO):
+        self._add(self._dataset_symlinks, dataset_symlink)
+        self.add_dataset(dataset_symlink.from_dataset)
+        self.add_dataset(dataset_symlink.to_dataset)
+
+    def add_job(self, job: JobDTO):
+        self._add(self._jobs, job)
+        self.add_location(job.location)
+
+    def add_run(self, run: RunDTO):
+        self._add(self._runs, run)
+        self.add_job(run.job)
+        if run.parent_run:
+            self.add_run(run.parent_run)
+        if run.user:
+            self.add_user(run.user)
+
+    def add_operation(self, operation: OperationDTO):
+        self._add(self._operations, operation)
+        self.add_run(operation.run)
+
+    def add_input(self, input: InputDTO):
+        self._add(self._inputs, input)
+        self.add_operation(input.operation)
+        self.add_dataset(input.dataset)
+        if input.schema:
+            self.add_schema(input.schema)
+
+    def add_output(self, output: OutputDTO):
+        self._add(self._outputs, output)
+        self.add_operation(output.operation)
+        self.add_dataset(output.dataset)
+        if output.schema:
+            self.add_schema(output.schema)
+
+    def add_schema(self, schema: SchemaDTO):
+        self._add(self._schemas, schema)
+
+    def add_user(self, user: UserDTO):
+        self._add(self._users, user)
+
+    def _get_location(self, location_key: tuple) -> LocationDTO:
+        return self._locations[location_key]
+
+    def _get_schema(self, schema_key: tuple) -> SchemaDTO:
+        return self._schemas[schema_key]
+
+    def _get_user(self, user_key: tuple) -> UserDTO:
+        return self._users[user_key]
+
+    def _get_dataset(self, dataset_key: tuple) -> DatasetDTO:
+        dataset = self._datasets[dataset_key]
+        dataset.location = self._get_location(dataset.location.unique_key)
+        return dataset
+
+    def _get_dataset_symlink(self, dataset_symlink_key: tuple) -> DatasetSymlinkDTO:
+        dataset_symlink = self._dataset_symlinks[dataset_symlink_key]
+        dataset_symlink.from_dataset = self._get_dataset(dataset_symlink.from_dataset.unique_key)
+        dataset_symlink.to_dataset = self._get_dataset(dataset_symlink.to_dataset.unique_key)
+        return dataset_symlink
+
+    def _get_job(self, job_key: tuple) -> JobDTO:
+        job = self._jobs[job_key]
+        job.location = self._get_location(job.location.unique_key)
+        return job
+
+    def _get_run(self, run_key: tuple) -> RunDTO:
+        run = self._runs[run_key]
+        run.job = self._get_job(run.job.unique_key)
+        if run.parent_run:
+            run.parent_run = self._get_run(run.parent_run.unique_key)
+        if run.user:
+            run.user = self._get_user(run.user.unique_key)
+        return run
+
+    def _get_operation(self, operation_key: tuple) -> OperationDTO:
+        operation = self._operations[operation_key]
+        operation.run = self._get_run(operation.run.unique_key)
+        return operation
+
+    def _get_input(self, input_key: tuple) -> InputDTO:
+        input = self._inputs[input_key]
+        input.operation = self._get_operation(input.operation.unique_key)
+        input.dataset = self._get_dataset(input.dataset.unique_key)
+        if input.schema:
+            input.schema = self._get_schema(input.schema.unique_key)
+        return input
+
+    def _get_output(self, output_key: tuple) -> OutputDTO:
+        output = self._outputs[output_key]
+        output.operation = self._get_operation(output.operation.unique_key)
+        output.dataset = self._get_dataset(output.dataset.unique_key)
+        if output.schema:
+            output.schema = self._get_schema(output.schema.unique_key)
+        return output
+
+    def locations(self) -> list[LocationDTO]:
+        return list(map(self._get_location, self._locations))
+
+    def datasets(self) -> list[DatasetDTO]:
+        return list(map(self._get_dataset, self._datasets))
+
+    def dataset_symlinks(self) -> list[DatasetSymlinkDTO]:
+        return list(map(self._get_dataset_symlink, self._dataset_symlinks))
+
+    def jobs(self) -> list[JobDTO]:
+        return list(map(self._get_job, self._jobs))
+
+    def runs(self) -> list[RunDTO]:
+        return list(map(self._get_run, self._runs))
+
+    def operations(self) -> list[OperationDTO]:
+        return list(map(self._get_operation, self._operations))
+
+    def inputs(self) -> list[InputDTO]:
+        return list(map(self._get_input, self._inputs))
+
+    def outputs(self) -> list[OutputDTO]:
+        return list(map(self._get_output, self._outputs))
+
+    def schemas(self) -> list[SchemaDTO]:
+        return list(map(self._get_schema, self._schemas))
+
+    def users(self) -> list[UserDTO]:
+        return list(map(self._get_user, self._users))
+
+
+def extract_batch(events: list[OpenLineageRunEvent]) -> BatchExtractionResult:
+    result = BatchExtractionResult()
+
+    for event in events:
+        if event.job.facets.jobType and event.job.facets.jobType.jobType == OpenLineageJobType.JOB:
+            operation = extract_operation(event)
+            result.add_operation(operation)
+
+            for input_dataset in event.inputs:
+                result.add_input(extract_input(operation, input_dataset))
+
+            for output_dataset in event.outputs:
+                result.add_output(extract_output(operation, output_dataset))
+
+            for dataset in event.inputs + event.outputs:
+                dataset_symlinks = extract_dataset_symlinks(dataset)
+                for dataset_symlink in dataset_symlinks:
+                    result.add_dataset_symlink(dataset_symlink)
+        else:
+            run = extract_run(event)
+            result.add_run(run)
+
+    return result

--- a/data_rentgen/consumer/extractors/dataset.py
+++ b/data_rentgen/consumer/extractors/dataset.py
@@ -79,7 +79,7 @@ def extract_dataset_location(dataset: OpenLineageDataset | OpenLineageSymlinkIde
     return LocationDTO(
         type=scheme,
         name=hosts[0],
-        addresses=[f"{scheme}://{host}" for host in hosts],
+        addresses={f"{scheme}://{host}" for host in hosts},
     )
 
 

--- a/data_rentgen/consumer/extractors/job.py
+++ b/data_rentgen/consumer/extractors/job.py
@@ -23,7 +23,7 @@ def extract_job_location(job: OpenLineageJob | OpenLineageParentJob) -> Location
     return LocationDTO(
         type=scheme,
         name=netloc,
-        addresses=[f"{scheme}://{netloc}"],
+        addresses={f"{scheme}://{netloc}"},
     )
 
 

--- a/data_rentgen/consumer/handlers.py
+++ b/data_rentgen/consumer/handlers.py
@@ -1,26 +1,15 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
-from faststream import Depends
+from __future__ import annotations
+
+from faststream import Depends, Logger
 from faststream.kafka import KafkaRouter
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from data_rentgen.consumer.extractors import (
-    extract_dataset,
-    extract_dataset_aliases,
-    extract_dataset_symlinks,
-    extract_input,
-    extract_operation,
-    extract_output,
-    extract_run,
-)
-from data_rentgen.consumer.openlineage.dataset import OpenLineageDataset
-from data_rentgen.consumer.openlineage.job_facets import OpenLineageJobType
+from data_rentgen.consumer.extractors import BatchExtractionResult, extract_batch
 from data_rentgen.consumer.openlineage.run_event import OpenLineageRunEvent
 from data_rentgen.dependencies import Stub
-from data_rentgen.dto import DatasetDTO, JobDTO, RunDTO, SchemaDTO, UserDTO
-from data_rentgen.dto.dataset_symlink import DatasetSymlinkDTO
-from data_rentgen.dto.location import LocationDTO
 from data_rentgen.services.uow import UnitOfWork
 
 router = KafkaRouter()
@@ -30,130 +19,80 @@ def get_unit_of_work(session: AsyncSession = Depends(Stub(AsyncSession))) -> Uni
     return UnitOfWork(session)
 
 
-@router.subscriber("input.runs", group_id="data-rentgen")
-async def runs_handler(event: OpenLineageRunEvent, unit_of_work: UnitOfWork = Depends(get_unit_of_work)):
-    if event.job.facets.jobType and event.job.facets.jobType.jobType == OpenLineageJobType.JOB:
-        await handle_operation(event, unit_of_work)
-    else:
-        await handle_run(event, unit_of_work)
+@router.subscriber("input.runs", group_id="data-rentgen", batch=True)
+async def runs_handler(
+    events: list[OpenLineageRunEvent],
+    logger: Logger,
+    unit_of_work: UnitOfWork = Depends(get_unit_of_work),
+):
+    logger.info("Got %d events", len(events))
+    extracted = extract_batch(events)
+    logger.info("Extracted: %r", extracted)
+
+    logger.info("Saving to database")
+    await save_to_db(extracted, unit_of_work, logger)
+    logger.info("Saved successfully")
 
 
-async def handle_run(event: OpenLineageRunEvent, unit_of_work: UnitOfWork) -> None:
-    run_dto = extract_run(event)
-
-    if run_dto.parent_run:
-        async with unit_of_work:
-            run_dto.parent_run = await create_or_update_run(run_dto.parent_run, unit_of_work)
-
-    async with unit_of_work:
-        await create_or_update_run(run_dto, unit_of_work)
-
-
-async def handle_operation(event: OpenLineageRunEvent, unit_of_work: UnitOfWork) -> None:
+async def save_to_db(data: BatchExtractionResult, unit_of_work: UnitOfWork, logger: Logger) -> None:  # noqa: WPS217
     # To avoid issues when parallel consumer instances create the same object, and then fail at the end,
     # commit changes as soon as possible. Yes, this is quite slow, but it's fine for a prototype.
-    # TODO: rewrite this to create objects in bulk.
-    operation_dto = extract_operation(event)
+    # TODO: rewrite this to create objects in batch.
 
-    async with unit_of_work:
-        operation_dto.run = await create_or_update_run(operation_dto.run, unit_of_work)
+    logger.debug("Creating locations")
+    for location_dto in data.locations():
+        async with unit_of_work:
+            location = await unit_of_work.location.create_or_update(location_dto)
+            location_dto.id = location.id
 
-    async with unit_of_work:
-        await unit_of_work.operation.create_or_update(operation_dto)
+    logger.debug("Creating datasets")
+    for dataset_dto in data.datasets():
+        async with unit_of_work:
+            dataset = await unit_of_work.dataset.create_or_update(dataset_dto)
+            dataset_dto.id = dataset.id
 
-    inputs = []
-    for raw_input in event.inputs:
-        input_dto = extract_input(operation_dto, raw_input)
-        input_dto.dataset = await handle_dataset(raw_input, unit_of_work)
+    logger.debug("Creating symlinks")
+    for dataset_symlink_dto in data.dataset_symlinks():
+        async with unit_of_work:
+            dataset_symlink = await unit_of_work.dataset_symlink.create_or_update(dataset_symlink_dto)
+            dataset_symlink_dto.id = dataset_symlink.id
 
-        if input_dto.schema:
-            async with unit_of_work:
-                input_dto.schema = await get_or_create_schema(input_dto.schema, unit_of_work)
+    logger.debug("Creating jobs")
+    for job_dto in data.jobs():
+        async with unit_of_work:
+            job = await unit_of_work.job.create_or_update(job_dto)
+            job_dto.id = job.id
 
-        inputs.append(input_dto)
+    logger.debug("Creating users")
+    for user_dto in data.users():
+        async with unit_of_work:
+            user = await unit_of_work.user.get_or_create(user_dto)
+            user_dto.id = user.id
 
-    outputs = []
-    for raw_output in event.outputs:
-        output_dto = extract_output(operation_dto, raw_output)
-        output_dto.dataset = await handle_dataset(raw_output, unit_of_work)
+    logger.debug("Creating schemas")
+    for schema_dto in data.schemas():
+        async with unit_of_work:
+            schema = await unit_of_work.schema.get_or_create(schema_dto)
+            schema_dto.id = schema.id
 
-        if output_dto.schema:
-            async with unit_of_work:
-                output_dto.schema = await get_or_create_schema(output_dto.schema, unit_of_work)
+    logger.debug("Creating runs")
+    for run_dto in data.runs():
+        async with unit_of_work:
+            await unit_of_work.run.create_or_update(run_dto)
 
-        outputs.append(output_dto)
+    logger.debug("Creating operations")
+    for operation_dto in data.operations():
+        async with unit_of_work:
+            await unit_of_work.operation.create_or_update(operation_dto)
 
-    # create inputs/outputs only as a last step, to avoid partial lineage graph. Operation should be either empty or not.
-    async with unit_of_work:
-        for input_dto in inputs:  # noqa: WPS440
-            await unit_of_work.input.create_or_update(input_dto)
+    logger.debug("Creating inputs")
+    for input_dto in data.inputs():
+        async with unit_of_work:
+            input = await unit_of_work.input.create_or_update(input_dto)
+            input_dto.id = input.id
 
-        for output_dto in outputs:  # noqa: WPS440
-            await unit_of_work.output.create_or_update(output_dto)
-
-
-async def handle_dataset(raw_dataset: OpenLineageDataset, unit_of_work: UnitOfWork) -> DatasetDTO:
-    dataset_dto = extract_dataset(raw_dataset)
-    dataset_dto = await create_or_update_dataset(dataset_dto, unit_of_work)
-    datasets: dict[str, DatasetDTO] = {dataset_dto.full_name: dataset_dto}
-
-    for raw_extra_dataset in extract_dataset_aliases(raw_dataset):
-        datasets[raw_extra_dataset.full_name] = await create_or_update_dataset(raw_extra_dataset, unit_of_work)
-
-    for dataset_symlink in extract_dataset_symlinks(raw_dataset):
-        from_dataset = datasets[dataset_symlink.from_dataset.full_name]
-        to_dataset = datasets[dataset_symlink.to_dataset.full_name]
-        dataset_symilnk_dto = DatasetSymlinkDTO(from_dataset, to_dataset, dataset_symlink.type)
-        await create_or_update_dataset_symlink(dataset_symilnk_dto, unit_of_work)
-
-    return dataset_dto
-
-
-async def create_or_update_location(location_dto: LocationDTO, unit_of_work: UnitOfWork) -> LocationDTO:
-    location = await unit_of_work.location.create_or_update(location_dto)
-    location_dto.id = location.id
-    return location_dto
-
-
-async def create_or_update_job(job_dto: JobDTO, unit_of_work: UnitOfWork) -> JobDTO:
-    job_dto.location = await create_or_update_location(job_dto.location, unit_of_work)
-    job = await unit_of_work.job.create_or_update(job_dto)
-    job_dto.id = job.id
-    return job_dto
-
-
-async def get_or_create_user(user_dto: UserDTO, unit_of_work: UnitOfWork) -> UserDTO:
-    user = await unit_of_work.user.get_or_create(user_dto)
-    user_dto.id = user.id
-    return user_dto
-
-
-async def create_or_update_run(run_dto: RunDTO, unit_of_work: UnitOfWork) -> RunDTO:
-    run_dto.job = await create_or_update_job(run_dto.job, unit_of_work)
-    if run_dto.user:
-        run_dto.user = await get_or_create_user(run_dto.user, unit_of_work)
-    run = await unit_of_work.run.create_or_update(run_dto)
-    run_dto.id = run.id
-    return run_dto
-
-
-async def create_or_update_dataset(dataset_dto: DatasetDTO, unit_of_work: UnitOfWork) -> DatasetDTO:
-    dataset_dto.location = await create_or_update_location(dataset_dto.location, unit_of_work)
-    dataset = await unit_of_work.dataset.create_or_update(dataset_dto)
-    dataset_dto.id = dataset.id
-    return dataset_dto
-
-
-async def create_or_update_dataset_symlink(
-    dataset_symlink_dto: DatasetSymlinkDTO,
-    unit_of_work: UnitOfWork,
-) -> DatasetSymlinkDTO:
-    dataset_symlink = await unit_of_work.dataset_symlink.create_or_update(dataset_symlink_dto)
-    dataset_symlink_dto.id = dataset_symlink.id
-    return dataset_symlink_dto
-
-
-async def get_or_create_schema(schema_dto: SchemaDTO, unit_of_work: UnitOfWork) -> SchemaDTO:
-    schema = await unit_of_work.schema.get_or_create(schema_dto)
-    schema_dto.id = schema.id
-    return schema_dto
+    logger.debug("Creating outputs")
+    for output_dto in data.outputs():
+        async with unit_of_work:
+            output = await unit_of_work.output.create_or_update(output_dto)
+            output_dto.id = output.id

--- a/data_rentgen/db/repositories/location.py
+++ b/data_rentgen/db/repositories/location.py
@@ -31,7 +31,7 @@ class LocationRepository(Repository[Location]):
             .join(Location.addresses)
             .where(
                 Location.type == location.type,
-                Address.url == any_(location.addresses),  # type: ignore[arg-type]
+                Address.url == any_(sorted(location.addresses)),  # type: ignore[arg-type]
             )
         )
         statement = (
@@ -48,7 +48,7 @@ class LocationRepository(Repository[Location]):
 
     async def _update_addresses(self, existing: Location, new: LocationDTO) -> Location:
         existing_urls = {address.url for address in existing.addresses}
-        new_urls = set(new.addresses) - existing_urls
+        new_urls = new.addresses - existing_urls
         if new_urls:
             addresses = [Address(url=url, location_id=existing.id) for url in new_urls]
             existing.addresses.extend(addresses)

--- a/data_rentgen/dto/dataset.py
+++ b/data_rentgen/dto/dataset.py
@@ -4,17 +4,26 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from functools import cached_property
 
 from data_rentgen.dto.location import LocationDTO
 
 
-@dataclass(slots=True)
+@dataclass
 class DatasetDTO:
     location: LocationDTO
     name: str
     format: str | None = None
     id: int | None = field(default=None, compare=False)
 
-    @property
-    def full_name(self) -> str:
-        return f"{self.location.full_name}/{self.name}"  # noqa: WPS237
+    @cached_property
+    def unique_key(self) -> tuple:
+        return (self.location.unique_key, self.name)
+
+    def merge(self, new: DatasetDTO) -> DatasetDTO:
+        return DatasetDTO(
+            location=self.location.merge(new.location),
+            name=self.name,
+            format=new.format or self.format,
+            id=new.id or self.id,
+        )

--- a/data_rentgen/dto/dataset_symlink.py
+++ b/data_rentgen/dto/dataset_symlink.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from functools import cached_property
 
 from data_rentgen.dto.dataset import DatasetDTO
 
@@ -17,9 +18,21 @@ class DatasetSymlinkTypeDTO(str, Enum):
         return self.value
 
 
-@dataclass(slots=True)
+@dataclass
 class DatasetSymlinkDTO:
     from_dataset: DatasetDTO
     to_dataset: DatasetDTO
     type: DatasetSymlinkTypeDTO
     id: int | None = field(default=None, compare=False)
+
+    @cached_property
+    def unique_key(self) -> tuple:
+        return (self.from_dataset.unique_key, self.to_dataset.unique_key, self.type)
+
+    def merge(self, new: DatasetSymlinkDTO) -> DatasetSymlinkDTO:
+        return DatasetSymlinkDTO(
+            from_dataset=self.from_dataset.merge(new.from_dataset),
+            to_dataset=self.to_dataset.merge(new.to_dataset),
+            type=self.type,
+            id=new.id or self.id,
+        )

--- a/data_rentgen/dto/input.py
+++ b/data_rentgen/dto/input.py
@@ -4,13 +4,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cached_property
+
+from uuid6 import UUID
 
 from data_rentgen.dto.dataset import DatasetDTO
 from data_rentgen.dto.operation import OperationDTO
 from data_rentgen.dto.schema import SchemaDTO
 
 
-@dataclass(slots=True)
+@dataclass
 class InputDTO:
     operation: OperationDTO
     dataset: DatasetDTO
@@ -18,3 +21,30 @@ class InputDTO:
     num_rows: int | None = None
     num_bytes: int | None = None
     num_files: int | None = None
+    # id is generated using other ids combination
+    id: UUID | None = None
+
+    @cached_property
+    def unique_key(self) -> tuple:
+        return (
+            self.operation.unique_key,
+            self.dataset.unique_key,
+            (self.schema.unique_key if self.schema else None),
+        )
+
+    def merge(self, new: InputDTO) -> InputDTO:
+        schema: SchemaDTO | None
+        if self.schema and new.schema:
+            schema = self.schema.merge(new.schema)
+        else:
+            schema = new.schema or self.schema
+
+        return InputDTO(
+            operation=self.operation.merge(new.operation),
+            dataset=self.dataset.merge(new.dataset),
+            schema=schema,
+            num_rows=new.num_rows or self.num_rows,
+            num_bytes=new.num_bytes or self.num_bytes,
+            num_files=new.num_files or self.num_files,
+            id=new.id or self.id,
+        )

--- a/data_rentgen/dto/job.py
+++ b/data_rentgen/dto/job.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from functools import cached_property
 
 from data_rentgen.dto.location import LocationDTO
 
@@ -18,9 +19,21 @@ class JobTypeDTO(str, Enum):
         return self.value
 
 
-@dataclass(slots=True)
+@dataclass
 class JobDTO:
     name: str
     location: LocationDTO
     type: JobTypeDTO | None = None
     id: int | None = field(default=None, compare=False)
+
+    @cached_property
+    def unique_key(self) -> tuple:
+        return (self.location.unique_key, self.name)
+
+    def merge(self, new: JobDTO) -> JobDTO:
+        return JobDTO(
+            location=self.location.merge(new.location),
+            name=self.name,
+            type=new.type or self.type,
+            id=new.id or self.id,
+        )

--- a/data_rentgen/dto/location.py
+++ b/data_rentgen/dto/location.py
@@ -5,13 +5,21 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 
-@dataclass(slots=True)
+@dataclass
 class LocationDTO:
     type: str
     name: str
-    addresses: list[str]
+    addresses: set[str]
     id: int | None = field(default=None, compare=False)
 
     @property
-    def full_name(self) -> str:
-        return f"{self.type}://{self.name}"
+    def unique_key(self) -> tuple:
+        return (self.type, self.name)
+
+    def merge(self, new: LocationDTO) -> LocationDTO:
+        return LocationDTO(
+            type=self.type,
+            name=self.name,
+            addresses=self.addresses | new.addresses,
+            id=new.id or self.id,
+        )

--- a/data_rentgen/dto/operation.py
+++ b/data_rentgen/dto/operation.py
@@ -27,15 +27,12 @@ class OperationStatusDTO(str, Enum):
     FAILED = "FAILED"
     UNKNOWN = "UNKNOWN"
 
-    def __str__(self) -> str:
-        return str(self.value)
 
-
-@dataclass(slots=True)
+@dataclass
 class OperationDTO:
     id: UUID
-    name: str
     run: RunDTO
+    name: str
     type: OperationTypeDTO | None = None
     position: int | None = None
     group: str | None = None
@@ -43,3 +40,21 @@ class OperationDTO:
     status: OperationStatusDTO | None = None
     started_at: datetime | None = None
     ended_at: datetime | None = None
+
+    @property
+    def unique_key(self) -> tuple:
+        return (self.id,)
+
+    def merge(self, new: OperationDTO) -> OperationDTO:
+        return OperationDTO(
+            id=self.id,
+            run=self.run.merge(new.run),
+            name=new.name or self.name,
+            type=new.type or self.type,
+            group=new.group or self.group,
+            description=new.description or self.description,
+            status=new.status or self.status,
+            position=new.position or self.position,
+            started_at=new.started_at or self.started_at,
+            ended_at=new.ended_at or self.ended_at,
+        )

--- a/data_rentgen/dto/output.py
+++ b/data_rentgen/dto/output.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from functools import cached_property
+
+from uuid6 import UUID
 
 from data_rentgen.dto.dataset import DatasetDTO
 from data_rentgen.dto.operation import OperationDTO
@@ -26,7 +29,7 @@ class OutputTypeDTO(str, Enum):
         return self.value
 
 
-@dataclass(slots=True)
+@dataclass
 class OutputDTO:
     operation: OperationDTO
     dataset: DatasetDTO
@@ -35,3 +38,32 @@ class OutputDTO:
     num_rows: int | None = None
     num_bytes: int | None = None
     num_files: int | None = None
+    # id is generated using other ids combination
+    id: UUID | None = None
+
+    @cached_property
+    def unique_key(self) -> tuple:
+        return (
+            self.operation.unique_key,
+            self.dataset.unique_key,
+            self.type,
+            (self.schema.unique_key if self.schema else None),
+        )
+
+    def merge(self, new: OutputDTO) -> OutputDTO:
+        schema: SchemaDTO | None
+        if self.schema and new.schema:
+            schema = self.schema.merge(new.schema)
+        else:
+            schema = new.schema or self.schema
+
+        return OutputDTO(
+            operation=self.operation.merge(new.operation),
+            dataset=self.dataset.merge(new.dataset),
+            type=self.type,
+            schema=schema,
+            num_rows=new.num_rows or self.num_rows,
+            num_bytes=new.num_bytes or self.num_bytes,
+            num_files=new.num_files or self.num_files,
+            id=new.id or self.id,
+        )

--- a/data_rentgen/dto/run.py
+++ b/data_rentgen/dto/run.py
@@ -32,7 +32,7 @@ class RunStartReasonDTO(str, Enum):
         return str(self.value)
 
 
-@dataclass(slots=True)
+@dataclass
 class RunDTO:
     id: UUID
     job: JobDTO
@@ -46,3 +46,35 @@ class RunDTO:
     attempt: str | None = None
     running_log_url: str | None = None
     persistent_log_url: str | None = None
+
+    @property
+    def unique_key(self) -> tuple:
+        return (self.id,)
+
+    def merge(self, new: RunDTO) -> RunDTO:
+        parent_run: RunDTO | None
+        if new.parent_run and self.parent_run:
+            parent_run = self.parent_run.merge(new.parent_run)
+        else:
+            parent_run = new.parent_run or self.parent_run
+
+        user: UserDTO | None
+        if new.user and self.user:
+            user = self.user.merge(new.user)
+        else:
+            user = new.user or self.user
+
+        return RunDTO(
+            id=self.id,
+            job=self.job.merge(new.job),
+            parent_run=parent_run,
+            status=new.status or self.status,
+            started_at=new.started_at or self.started_at,
+            start_reason=new.start_reason or self.start_reason,
+            user=user,
+            ended_at=new.ended_at or self.ended_at,
+            external_id=new.external_id or self.external_id,
+            attempt=new.attempt or self.attempt,
+            running_log_url=new.running_log_url or self.running_log_url,
+            persistent_log_url=new.persistent_log_url or self.persistent_log_url,
+        )

--- a/data_rentgen/dto/schema.py
+++ b/data_rentgen/dto/schema.py
@@ -3,10 +3,22 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
+from functools import cached_property
 
 
-@dataclass(slots=True)
+@dataclass
 class SchemaDTO:
     fields: list[dict]
     id: int | None = field(default=None, compare=False)
+
+    @cached_property
+    def unique_key(self) -> tuple:
+        return (json.dumps(self.fields, sort_keys=True),)
+
+    def merge(self, new: SchemaDTO) -> SchemaDTO:
+        return SchemaDTO(
+            fields=self.fields,
+            id=new.id or self.id,
+        )

--- a/data_rentgen/dto/user.py
+++ b/data_rentgen/dto/user.py
@@ -6,7 +6,17 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 
-@dataclass(slots=True)
+@dataclass
 class UserDTO:
     name: str
     id: int | None = field(default=None, compare=False)
+
+    @property
+    def unique_key(self) -> tuple:
+        return (self.name,)
+
+    def merge(self, new: UserDTO) -> UserDTO:
+        return UserDTO(
+            name=self.name,
+            id=new.id or self.id,
+        )

--- a/tests/test_consumer/test_extractors/test_extractors_batch_airflow.py
+++ b/tests/test_consumer/test_extractors/test_extractors_batch_airflow.py
@@ -1,0 +1,292 @@
+from datetime import datetime, timezone
+
+import pytest
+from packaging.version import Version
+from uuid6 import UUID
+
+from data_rentgen.consumer.extractors.batch import extract_batch
+from data_rentgen.consumer.openlineage.job import OpenLineageJob
+from data_rentgen.consumer.openlineage.job_facets import (
+    OpenLineageJobFacets,
+    OpenLineageJobIntegrationType,
+    OpenLineageJobType,
+    OpenLineageJobTypeJobFacet,
+)
+from data_rentgen.consumer.openlineage.run import OpenLineageRun
+from data_rentgen.consumer.openlineage.run_event import (
+    OpenLineageRunEvent,
+    OpenLineageRunEventType,
+)
+from data_rentgen.consumer.openlineage.run_facets import (
+    OpenLineageAirflowDagInfo,
+    OpenLineageAirflowDagRunFacet,
+    OpenLineageAirflowDagRunInfo,
+    OpenLineageAirflowDagRunType,
+    OpenLineageAirflowTaskInfo,
+    OpenLineageAirflowTaskInstanceInfo,
+    OpenLineageAirflowTaskRunFacet,
+    OpenLineageProcessingEngineName,
+    OpenLineageProcessingEngineRunFacet,
+    OpenLineageRunFacets,
+)
+from data_rentgen.dto import (
+    JobDTO,
+    JobTypeDTO,
+    LocationDTO,
+    RunDTO,
+    RunStartReasonDTO,
+    RunStatusDTO,
+)
+
+
+@pytest.fixture
+def airflow_dag_run_event_start() -> OpenLineageRunEvent:
+    event_time = datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc)
+    run_id = UUID("01908223-0782-79b8-9495-b1c38aaee839")
+    return OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.START,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="http://airflow-host:8081",
+            name="mydag",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    processingType=None,
+                    integration=OpenLineageJobIntegrationType.AIRFLOW,
+                    jobType=OpenLineageJobType.DAG,
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=run_id,
+            facets=OpenLineageRunFacets(
+                processing_engine=OpenLineageProcessingEngineRunFacet(
+                    version=Version("2.9.2"),
+                    name=OpenLineageProcessingEngineName.AIRFLOW,
+                    openlineageAdapterVersion=Version("1.10.0"),
+                ),
+                airflowDagRun=OpenLineageAirflowDagRunFacet(
+                    dag=OpenLineageAirflowDagInfo(dag_id="mydag"),
+                    dagRun=OpenLineageAirflowDagRunInfo(
+                        run_id="manual__2024-07-05T09:04:13:979349+00:00",
+                        run_type=OpenLineageAirflowDagRunType.MANUAL,
+                        data_interval_start=datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc),
+                        data_interval_end=datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def airflow_dag_run_event_stop() -> OpenLineageRunEvent:
+    event_time = datetime(2024, 7, 5, 9, 8, 5, 691973, tzinfo=timezone.utc)
+    run_id = UUID("01908223-0782-79b8-9495-b1c38aaee839")
+    return OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.COMPLETE,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="http://airflow-host:8081",
+            name="mydag",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    processingType=None,
+                    integration=OpenLineageJobIntegrationType.AIRFLOW,
+                    jobType=OpenLineageJobType.DAG,
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=run_id,
+            facets=OpenLineageRunFacets(
+                processing_engine=OpenLineageProcessingEngineRunFacet(
+                    version=Version("2.9.2"),
+                    name=OpenLineageProcessingEngineName.AIRFLOW,
+                    openlineageAdapterVersion=Version("1.10.0"),
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def airflow_task_run_event_start() -> OpenLineageRunEvent:
+    event_time = datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc)
+    run_id = UUID("01908223-0782-7fc0-9d69-b1df9dac2c60")
+    return OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.START,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="http://airflow-host:8081",
+            name="mydag.mytask",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    processingType=None,
+                    integration=OpenLineageJobIntegrationType.AIRFLOW,
+                    jobType=OpenLineageJobType.TASK,
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=run_id,
+            facets=OpenLineageRunFacets(
+                processing_engine=OpenLineageProcessingEngineRunFacet(
+                    version=Version("2.9.2"),
+                    name=OpenLineageProcessingEngineName.AIRFLOW,
+                    openlineageAdapterVersion=Version("1.10.0"),
+                ),
+                airflow=OpenLineageAirflowTaskRunFacet(
+                    dag=OpenLineageAirflowDagInfo(dag_id="mydag"),
+                    dagRun=OpenLineageAirflowDagRunInfo(
+                        run_id="manual__2024-07-05T09:04:13:979349+00:00",
+                        run_type=OpenLineageAirflowDagRunType.MANUAL,
+                        data_interval_start=datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc),
+                        data_interval_end=datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc),
+                    ),
+                    task=OpenLineageAirflowTaskInfo(
+                        task_id="mytask",
+                    ),
+                    taskInstance=OpenLineageAirflowTaskInstanceInfo(
+                        try_number=1,
+                        log_url=(
+                            "http://airflow-host:8081/dags/mydag/grid?tab=logs&dag_run_id=manual__2024-07-05T09%3A04%3A13%3A979349%2B00%3A00&task_id=mytask"
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def airflow_task_run_event_stop() -> OpenLineageRunEvent:
+    event_time = datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc)
+    run_id = UUID("01908223-0782-7fc0-9d69-b1df9dac2c60")
+    return OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.COMPLETE,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="http://airflow-host:8081",
+            name="mydag.mytask",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    processingType=None,
+                    integration=OpenLineageJobIntegrationType.AIRFLOW,
+                    jobType=OpenLineageJobType.TASK,
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=run_id,
+            facets=OpenLineageRunFacets(
+                processing_engine=OpenLineageProcessingEngineRunFacet(
+                    version=Version("2.9.2"),
+                    name=OpenLineageProcessingEngineName.AIRFLOW,
+                    openlineageAdapterVersion=Version("1.10.0"),
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def extracted_airflow_location() -> LocationDTO:
+    return LocationDTO(
+        type="http",
+        name="airflow-host:8081",
+        addresses={"http://airflow-host:8081"},
+    )
+
+
+@pytest.fixture
+def extracted_airflow_dag_job(
+    extracted_airflow_location: LocationDTO,
+) -> JobDTO:
+    return JobDTO(
+        name="mydag",
+        location=extracted_airflow_location,
+        type=JobTypeDTO.AIRFLOW_DAG,
+    )
+
+
+@pytest.fixture
+def extracted_airflow_task_job(
+    extracted_airflow_location: LocationDTO,
+) -> JobDTO:
+    return JobDTO(
+        name="mydag.mytask",
+        location=extracted_airflow_location,
+        type=JobTypeDTO.AIRFLOW_TASK,
+    )
+
+
+@pytest.fixture
+def extracted_airflow_dag_run(
+    extracted_airflow_dag_job: JobDTO,
+) -> RunDTO:
+    return RunDTO(
+        id=UUID("01908223-0782-79b8-9495-b1c38aaee839"),
+        job=extracted_airflow_dag_job,
+        status=RunStatusDTO.SUCCEEDED,
+        started_at=datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc),
+        start_reason=RunStartReasonDTO.MANUAL,
+        ended_at=datetime(2024, 7, 5, 9, 8, 5, 691973, tzinfo=timezone.utc),
+        external_id="manual__2024-07-05T09:04:13:979349+00:00",
+        persistent_log_url="http://airflow-host:8081/dags/mydag/grid?dag_run_id=manual__2024-07-05T09%3A04%3A13%3A979349%2B00%3A00",
+    )
+
+
+@pytest.fixture
+def extracted_airflow_task_run(
+    extracted_airflow_task_job: JobDTO,
+) -> RunDTO:
+    return RunDTO(
+        id=UUID("01908223-0782-7fc0-9d69-b1df9dac2c60"),
+        job=extracted_airflow_task_job,
+        status=RunStatusDTO.SUCCEEDED,
+        started_at=datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc),
+        start_reason=RunStartReasonDTO.MANUAL,
+        ended_at=datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc),
+        external_id="manual__2024-07-05T09:04:13:979349+00:00",
+        attempt="1",
+        persistent_log_url=(
+            "http://airflow-host:8081/dags/mydag/grid?tab=logs&dag_run_id=manual__2024-07-05T09%3A04%3A13%3A979349%2B00%3A00&task_id=mytask"
+        ),
+    )
+
+
+def test_extractors_extract_batch_airflow(
+    airflow_dag_run_event_start: OpenLineageRunEvent,
+    airflow_dag_run_event_stop: OpenLineageRunEvent,
+    airflow_task_run_event_start: OpenLineageRunEvent,
+    airflow_task_run_event_stop: OpenLineageRunEvent,
+    extracted_airflow_location: LocationDTO,
+    extracted_airflow_dag_job: JobDTO,
+    extracted_airflow_task_job: JobDTO,
+    extracted_airflow_dag_run: RunDTO,
+    extracted_airflow_task_run: RunDTO,
+):
+    events = [
+        airflow_dag_run_event_start,
+        airflow_task_run_event_start,
+        airflow_task_run_event_stop,
+        airflow_dag_run_event_stop,
+    ]
+
+    extracted = extract_batch(events)
+
+    assert extracted.locations() == [extracted_airflow_location]
+    assert extracted.jobs() == [extracted_airflow_dag_job, extracted_airflow_task_job]
+    assert extracted.runs() == [
+        extracted_airflow_dag_run,
+        extracted_airflow_task_run,
+    ]
+
+    assert not extracted.datasets()
+    assert not extracted.dataset_symlinks()
+    assert not extracted.users()
+    assert not extracted.schemas()
+    assert not extracted.operations()
+    assert not extracted.inputs()
+    assert not extracted.outputs()

--- a/tests/test_consumer/test_extractors/test_extractors_batch_spark.py
+++ b/tests/test_consumer/test_extractors/test_extractors_batch_spark.py
@@ -1,0 +1,772 @@
+from datetime import datetime, timezone
+
+import pytest
+from uuid6 import UUID
+
+from data_rentgen.consumer.extractors.batch import extract_batch
+from data_rentgen.consumer.openlineage.dataset import (
+    OpenLineageInputDataset,
+    OpenLineageOutputDataset,
+)
+from data_rentgen.consumer.openlineage.dataset_facets import (
+    OpenLineageDatasetFacets,
+    OpenLineageDatasetLifecycleStateChange,
+    OpenLineageLifecycleStateChangeDatasetFacet,
+    OpenLineageOutputDatasetFacets,
+    OpenLineageOutputStatisticsOutputDatasetFacet,
+    OpenLineageSchemaDatasetFacet,
+    OpenLineageSchemaField,
+    OpenLineageSymlinkIdentifier,
+    OpenLineageSymlinksDatasetFacet,
+    OpenLineageSymlinkType,
+)
+from data_rentgen.consumer.openlineage.job import OpenLineageJob
+from data_rentgen.consumer.openlineage.job_facets import (
+    OpenLineageJobFacets,
+    OpenLineageJobIntegrationType,
+    OpenLineageJobProcessingType,
+    OpenLineageJobType,
+    OpenLineageJobTypeJobFacet,
+)
+from data_rentgen.consumer.openlineage.run import OpenLineageRun
+from data_rentgen.consumer.openlineage.run_event import (
+    OpenLineageRunEvent,
+    OpenLineageRunEventType,
+)
+from data_rentgen.consumer.openlineage.run_facets import (
+    OpenLineageParentJob,
+    OpenLineageParentRun,
+    OpenLineageParentRunFacet,
+    OpenLineageRunFacets,
+    OpenLineageSparkApplicationDetailsRunFacet,
+    OpenLineageSparkDeployMode,
+)
+from data_rentgen.dto import (
+    DatasetDTO,
+    DatasetSymlinkDTO,
+    DatasetSymlinkTypeDTO,
+    InputDTO,
+    JobDTO,
+    JobTypeDTO,
+    LocationDTO,
+    OperationDTO,
+    OperationStatusDTO,
+    OperationTypeDTO,
+    OutputDTO,
+    OutputTypeDTO,
+    RunDTO,
+    RunStatusDTO,
+    SchemaDTO,
+    UserDTO,
+)
+
+
+@pytest.fixture
+def spark_app_run_event_start() -> OpenLineageRunEvent:
+    event_time = datetime(2024, 7, 5, 9, 4, 48, 794900, tzinfo=timezone.utc)
+    run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
+    return OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.START,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="local://some.host.com",
+            name="mysession",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    processingType=None,
+                    integration=OpenLineageJobIntegrationType.SPARK,
+                    jobType=OpenLineageJobType.APPLICATION,
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=run_id,
+            facets=OpenLineageRunFacets(
+                spark_applicationDetails=OpenLineageSparkApplicationDetailsRunFacet(
+                    master="local[*]",
+                    appName="spark_session",
+                    applicationId="local-1719136537510",
+                    deployMode=OpenLineageSparkDeployMode.CLIENT,
+                    driverHost="127.0.0.1",
+                    userName="myuser",
+                    uiWebUrl="http://127.0.0.1:4040",
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def spark_app_run_event_stop() -> OpenLineageRunEvent:
+    event_time = datetime(2024, 7, 5, 9, 7, 15, 646000, tzinfo=timezone.utc)
+    run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
+    return OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.COMPLETE,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="local://some.host.com",
+            name="mysession",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    processingType=None,
+                    integration=OpenLineageJobIntegrationType.SPARK,
+                    jobType=OpenLineageJobType.APPLICATION,
+                ),
+            ),
+        ),
+        run=OpenLineageRun(runId=run_id),
+    )
+
+
+@pytest.fixture
+def spark_operation_run_event_start() -> OpenLineageRunEvent:
+    event_time = datetime(2024, 7, 5, 9, 6, 29, 462000, tzinfo=timezone.utc)
+    run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
+    operation_id = UUID("01908225-1fd7-746b-910c-70d24f2898b1")
+    return OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.START,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="local://some.host.com",
+            name="mysession.execute_some_command",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    jobType=OpenLineageJobType.JOB,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration=OpenLineageJobIntegrationType.SPARK,
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=operation_id,
+            facets=OpenLineageRunFacets(
+                parent=OpenLineageParentRunFacet(
+                    job=OpenLineageParentJob(
+                        namespace="local://some.host.com",
+                        name="mysession",
+                    ),
+                    run=OpenLineageParentRun(
+                        runId=run_id,
+                    ),
+                ),
+            ),
+        ),
+        inputs=[
+            OpenLineageInputDataset(
+                namespace="postgres://192.168.1.1:5432",
+                name="mydb.myschema.mytable",
+                facets=OpenLineageDatasetFacets(
+                    schema=OpenLineageSchemaDatasetFacet(
+                        fields=[
+                            OpenLineageSchemaField(
+                                name="dt",
+                                type="timestamp",
+                                description="Business date",
+                            ),
+                            OpenLineageSchemaField(name="customer_id", type="decimal(20,0)"),
+                            OpenLineageSchemaField(name="total_spent", type="float"),
+                            OpenLineageSchemaField(
+                                name="phones",
+                                type="array",
+                                fields=[
+                                    OpenLineageSchemaField(name="_element", type="string"),
+                                ],
+                            ),
+                            OpenLineageSchemaField(
+                                name="address",
+                                type="struct",
+                                fields=[
+                                    OpenLineageSchemaField(name="street", type="string"),
+                                    OpenLineageSchemaField(name="city", type="string"),
+                                    OpenLineageSchemaField(name="state", type="string"),
+                                    OpenLineageSchemaField(name="zip", type="string"),
+                                ],
+                            ),
+                        ],
+                    ),
+                ),
+            ),
+        ],
+        outputs=[
+            OpenLineageOutputDataset(
+                namespace="hdfs://test-hadoop:9820",
+                name="/user/hive/warehouse/mydb.db/mytable",
+                facets=OpenLineageDatasetFacets(
+                    lifecycleStateChange=OpenLineageLifecycleStateChangeDatasetFacet(
+                        lifecycleStateChange=OpenLineageDatasetLifecycleStateChange.CREATE,
+                    ),
+                    symlinks=OpenLineageSymlinksDatasetFacet(
+                        identifiers=[
+                            OpenLineageSymlinkIdentifier(
+                                namespace="hive://test-hadoop:9083",
+                                name="mydb.mytable",
+                                type=OpenLineageSymlinkType.TABLE,
+                            ),
+                        ],
+                    ),
+                    schema=OpenLineageSchemaDatasetFacet(
+                        fields=[
+                            OpenLineageSchemaField(
+                                name="dt",
+                                type="timestamp",
+                                description="Business date",
+                            ),
+                            OpenLineageSchemaField(name="customer_id", type="decimal(20,0)"),
+                            OpenLineageSchemaField(name="total_spent", type="float"),
+                            OpenLineageSchemaField(
+                                name="phones",
+                                type="array",
+                                fields=[
+                                    OpenLineageSchemaField(name="_element", type="string"),
+                                ],
+                            ),
+                            OpenLineageSchemaField(
+                                name="address",
+                                type="struct",
+                                fields=[
+                                    OpenLineageSchemaField(name="street", type="string"),
+                                    OpenLineageSchemaField(name="city", type="string"),
+                                    OpenLineageSchemaField(name="state", type="string"),
+                                    OpenLineageSchemaField(name="zip", type="string"),
+                                ],
+                            ),
+                        ],
+                    ),
+                ),
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def spark_operation_run_event_running() -> OpenLineageRunEvent:
+    event_time = datetime(2024, 7, 5, 9, 7, 9, 849000, tzinfo=timezone.utc)
+    run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
+    operation_id = UUID("01908225-1fd7-746b-910c-70d24f2898b1")
+    return OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.RUNNING,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="local://some.host.com",
+            name="mysession.execute_some_command",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    jobType=OpenLineageJobType.JOB,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration=OpenLineageJobIntegrationType.SPARK,
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=operation_id,
+            facets=OpenLineageRunFacets(
+                parent=OpenLineageParentRunFacet(
+                    job=OpenLineageParentJob(
+                        namespace="local://some.host.com",
+                        name="mysession",
+                    ),
+                    run=OpenLineageParentRun(
+                        runId=run_id,
+                    ),
+                ),
+            ),
+        ),
+        inputs=[
+            OpenLineageInputDataset(
+                namespace="postgres://192.168.1.1:5432",
+                name="mydb.myschema.mytable",
+                facets=OpenLineageDatasetFacets(
+                    schema=OpenLineageSchemaDatasetFacet(
+                        fields=[
+                            OpenLineageSchemaField(
+                                name="dt",
+                                type="timestamp",
+                                description="Business date",
+                            ),
+                            OpenLineageSchemaField(name="customer_id", type="decimal(20,0)"),
+                            OpenLineageSchemaField(name="total_spent", type="float"),
+                            OpenLineageSchemaField(
+                                name="phones",
+                                type="array",
+                                fields=[
+                                    OpenLineageSchemaField(name="_element", type="string"),
+                                ],
+                            ),
+                            OpenLineageSchemaField(
+                                name="address",
+                                type="struct",
+                                fields=[
+                                    OpenLineageSchemaField(name="street", type="string"),
+                                    OpenLineageSchemaField(name="city", type="string"),
+                                    OpenLineageSchemaField(name="state", type="string"),
+                                    OpenLineageSchemaField(name="zip", type="string"),
+                                ],
+                            ),
+                        ],
+                    ),
+                ),
+            ),
+        ],
+        outputs=[
+            OpenLineageOutputDataset(
+                namespace="hdfs://test-hadoop:9820",
+                name="/user/hive/warehouse/mydb.db/mytable",
+                facets=OpenLineageDatasetFacets(
+                    lifecycleStateChange=OpenLineageLifecycleStateChangeDatasetFacet(
+                        lifecycleStateChange=OpenLineageDatasetLifecycleStateChange.CREATE,
+                    ),
+                    symlinks=OpenLineageSymlinksDatasetFacet(
+                        identifiers=[
+                            OpenLineageSymlinkIdentifier(
+                                namespace="hive://test-hadoop:9083",
+                                name="mydb.mytable",
+                                type=OpenLineageSymlinkType.TABLE,
+                            ),
+                        ],
+                    ),
+                    schema=OpenLineageSchemaDatasetFacet(
+                        fields=[
+                            OpenLineageSchemaField(
+                                name="dt",
+                                type="timestamp",
+                                description="Business date",
+                            ),
+                            OpenLineageSchemaField(name="customer_id", type="decimal(20,0)"),
+                            OpenLineageSchemaField(name="total_spent", type="float"),
+                            OpenLineageSchemaField(
+                                name="phones",
+                                type="array",
+                                fields=[
+                                    OpenLineageSchemaField(name="_element", type="string"),
+                                ],
+                            ),
+                            OpenLineageSchemaField(
+                                name="address",
+                                type="struct",
+                                fields=[
+                                    OpenLineageSchemaField(name="street", type="string"),
+                                    OpenLineageSchemaField(name="city", type="string"),
+                                    OpenLineageSchemaField(name="state", type="string"),
+                                    OpenLineageSchemaField(name="zip", type="string"),
+                                ],
+                            ),
+                        ],
+                    ),
+                ),
+                outputFacets=OpenLineageOutputDatasetFacets(
+                    outputStatistics=OpenLineageOutputStatisticsOutputDatasetFacet(
+                        rowCount=1_000_000,
+                        size=1000 * 1024 * 1024,
+                    ),
+                ),
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def spark_operation_run_event_stop() -> OpenLineageRunEvent:
+    event_time = datetime(2024, 7, 5, 9, 7, 15, 642000, tzinfo=timezone.utc)
+    run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
+    operation_id = UUID("01908225-1fd7-746b-910c-70d24f2898b1")
+    return OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.COMPLETE,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="local://some.host.com",
+            name="mysession.execute_some_command",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    jobType=OpenLineageJobType.JOB,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration=OpenLineageJobIntegrationType.SPARK,
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=operation_id,
+            facets=OpenLineageRunFacets(
+                parent=OpenLineageParentRunFacet(
+                    job=OpenLineageParentJob(
+                        namespace="local://some.host.com",
+                        name="mysession",
+                    ),
+                    run=OpenLineageParentRun(
+                        runId=run_id,
+                    ),
+                ),
+            ),
+        ),
+        inputs=[
+            OpenLineageInputDataset(
+                namespace="postgres://192.168.1.1:5432",
+                name="mydb.myschema.mytable",
+                facets=OpenLineageDatasetFacets(
+                    schema=OpenLineageSchemaDatasetFacet(
+                        fields=[
+                            OpenLineageSchemaField(
+                                name="dt",
+                                type="timestamp",
+                                description="Business date",
+                            ),
+                            OpenLineageSchemaField(name="customer_id", type="decimal(20,0)"),
+                            OpenLineageSchemaField(name="total_spent", type="float"),
+                            OpenLineageSchemaField(
+                                name="phones",
+                                type="array",
+                                fields=[
+                                    OpenLineageSchemaField(name="_element", type="string"),
+                                ],
+                            ),
+                            OpenLineageSchemaField(
+                                name="address",
+                                type="struct",
+                                fields=[
+                                    OpenLineageSchemaField(name="street", type="string"),
+                                    OpenLineageSchemaField(name="city", type="string"),
+                                    OpenLineageSchemaField(name="state", type="string"),
+                                    OpenLineageSchemaField(name="zip", type="string"),
+                                ],
+                            ),
+                        ],
+                    ),
+                ),
+            ),
+        ],
+        outputs=[
+            OpenLineageOutputDataset(
+                namespace="hdfs://test-hadoop:9820",
+                name="/user/hive/warehouse/mydb.db/mytable",
+                facets=OpenLineageDatasetFacets(
+                    lifecycleStateChange=OpenLineageLifecycleStateChangeDatasetFacet(
+                        lifecycleStateChange=OpenLineageDatasetLifecycleStateChange.CREATE,
+                    ),
+                    symlinks=OpenLineageSymlinksDatasetFacet(
+                        identifiers=[
+                            OpenLineageSymlinkIdentifier(
+                                namespace="hive://test-hadoop:9083",
+                                name="mydb.mytable",
+                                type=OpenLineageSymlinkType.TABLE,
+                            ),
+                        ],
+                    ),
+                    schema=OpenLineageSchemaDatasetFacet(
+                        fields=[
+                            OpenLineageSchemaField(
+                                name="dt",
+                                type="timestamp",
+                                description="Business date",
+                            ),
+                            OpenLineageSchemaField(name="customer_id", type="decimal(20,0)"),
+                            OpenLineageSchemaField(name="total_spent", type="float"),
+                            OpenLineageSchemaField(
+                                name="phones",
+                                type="array",
+                                fields=[
+                                    OpenLineageSchemaField(name="_element", type="string"),
+                                ],
+                            ),
+                            OpenLineageSchemaField(
+                                name="address",
+                                type="struct",
+                                fields=[
+                                    OpenLineageSchemaField(name="street", type="string"),
+                                    OpenLineageSchemaField(name="city", type="string"),
+                                    OpenLineageSchemaField(name="state", type="string"),
+                                    OpenLineageSchemaField(name="zip", type="string"),
+                                ],
+                            ),
+                        ],
+                    ),
+                ),
+                outputFacets=OpenLineageOutputDatasetFacets(
+                    outputStatistics=OpenLineageOutputStatisticsOutputDatasetFacet(
+                        rowCount=1_000_000,
+                        size=1000 * 1024 * 1024,
+                    ),
+                ),
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def extracted_postgres_location() -> LocationDTO:
+    return LocationDTO(
+        type="postgres",
+        name="192.168.1.1:5432",
+        addresses={"postgres://192.168.1.1:5432"},
+    )
+
+
+@pytest.fixture
+def extracted_hdfs_location() -> LocationDTO:
+    return LocationDTO(
+        type="hdfs",
+        name="test-hadoop:9820",
+        addresses={"hdfs://test-hadoop:9820"},
+    )
+
+
+@pytest.fixture
+def extracted_hive_location() -> LocationDTO:
+    return LocationDTO(
+        type="hive",
+        name="test-hadoop:9083",
+        addresses={"hive://test-hadoop:9083"},
+    )
+
+
+@pytest.fixture
+def extracted_spark_location() -> LocationDTO:
+    return LocationDTO(
+        type="local",
+        name="some.host.com",
+        addresses={"local://some.host.com"},
+    )
+
+
+@pytest.fixture
+def extracted_postgres_dataset(
+    extracted_postgres_location: LocationDTO,
+) -> DatasetDTO:
+    return DatasetDTO(
+        location=extracted_postgres_location,
+        name="mydb.myschema.mytable",
+    )
+
+
+@pytest.fixture
+def extracted_hdfs_dataset(
+    extracted_hdfs_location: LocationDTO,
+) -> DatasetDTO:
+    return DatasetDTO(
+        location=extracted_hdfs_location,
+        name="/user/hive/warehouse/mydb.db/mytable",
+    )
+
+
+@pytest.fixture
+def extracted_hive_dataset(
+    extracted_hive_location: LocationDTO,
+) -> DatasetDTO:
+    return DatasetDTO(
+        location=extracted_hive_location,
+        name="mydb.mytable",
+    )
+
+
+@pytest.fixture
+def extracted_hdfs_dataset_symlink(
+    extracted_hdfs_dataset: DatasetDTO,
+    extracted_hive_dataset: DatasetDTO,
+) -> DatasetSymlinkDTO:
+    return DatasetSymlinkDTO(
+        from_dataset=extracted_hdfs_dataset,
+        to_dataset=extracted_hive_dataset,
+        type=DatasetSymlinkTypeDTO.METASTORE,
+    )
+
+
+@pytest.fixture
+def extracted_hive_dataset_symlink(
+    extracted_hdfs_dataset: DatasetDTO,
+    extracted_hive_dataset: DatasetDTO,
+) -> DatasetSymlinkDTO:
+    return DatasetSymlinkDTO(
+        from_dataset=extracted_hive_dataset,
+        to_dataset=extracted_hdfs_dataset,
+        type=DatasetSymlinkTypeDTO.WAREHOUSE,
+    )
+
+
+@pytest.fixture
+def extracted_dataset_schema() -> SchemaDTO:
+    return SchemaDTO(
+        fields=[
+            {
+                "name": "dt",
+                "type": "timestamp",
+                "description": "Business date",
+            },
+            {
+                "name": "customer_id",
+                "type": "decimal(20,0)",
+            },
+            {
+                "name": "total_spent",
+                "type": "float",
+            },
+            {
+                "name": "phones",
+                "type": "array",
+                "fields": [
+                    {
+                        "name": "_element",
+                        "type": "string",
+                    },
+                ],
+            },
+            {
+                "name": "address",
+                "type": "struct",
+                "fields": [
+                    {
+                        "name": "street",
+                        "type": "string",
+                    },
+                    {
+                        "name": "city",
+                        "type": "string",
+                    },
+                    {
+                        "name": "state",
+                        "type": "string",
+                    },
+                    {
+                        "name": "zip",
+                        "type": "string",
+                    },
+                ],
+            },
+        ],
+    )
+
+
+@pytest.fixture
+def extracted_user() -> UserDTO:
+    return UserDTO(name="myuser")
+
+
+@pytest.fixture
+def extracted_spark_app_job(
+    extracted_spark_location: LocationDTO,
+) -> JobDTO:
+    return JobDTO(
+        name="mysession",
+        location=extracted_spark_location,
+        type=JobTypeDTO.SPARK_APPLICATION,
+    )
+
+
+@pytest.fixture
+def extracted_spark_app_run(
+    extracted_spark_app_job: JobDTO,
+    extracted_user: UserDTO,
+) -> RunDTO:
+    return RunDTO(
+        id=UUID("01908224-8410-79a2-8de6-a769ad6944c9"),
+        job=extracted_spark_app_job,
+        user=extracted_user,
+        status=RunStatusDTO.SUCCEEDED,
+        started_at=datetime(2024, 7, 5, 9, 4, 48, 794900, tzinfo=timezone.utc),
+        ended_at=datetime(2024, 7, 5, 9, 7, 15, 646000, tzinfo=timezone.utc),
+        external_id="local-1719136537510",
+        running_log_url="http://127.0.0.1:4040",
+    )
+
+
+@pytest.fixture
+def extracted_spark_operation(
+    extracted_spark_app_run: RunDTO,
+):
+    return OperationDTO(
+        id=UUID("01908225-1fd7-746b-910c-70d24f2898b1"),
+        name="execute_some_command",
+        run=extracted_spark_app_run,
+        status=OperationStatusDTO.SUCCEEDED,
+        type=OperationTypeDTO.BATCH,
+        started_at=datetime(2024, 7, 5, 9, 6, 29, 462000, tzinfo=timezone.utc),
+        ended_at=datetime(2024, 7, 5, 9, 7, 15, 642000, tzinfo=timezone.utc),
+    )
+
+
+@pytest.fixture
+def extracted_postgres_input(
+    extracted_spark_operation: OperationDTO,
+    extracted_postgres_dataset: DatasetDTO,
+    extracted_dataset_schema: SchemaDTO,
+) -> InputDTO:
+    return InputDTO(
+        operation=extracted_spark_operation,
+        dataset=extracted_postgres_dataset,
+        schema=extracted_dataset_schema,
+    )
+
+
+@pytest.fixture
+def extracted_hdfs_output(
+    extracted_spark_operation: OperationDTO,
+    extracted_hdfs_dataset: DatasetDTO,
+    extracted_dataset_schema: SchemaDTO,
+) -> OutputDTO:
+    return OutputDTO(
+        type=OutputTypeDTO.CREATE,
+        operation=extracted_spark_operation,
+        dataset=extracted_hdfs_dataset,
+        schema=extracted_dataset_schema,
+        num_rows=1_000_000,
+        num_bytes=1000 * 1024 * 1024,
+    )
+
+
+def test_extractors_extract_batch_spark(
+    spark_app_run_event_start: OpenLineageRunEvent,
+    spark_app_run_event_stop: OpenLineageRunEvent,
+    spark_operation_run_event_start: OpenLineageRunEvent,
+    spark_operation_run_event_running: OpenLineageRunEvent,
+    spark_operation_run_event_stop: OpenLineageRunEvent,
+    extracted_postgres_location: LocationDTO,
+    extracted_hdfs_location: LocationDTO,
+    extracted_hive_location: LocationDTO,
+    extracted_spark_location: LocationDTO,
+    extracted_postgres_dataset: DatasetDTO,
+    extracted_hdfs_dataset: DatasetDTO,
+    extracted_hive_dataset: DatasetDTO,
+    extracted_hdfs_dataset_symlink: DatasetSymlinkDTO,
+    extracted_hive_dataset_symlink: DatasetSymlinkDTO,
+    extracted_dataset_schema: SchemaDTO,
+    extracted_spark_app_job: JobDTO,
+    extracted_user: UserDTO,
+    extracted_spark_app_run: RunDTO,
+    extracted_spark_operation: OperationDTO,
+    extracted_postgres_input: InputDTO,
+    extracted_hdfs_output: OutputDTO,
+):
+    events = [
+        spark_app_run_event_start,
+        spark_operation_run_event_start,
+        spark_operation_run_event_running,
+        spark_operation_run_event_stop,
+        spark_app_run_event_stop,
+    ]
+
+    extracted = extract_batch(events)
+
+    assert extracted.locations() == [
+        extracted_spark_location,
+        extracted_postgres_location,
+        extracted_hdfs_location,
+        extracted_hive_location,
+    ]
+
+    assert extracted.jobs() == [extracted_spark_app_job]
+    assert extracted.users() == [extracted_user]
+    assert extracted.runs() == [extracted_spark_app_run]
+    assert extracted.operations() == [extracted_spark_operation]
+
+    assert extracted.datasets() == [
+        extracted_postgres_dataset,
+        extracted_hdfs_dataset,
+        extracted_hive_dataset,
+    ]
+
+    assert extracted.dataset_symlinks() == [
+        extracted_hdfs_dataset_symlink,
+        extracted_hive_dataset_symlink,
+    ]
+
+    # Both input & output schemas are the same
+    assert extracted.schemas() == [extracted_dataset_schema]
+    assert extracted.inputs() == [extracted_postgres_input]
+    assert extracted.outputs() == [extracted_hdfs_output]

--- a/tests/test_consumer/test_extractors/test_extractors_dataset.py
+++ b/tests/test_consumer/test_extractors/test_extractors_dataset.py
@@ -31,7 +31,7 @@ def test_extractors_extract_dataset_hdfs():
         location=LocationDTO(
             type="hdfs",
             name="test-hadoop:9820",
-            addresses=["hdfs://test-hadoop:9820"],
+            addresses={"hdfs://test-hadoop:9820"},
         ),
         name="/user/hive/warehouse/mydb.db/mytable",
     )
@@ -60,7 +60,7 @@ def test_extractors_extract_dataset_hdfs_with_table_symlink():
         location=LocationDTO(
             type="hdfs",
             name="test-hadoop:9820",
-            addresses=["hdfs://test-hadoop:9820"],
+            addresses={"hdfs://test-hadoop:9820"},
         ),
         name="/warehouse/mydb.db/mytable",
     )
@@ -69,7 +69,7 @@ def test_extractors_extract_dataset_hdfs_with_table_symlink():
         location=LocationDTO(
             type="hive",
             name="test-hadoop:9083",
-            addresses=["hive://test-hadoop:9083"],
+            addresses={"hive://test-hadoop:9083"},
         ),
         name="mydb.mytable",
     )
@@ -107,7 +107,7 @@ def test_extractors_extract_dataset_hdfs_with_format(storage_layer: str, file_fo
         location=LocationDTO(
             type="hdfs",
             name="test-hadoop:9820",
-            addresses=["hdfs://test-hadoop:9820"],
+            addresses={"hdfs://test-hadoop:9820"},
         ),
         name="/user/hive/warehouse/mydb.db/mytable",
         format=expected_format,
@@ -125,7 +125,7 @@ def test_extractors_extract_dataset_s3():
         location=LocationDTO(
             type="s3",
             name="bucket",
-            addresses=["s3://bucket"],
+            addresses={"s3://bucket"},
         ),
         name="warehouse/mydb.db/mytable",
     )
@@ -143,7 +143,7 @@ def test_extractors_extract_dataset_file():
         location=LocationDTO(
             type="file",
             name="unknown",
-            addresses=["file://unknown"],
+            addresses={"file://unknown"},
         ),
         name="/warehouse/mydb.db/mytable",
     )
@@ -161,7 +161,7 @@ def test_extractors_extract_dataset_hive():
         location=LocationDTO(
             type="hive",
             name="test-hadoop:9083",
-            addresses=["hive://test-hadoop:9083"],
+            addresses={"hive://test-hadoop:9083"},
         ),
         name="mydb.mytable",
     )
@@ -191,7 +191,7 @@ def test_extractors_extract_dataset_hive_with_location_symlink():
         location=LocationDTO(
             type="hive",
             name="test-hadoop:9083",
-            addresses=["hive://test-hadoop:9083"],
+            addresses={"hive://test-hadoop:9083"},
         ),
         name="mydb.mytable",
     )
@@ -200,7 +200,7 @@ def test_extractors_extract_dataset_hive_with_location_symlink():
         location=LocationDTO(
             type="hdfs",
             name="test-hadoop:9820",
-            addresses=["hdfs://test-hadoop:9820"],
+            addresses={"hdfs://test-hadoop:9820"},
         ),
         name="/warehouse/mydb.db/mytable",
     )
@@ -223,7 +223,7 @@ def test_extractors_extract_dataset_postgres():
         location=LocationDTO(
             type="postgres",
             name="192.168.1.1:5432",
-            addresses=["postgres://192.168.1.1:5432"],
+            addresses={"postgres://192.168.1.1:5432"},
         ),
         name="mydb.myschema.mytable",
     )
@@ -241,7 +241,7 @@ def test_extractors_extract_dataset_kafka():
         location=LocationDTO(
             type="kafka",
             name="192.168.1.1:9092",
-            addresses=["kafka://192.168.1.1:9092", "kafka://192.168.1.2:9092"],
+            addresses={"kafka://192.168.1.1:9092", "kafka://192.168.1.2:9092"},
         ),
         name="mytopic",
     )
@@ -259,7 +259,7 @@ def test_extractors_extract_dataset_unknown():
         location=LocationDTO(
             type="unknown",
             name="some-namespace",
-            addresses=["unknown://some-namespace"],
+            addresses={"unknown://some-namespace"},
         ),
         name="some.name",
     )

--- a/tests/test_consumer/test_extractors/test_extractors_interaction.py
+++ b/tests/test_consumer/test_extractors/test_extractors_interaction.py
@@ -122,7 +122,7 @@ def test_extractors_extract_input(
             location=LocationDTO(
                 type="hdfs",
                 name="test-hadoop:9820",
-                addresses=["hdfs://test-hadoop:9820"],
+                addresses={"hdfs://test-hadoop:9820"},
             ),
         ),
         num_rows=row_count,
@@ -184,7 +184,7 @@ def test_extractors_extract_output(
             location=LocationDTO(
                 type="hdfs",
                 name="test-hadoop:9820",
-                addresses=["hdfs://test-hadoop:9820"],
+                addresses={"hdfs://test-hadoop:9820"},
             ),
         ),
         num_rows=row_count,

--- a/tests/test_consumer/test_extractors/test_extractors_job.py
+++ b/tests/test_consumer/test_extractors/test_extractors_job.py
@@ -23,7 +23,7 @@ def test_extractors_extract_job_spark_yarn():
     )
     assert extract_job(job) == JobDTO(
         name="myjob",
-        location=LocationDTO(type="yarn", name="cluster", addresses=["yarn://cluster"]),
+        location=LocationDTO(type="yarn", name="cluster", addresses={"yarn://cluster"}),
         type=JobTypeDTO.SPARK_APPLICATION,
     )
 
@@ -42,7 +42,7 @@ def test_extractors_extract_job_spark_local():
     )
     assert extract_job(job) == JobDTO(
         name="myjob",
-        location=LocationDTO(type="host", name="some.host.com", addresses=["host://some.host.com"]),
+        location=LocationDTO(type="host", name="some.host.com", addresses={"host://some.host.com"}),
         type=JobTypeDTO.SPARK_APPLICATION,
     )
 
@@ -64,7 +64,7 @@ def test_extractors_extract_job_airflow_dag():
         location=LocationDTO(
             type="http",
             name="airflow-host:8081",
-            addresses=["http://airflow-host:8081"],
+            addresses={"http://airflow-host:8081"},
         ),
         type=JobTypeDTO.AIRFLOW_DAG,
     )
@@ -87,7 +87,7 @@ def test_extractors_extract_job_airflow_task():
         location=LocationDTO(
             type="http",
             name="airflow-host:8081",
-            addresses=["http://airflow-host:8081"],
+            addresses={"http://airflow-host:8081"},
         ),
         type=JobTypeDTO.AIRFLOW_TASK,
     )
@@ -100,6 +100,6 @@ def test_extractors_extract_job_unknown():
         location=LocationDTO(
             type="unknown",
             name="something",
-            addresses=["unknown://something"],
+            addresses={"unknown://something"},
         ),
     )

--- a/tests/test_consumer/test_extractors/test_extractors_operation.py
+++ b/tests/test_consumer/test_extractors/test_extractors_operation.py
@@ -74,7 +74,7 @@ def test_extractors_extract_operation_spark_job_no_details():
                 location=LocationDTO(
                     type="unknown",
                     name="anything",
-                    addresses=["unknown://anything"],
+                    addresses={"unknown://anything"},
                 ),
             ),
         ),
@@ -159,7 +159,7 @@ def test_extractors_extract_operation_spark_job_with_details(
                 location=LocationDTO(
                     type="unknown",
                     name="anything",
-                    addresses=["unknown://anything"],
+                    addresses={"unknown://anything"},
                 ),
             ),
         ),
@@ -219,7 +219,7 @@ def test_extractors_extract_operation_spark_job_name_contains_newlines():
                 location=LocationDTO(
                     type="unknown",
                     name="anything",
-                    addresses=["unknown://anything"],
+                    addresses={"unknown://anything"},
                 ),
             ),
         ),
@@ -280,7 +280,7 @@ def test_extractors_extract_operation_spark_job_finished(
                 location=LocationDTO(
                     type="unknown",
                     name="anything",
-                    addresses=["unknown://anything"],
+                    addresses={"unknown://anything"},
                 ),
             ),
         ),

--- a/tests/test_consumer/test_extractors/test_extractors_run.py
+++ b/tests/test_consumer/test_extractors/test_extractors_run.py
@@ -82,7 +82,7 @@ def test_extractors_extract_run_spark_app_yarn():
         id=run_id,
         job=JobDTO(
             name="myjob",
-            location=LocationDTO(type="yarn", name="cluster", addresses=["yarn://cluster"]),
+            location=LocationDTO(type="yarn", name="cluster", addresses={"yarn://cluster"}),
             type=JobTypeDTO.SPARK_APPLICATION,
         ),
         status=RunStatusDTO.STARTED,
@@ -134,7 +134,7 @@ def test_extractors_extract_run_spark_app_local():
         id=run_id,
         job=JobDTO(
             name="myjob",
-            location=LocationDTO(type="host", name="some.host.com", addresses=["host://some.host.com"]),
+            location=LocationDTO(type="host", name="some.host.com", addresses={"host://some.host.com"}),
             type=JobTypeDTO.SPARK_APPLICATION,
         ),
         status=RunStatusDTO.STARTED,
@@ -193,7 +193,7 @@ def test_extractors_extract_run_airflow_dag_2_3_plus():
             location=LocationDTO(
                 type="http",
                 name="airflow-host:8081",
-                addresses=["http://airflow-host:8081"],
+                addresses={"http://airflow-host:8081"},
             ),
             type=JobTypeDTO.AIRFLOW_DAG,
         ),
@@ -256,7 +256,7 @@ def test_extractors_extract_run_airflow_dag_2_x():
             location=LocationDTO(
                 type="http",
                 name="airflow-host:8081",
-                addresses=["http://airflow-host:8081"],
+                addresses={"http://airflow-host:8081"},
             ),
             type=JobTypeDTO.AIRFLOW_DAG,
         ),
@@ -274,7 +274,7 @@ def test_extractors_extract_run_airflow_dag_2_x():
     )
 
 
-def test_extractors_extract_run_airflow_task_with_ti_log_url():
+def test_extractors_extract_run_airflow_task_with_ti_persistent_log_url():
     now = datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc)
     run_id = UUID("01908223-0e9b-7c52-9856-6cecfc842610")
     run = OpenLineageRunEvent(
@@ -328,7 +328,7 @@ def test_extractors_extract_run_airflow_task_with_ti_log_url():
             location=LocationDTO(
                 type="http",
                 name="airflow-host:8081",
-                addresses=["http://airflow-host:8081"],
+                addresses={"http://airflow-host:8081"},
             ),
             type=JobTypeDTO.AIRFLOW_TASK,
         ),
@@ -397,7 +397,7 @@ def test_extractors_extract_run_airflow_task_2_9_plus():
             location=LocationDTO(
                 type="http",
                 name="airflow-host:8081",
-                addresses=["http://airflow-host:8081"],
+                addresses={"http://airflow-host:8081"},
             ),
             type=JobTypeDTO.AIRFLOW_TASK,
         ),
@@ -461,7 +461,7 @@ def test_extractors_extract_run_airflow_task_2_x():
             location=LocationDTO(
                 type="http",
                 name="airflow-host:8081",
-                addresses=["http://airflow-host:8081"],
+                addresses={"http://airflow-host:8081"},
             ),
             type=JobTypeDTO.AIRFLOW_TASK,
         ),
@@ -505,7 +505,7 @@ def test_extractors_extract_run_unknown(event_type: OpenLineageRunEventType, exp
             location=LocationDTO(
                 type="unknown",
                 name="something",
-                addresses=["unknown://something"],
+                addresses={"unknown://something"},
             ),
         ),
         status=expected_status,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Make consumer fetching a list of OpenLineage events instead of fetching them one-by-one:
* Add DTO property `unique_key` and method `merge`. This allows tracking multiple versions of the same DTO, and then merge into one DTO having all the non-null fields. For example, all RunDTOs with same id are merged into one RunDTO with non-null created_at and ended_at, and so on.
* Add `BatchExtractResult` class which tracks each type of DTO, merges old items with new ones, and then allows to iterate other merged items.
* Move all extraction logic from consumer to dedicated function `extract_batch`. It iterates other list of OpenLineage events (e.g. sequence of STARTED+RUNNING+SUCCESS) into a final one (SUCCESS with started_at + ended_at + ...).
* Combine all DB logic inside consumer into one function which just iterates other `BatchExtractResult`, and creates all the extracted items in database. All cross-DTO links are resolved by `BatchExtractResult`. For example, when `dataset_dto.id = ...` is populated from database model, all InputDTOs and OutputDTOs with the same dataset got the same dataset id, which simplifies consumer logic.

This reduces the number of IO operations a lot - instead of sequence of INSERT+UPDATE+UPDATE+UPDATE+... statements, we perform only one INSERT/UPDATE per unique object. Consumer throughput increased from ~60RPS to ~540RPS (4 partitions, 4 parallel workers, 142k events).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
