### PR TITLE
[DOP-20958] Insert operations, inputs & outputs in one statement

### DIFF
--- a/data_rentgen/db/repositories/dataset.py
+++ b/data_rentgen/db/repositories/dataset.py
@@ -113,6 +113,7 @@ class DatasetRepository(Repository[Dataset]):
         return result
 
     async def _update(self, existing: Dataset, new: DatasetDTO) -> Dataset:
+        # almost of fields are immutable, so we can avoid UPDATE statements if row is unchanged
         if new.format:
             existing.format = new.format
             await self._session.flush([existing])

--- a/data_rentgen/db/repositories/dataset_symlink.py
+++ b/data_rentgen/db/repositories/dataset_symlink.py
@@ -54,6 +54,7 @@ class DatasetSymlinkRepository(Repository[DatasetSymlink]):
         return result
 
     async def _update(self, existing: DatasetSymlink, new: DatasetSymlinkDTO) -> DatasetSymlink:
+        # almost of fields are immutable, so we can avoid UPDATE statements if row is unchanged
         existing.type = DatasetSymlinkType(new.type)
         await self._session.flush([existing])
         return existing

--- a/data_rentgen/db/repositories/job.py
+++ b/data_rentgen/db/repositories/job.py
@@ -116,6 +116,7 @@ class JobRepository(Repository[Job]):
         return result
 
     async def _update(self, existing: Job, new: JobDTO) -> Job:
+        # almost of fields are immutable, so we can avoid UPDATE statements if row is unchanged
         if new.type:
             existing.type = JobType(new.type)
             await self._session.flush([existing])

--- a/data_rentgen/db/repositories/location.py
+++ b/data_rentgen/db/repositories/location.py
@@ -49,6 +49,7 @@ class LocationRepository(Repository[Location]):
     async def _update_addresses(self, existing: Location, new: LocationDTO) -> Location:
         existing_urls = {address.url for address in existing.addresses}
         new_urls = new.addresses - existing_urls
+        # in most cases, Location is unchanged, so we can avoid UPDATE statements
         if not new_urls:
             return existing
 

--- a/data_rentgen/db/repositories/run.py
+++ b/data_rentgen/db/repositories/run.py
@@ -37,7 +37,6 @@ class RunRepository(Repository[Run]):
 
         if not result:
             return await self._create(created_at, run)
-
         return await self._update(result, run)
 
     async def paginate(
@@ -183,6 +182,7 @@ class RunRepository(Repository[Run]):
         existing: Run,
         new: RunDTO,
     ) -> Run:
+        # for parent_run most of fields are None, so we can avoid UPDATE statements if row is unchanged
         optional_fields = {
             "status": Status(new.status) if new.status else None,
             "parent_run_id": new.parent_run.id if new.parent_run else None,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

* All evens for operation and related inputs & outputs are always send to the same Kafka topic - OpenLineage's default key is `parentRunId or runId`, and user can override it only for the entire Spark session, not specific operations. So instead of saving them row-by-row, we can generate one `INSERT ON CONFLICT UPDATE` statement with all data in the batch.
  For other entity types, it is not safe to bulk inserts as it may introduce deadlocks between parallel consumer workers.
* Sometimes parallel workers may insert new addresses to the location. This case wasn't covered with a proper lock, so the entire batch may fail due to conflict. Fixed.

Benchmarks were run in the same environment (4 FastStream workers, 4 Kafka partitions) and the amount of data (239k events, 632MB with ZSTD compression).

Before this change:
* Consuming all events: 6.6 min, ~600 RPS.
* Postgres network usage: 167MB (input) / 104MB (output).
* Postgres IO: 21.3MB (read) / 1.63GB (write)

After this change:
* Consuming all events: 5 min, ~790 RPS.
* Postgres network usage: 147MB (input) / 93MB (output).
* Postgres IO: 1.84MB (read) / 1.34GB (write)

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
