### PR TITLE
[DOP-21531] Set default direction to BOTH

### DIFF
--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -50,6 +50,7 @@ class BaseLineageQueryV1(BaseModel):
         examples=["2008-09-15T15:53:00+05:00"],
     )
     direction: LineageDirectionV1 = Field(
+        default=LineageDirectionV1.BOTH,
         description="Direction of the lineage",
         examples=["DOWNSTREAM", "UPSTREAM", "BOTH"],
     )
@@ -75,8 +76,8 @@ class BaseLineageQueryV1(BaseModel):
 class DatasetLineageQueryV1(BaseLineageQueryV1):
     start_node_id: int = Field(description="Dataset id", examples=[42])
     granularity: Literal["OPERATION", "RUN", "JOB"] = Field(
-        description="Granularity of the dataset lineage",
         default="RUN",
+        description="Granularity of the dataset lineage",
         examples=["OPERATION", "RUN", "JOB"],
     )
 
@@ -86,8 +87,8 @@ class DatasetLineageQueryV1(BaseLineageQueryV1):
 class JobLineageQueryV1(BaseLineageQueryV1):
     start_node_id: int = Field(description="Job id", examples=[42])
     granularity: Literal["JOB", "RUN"] = Field(
-        description="Granularity of the job lineage",
         default="JOB",
+        description="Granularity of the job lineage",
         examples=["JOB", "RUN"],
     )
 
@@ -99,8 +100,8 @@ class OperationLineageQueryV1(BaseLineageQueryV1):
 class RunLineageQueryV1(BaseLineageQueryV1):
     start_node_id: UUID = Field(description="Run id", examples=["00000000-0000-0000-0000-000000000000"])
     granularity: Literal["OPERATION", "RUN"] = Field(
-        description="Granularity of the run lineage",
         default="RUN",
+        description="Granularity of the run lineage",
         examples=["OPERATION", "RUN"],
     )
 

--- a/data_rentgen/server/services/lineage.py
+++ b/data_rentgen/server/services/lineage.py
@@ -31,8 +31,8 @@ class LineageServiceResult:
     operations: dict[UUID, Operation] = field(default_factory=dict)
     datasets: dict[int, Dataset] = field(default_factory=dict)
     dataset_symlinks: dict[tuple[int, int], DatasetSymlink] = field(default_factory=dict)
-    inputs: list[Input] = field(default_factory=list)
-    outputs: list[Output] = field(default_factory=list)
+    inputs: dict[tuple[int, int, UUID | None, UUID | None], Input] = field(default_factory=dict)
+    outputs: dict[tuple[int, int, UUID | None, UUID | None, str | None], Output] = field(default_factory=dict)
 
     def merge(self, other: "LineageServiceResult") -> "LineageServiceResult":
         self.jobs.update(other.jobs)
@@ -40,8 +40,8 @@ class LineageServiceResult:
         self.operations.update(other.operations)
         self.datasets.update(other.datasets)
         self.dataset_symlinks.update(other.dataset_symlinks)
-        self.inputs.extend(other.inputs)
-        self.outputs.extend(other.outputs)
+        self.inputs.update(other.inputs)
+        self.outputs.update(other.outputs)
         return self
 
 
@@ -134,8 +134,11 @@ class LineageService:
             jobs=jobs_by_id,
             runs=runs_by_id,
             operations=operations_by_id,
-            inputs=inputs,
-            outputs=outputs,
+            inputs={(input.dataset_id, input.job_id, input.run_id, input.operation_id): input for input in inputs},
+            outputs={
+                (output.dataset_id, output.job_id, output.run_id, output.operation_id, output.type): output
+                for output in outputs
+            },
         )
 
         dataset_ids = sorted(
@@ -238,8 +241,11 @@ class LineageService:
             jobs=jobs_by_id,
             runs=runs_by_id,
             operations=operations_by_id,
-            inputs=inputs,
-            outputs=outputs,
+            inputs={(input.dataset_id, input.job_id, input.run_id, input.operation_id): input for input in inputs},
+            outputs={
+                (output.dataset_id, output.job_id, output.run_id, output.operation_id, output.type): output
+                for output in outputs
+            },
         )
 
         dataset_ids = sorted(
@@ -330,8 +336,11 @@ class LineageService:
             jobs=jobs_by_id,
             runs=runs_by_id,
             operations=operations_by_id,
-            inputs=inputs,
-            outputs=outputs,
+            inputs={(input.dataset_id, input.job_id, input.run_id, input.operation_id): input for input in inputs},
+            outputs={
+                (output.dataset_id, output.job_id, output.run_id, output.operation_id, output.type): output
+                for output in outputs
+            },
         )
 
         dataset_ids = {input.dataset_id for input in inputs} | {output.dataset_id for output in outputs}
@@ -515,8 +524,11 @@ class LineageService:
         result = LineageServiceResult(
             datasets=datasets_by_id,
             dataset_symlinks=dataset_symlinks_by_id,
-            inputs=inputs,
-            outputs=outputs,
+            inputs={(input.dataset_id, input.job_id, input.run_id, input.operation_id): input for input in inputs},
+            outputs={
+                (output.dataset_id, output.job_id, output.run_id, output.operation_id, output.type): output
+                for output in outputs
+            },
         )
         operation_ids = {input.operation_id for input in inputs} | {output.operation_id for output in outputs}
         operation_ids_to_fetch = sorted(operation_ids - ids_to_skip.operations)
@@ -577,8 +589,11 @@ class LineageService:
         result = LineageServiceResult(
             datasets=datasets_by_id,
             dataset_symlinks=dataset_symlinks_by_id,
-            inputs=inputs,
-            outputs=outputs,
+            inputs={(input.dataset_id, input.job_id, input.run_id, input.operation_id): input for input in inputs},
+            outputs={
+                (output.dataset_id, output.job_id, output.run_id, output.operation_id, output.type): output
+                for output in outputs
+            },
         )
 
         run_ids = {input.run_id for input in inputs} | {output.run_id for output in outputs}
@@ -637,8 +652,11 @@ class LineageService:
         result = LineageServiceResult(
             datasets=datasets_by_id,
             dataset_symlinks=dataset_symlinks_by_id,
-            inputs=inputs,
-            outputs=outputs,
+            inputs={(input.dataset_id, input.job_id, input.run_id, input.operation_id): input for input in inputs},
+            outputs={
+                (output.dataset_id, output.job_id, output.run_id, output.operation_id, output.type): output
+                for output in outputs
+            },
         )
         ids_to_skip = ids_to_skip or IdsToSkip()
         job_ids = {input.job_id for input in inputs} | {output.job_id for output in outputs}

--- a/data_rentgen/server/utils/lineage_response.py
+++ b/data_rentgen/server/utils/lineage_response.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Iterable
+
 from data_rentgen.server.schemas.v1 import (
     DatasetResponseV1,
     JobResponseV1,
@@ -56,17 +58,17 @@ async def build_lineage_response(lineage: LineageServiceResult) -> LineageRespon
         )
         response.relations.append(relation)
 
-    input_relations = await _add_input_relations(lineage.inputs)
+    input_relations = await _add_input_relations(lineage.inputs.values())
     response.relations.extend(input_relations)
 
-    output_relations = await _add_output_relations(lineage.outputs)
+    output_relations = await _add_output_relations(lineage.outputs.values())
     response.relations.extend(output_relations)
 
     return response
 
 
 async def _add_input_relations(
-    inputs: list,
+    inputs: Iterable,
 ) -> list[LineageInputRelationV1]:
     relations = []
     for input in inputs:
@@ -89,7 +91,7 @@ async def _add_input_relations(
 
 
 async def _add_output_relations(
-    outputs: list,
+    outputs: Iterable,
 ) -> list[LineageOutputRelationV1]:
     relations = []
     for output in outputs:

--- a/tests/test_server/test_lineage/test_dataset_lineage.py
+++ b/tests/test_server/test_lineage/test_dataset_lineage.py
@@ -5,33 +5,23 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from data_rentgen.db.models import Dataset, Input, Job, Operation, Output, Run
-from data_rentgen.db.models.dataset_symlink import DatasetSymlink
+from data_rentgen.db.models import Dataset
 from tests.test_server.utils.enrich import enrich_datasets, enrich_jobs, enrich_runs
 from tests.test_server.utils.lineage_result import LineageResult
-from tests.test_server.utils.stats import (
-    relation_stats_by_jobs,
-    relation_stats_by_operations,
-    relation_stats_by_runs,
-)
+from tests.test_server.utils.stats import relation_stats_by_jobs, relation_stats_by_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio, pytest.mark.lineage]
 
-LINEAGE_FIXTURE_ANNOTATION = tuple[list[Job], list[Run], list[Operation], list[Dataset], list[Input], list[Output]]
 
-
-@pytest.mark.parametrize("direction", ["DOWNSTREAM", "UPSTREAM", "BOTH"])
 async def test_get_dataset_lineage_unknown_id(
     test_client: AsyncClient,
     new_dataset: Dataset,
-    direction: str,
 ):
     response = await test_client.get(
         "v1/datasets/lineage",
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "start_node_id": new_dataset.id,
-            "direction": direction,
         },
     )
 
@@ -42,19 +32,16 @@ async def test_get_dataset_lineage_unknown_id(
     }
 
 
-@pytest.mark.parametrize("direction", ["DOWNSTREAM", "UPSTREAM", "BOTH"])
 async def test_get_dataset_lineage_no_relations(
     test_client: AsyncClient,
     async_session: AsyncSession,
     dataset: Dataset,
-    direction: str,
 ):
     response = await test_client.get(
         "v1/datasets/lineage",
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "start_node_id": dataset.id,
-            "direction": direction,
         },
     )
 
@@ -85,31 +72,38 @@ async def test_get_dataset_lineage_no_relations(
 async def test_get_dataset_lineage_with_granularity_run(
     test_client: AsyncClient,
     async_session: AsyncSession,
-    simple_lineage: LineageResult,
+    three_days_lineage: LineageResult,
 ):
-    lineage = simple_lineage
-
-    dataset = lineage.datasets[0]
-    [dataset] = await enrich_datasets([dataset], async_session)
+    lineage = three_days_lineage
+    # We need a middle dataset, which has inputs and outputs
+    dataset = lineage.datasets[1]
 
     inputs = [input for input in lineage.inputs if input.dataset_id == dataset.id]
     input_stats = relation_stats_by_runs(inputs)
+    assert inputs
 
-    run_ids = {input.run_id for input in inputs}
+    outputs = [output for output in lineage.outputs if output.dataset_id == dataset.id]
+    output_stats = relation_stats_by_runs(outputs)
+    assert outputs
+
+    run_ids = {input.run_id for input in inputs} | {output.run_id for output in outputs}
     runs = [run for run in lineage.runs if run.id in run_ids]
+    assert runs
+
     job_ids = {run.job_id for run in runs}
     jobs = [job for job in lineage.jobs if job.id in job_ids]
+    assert jobs
 
+    [dataset] = await enrich_datasets([dataset], async_session)
     jobs = await enrich_jobs(jobs, async_session)
     runs = await enrich_runs(runs, async_session)
-
     since = min(run.created_at for run in runs)
+
     response = await test_client.get(
         "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
             "start_node_id": dataset.id,
-            "direction": "DOWNSTREAM",
         },
     )
 
@@ -126,16 +120,31 @@ async def test_get_dataset_lineage_with_granularity_run(
         + [
             {
                 "kind": "INPUT",
-                "from": {"kind": "DATASET", "id": dataset.id},
-                "to": {"kind": "RUN", "id": str(run.id)},
-                "num_bytes": input_stats[(run.id, dataset.id)]["num_bytes"],
-                "num_rows": input_stats[(run.id, dataset.id)]["num_rows"],
-                "num_files": input_stats[(run.id, dataset.id)]["num_files"],
-                "last_interaction_at": input_stats[(run.id, dataset.id)]["created_at"].strftime(
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "RUN", "id": str(input.run_id)},
+                "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for run in runs
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.run_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "RUN", "id": str(output.run_id)},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for output in sorted(outputs, key=lambda x: (x.run_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -194,33 +203,33 @@ async def test_get_dataset_lineage_with_granularity_run(
 async def test_get_dataset_lineage_with_granularity_job(
     test_client: AsyncClient,
     async_session: AsyncSession,
-    simple_lineage: LineageResult,
+    three_days_lineage: LineageResult,
 ):
-    lineage = simple_lineage
-
-    dataset = lineage.datasets[0]
-    [dataset] = await enrich_datasets([dataset], async_session)
+    lineage = three_days_lineage
+    # We need a middle dataset, which has inputs and outputs
+    dataset = lineage.datasets[1]
 
     inputs = [input for input in lineage.inputs if input.dataset_id == dataset.id]
     input_stats = relation_stats_by_jobs(inputs)
+    assert inputs
 
-    # Runs for since
-    run_ids = {input.run_id for input in inputs}
-    runs = [run for run in lineage.runs if run.id in run_ids]
+    outputs = [output for output in lineage.outputs if output.dataset_id == dataset.id]
+    output_stats = relation_stats_by_jobs(outputs)
+    assert outputs
 
-    job_ids = {input.job_id for input in inputs}
+    job_ids = {input.job_id for input in inputs} | {output.job_id for output in outputs}
     jobs = [job for job in lineage.jobs if job.id in job_ids]
+    assert jobs
 
+    [dataset] = await enrich_datasets([dataset], async_session)
     jobs = await enrich_jobs(jobs, async_session)
-    runs = await enrich_runs(runs, async_session)
+    since = min(run.created_at for run in lineage.runs)
 
-    since = min(run.created_at for run in runs)
     response = await test_client.get(
         "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
             "start_node_id": dataset.id,
-            "direction": "DOWNSTREAM",
             "granularity": "JOB",
         },
     )
@@ -230,16 +239,31 @@ async def test_get_dataset_lineage_with_granularity_job(
         "relations": [
             {
                 "kind": "INPUT",
-                "from": {"kind": "DATASET", "id": dataset.id},
-                "to": {"kind": "JOB", "id": job.id},
-                "num_bytes": input_stats[(job.id, dataset.id)]["num_bytes"],
-                "num_rows": input_stats[(job.id, dataset.id)]["num_rows"],
-                "num_files": input_stats[(job.id, dataset.id)]["num_files"],
-                "last_interaction_at": input_stats[(job.id, dataset.id)]["created_at"].strftime(
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "JOB", "id": input.job_id},
+                "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for job in jobs
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.job_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "JOB", "id": output.job_id},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for output in sorted(outputs, key=lambda x: (x.job_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -278,33 +302,40 @@ async def test_get_dataset_lineage_with_granularity_job(
 async def test_get_dataset_lineage_with_granularity_operation(
     test_client: AsyncClient,
     async_session: AsyncSession,
-    simple_lineage: LineageResult,
+    three_days_lineage: LineageResult,
 ):
-    lineage = simple_lineage
-
-    dataset = lineage.datasets[0]
-    [dataset] = await enrich_datasets([dataset], async_session)
+    lineage = three_days_lineage
+    # We need a middle dataset, which has inputs and outputs
+    dataset = lineage.datasets[1]
 
     inputs = [input for input in lineage.inputs if input.dataset_id == dataset.id]
-    input_stats = relation_stats_by_operations(inputs)
+    assert inputs
 
-    operation_ids = {input.operation_id for input in inputs}
+    outputs = [output for output in lineage.outputs if output.dataset_id == dataset.id]
+    assert outputs
+
+    operation_ids = {input.operation_id for input in inputs} | {output.operation_id for output in outputs}
     operations = [operation for operation in lineage.operations if operation.id in operation_ids]
+    assert operations
+
     run_ids = {operation.run_id for operation in operations}
     runs = [run for run in lineage.runs if run.id in run_ids]
+    assert runs
+
     job_ids = {run.job_id for run in runs}
     jobs = [job for job in lineage.jobs if job.id in job_ids]
+    assert jobs
 
+    [dataset] = await enrich_datasets([dataset], async_session)
     jobs = await enrich_jobs(jobs, async_session)
     runs = await enrich_runs(runs, async_session)
-
     since = min(run.created_at for run in runs)
+
     response = await test_client.get(
         "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
             "start_node_id": dataset.id,
-            "direction": "DOWNSTREAM",
             "granularity": "OPERATION",
         },
     )
@@ -330,16 +361,27 @@ async def test_get_dataset_lineage_with_granularity_operation(
         + [
             {
                 "kind": "INPUT",
-                "from": {"kind": "DATASET", "id": dataset.id},
-                "to": {"kind": "OPERATION", "id": str(operation.id)},
-                "num_bytes": input_stats[(operation.id, dataset.id)]["num_bytes"],
-                "num_rows": input_stats[(operation.id, dataset.id)]["num_rows"],
-                "num_files": input_stats[(operation.id, dataset.id)]["num_files"],
-                "last_interaction_at": input_stats[(operation.id, dataset.id)]["created_at"].strftime(
-                    "%Y-%m-%dT%H:%M:%S.%fZ",
-                ),
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "OPERATION", "id": str(input.operation_id)},
+                "num_bytes": input.num_bytes,
+                "num_rows": input.num_rows,
+                "num_files": input.num_files,
+                "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
-            for operation in operations
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.operation_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "OPERATION", "id": str(output.operation_id)},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output.num_bytes,
+                "num_rows": output.num_rows,
+                "num_files": output.num_files,
+                "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            }
+            for output in sorted(outputs, key=lambda x: (x.operation_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -412,37 +454,38 @@ async def test_get_dataset_lineage_with_granularity_operation(
     }
 
 
-async def test_get_dataset_lineage_with_direction_both(
+async def test_get_dataset_lineage_with_direction_downstream(
     test_client: AsyncClient,
     async_session: AsyncSession,
     three_days_lineage: LineageResult,
 ):
     lineage = three_days_lineage
-
     # We need a middle dataset, which has inputs and outputs
     dataset = lineage.datasets[1]
-    [dataset] = await enrich_datasets([dataset], async_session)
 
     inputs = [input for input in lineage.inputs if input.dataset_id == dataset.id]
     input_stats = relation_stats_by_runs(inputs)
-    outputs = [output for output in lineage.outputs if output.dataset_id == dataset.id]
-    output_stats = relation_stats_by_runs(outputs)
+    assert inputs
 
-    run_ids = {input.run_id for input in inputs} | {output.run_id for output in outputs}
+    run_ids = {input.run_id for input in inputs}
     runs = [run for run in lineage.runs if run.id in run_ids]
+    assert runs
+
     job_ids = {run.job_id for run in runs}
     jobs = [job for job in lineage.jobs if job.id in job_ids]
+    assert jobs
 
+    [dataset] = await enrich_datasets([dataset], async_session)
     jobs = await enrich_jobs(jobs, async_session)
     runs = await enrich_runs(runs, async_session)
+    since = min(input.created_at for input in inputs)
 
-    since = min(run.created_at for run in runs)
     response = await test_client.get(
         "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
             "start_node_id": dataset.id,
-            "direction": "BOTH",
+            "direction": "DOWNSTREAM",
         },
     )
 
@@ -459,31 +502,16 @@ async def test_get_dataset_lineage_with_direction_both(
         + [
             {
                 "kind": "INPUT",
-                "from": {"kind": "DATASET", "id": dataset.id},
-                "to": {"kind": "RUN", "id": str(run.id)},
-                "num_bytes": input_stats[(run.id, dataset.id)]["num_bytes"],
-                "num_rows": input_stats[(run.id, dataset.id)]["num_rows"],
-                "num_files": input_stats[(run.id, dataset.id)]["num_files"],
-                "last_interaction_at": input_stats[(run.id, dataset.id)]["created_at"].strftime(
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "RUN", "id": str(input.run_id)},
+                "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for run in runs
-        ]
-        + [
-            {
-                "kind": "OUTPUT",
-                "from": {"kind": "RUN", "id": str(run.id)},
-                "to": {"kind": "DATASET", "id": dataset.id},
-                "type": "APPEND",
-                "num_bytes": output_stats[(run.id, dataset.id)]["num_bytes"],
-                "num_rows": output_stats[(run.id, dataset.id)]["num_rows"],
-                "num_files": output_stats[(run.id, dataset.id)]["num_files"],
-                "last_interaction_at": output_stats[(run.id, dataset.id)]["created_at"].strftime(
-                    "%Y-%m-%dT%H:%M:%S.%fZ",
-                ),
-            }
-            for run in runs
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.run_id))
         ],
         "nodes": [
             {
@@ -539,41 +567,37 @@ async def test_get_dataset_lineage_with_direction_both(
     }
 
 
-async def test_get_dataset_lineage_with_direction_and_until_and_granularity_operation(
+async def test_get_dataset_lineage_with_direction_upstream(
     test_client: AsyncClient,
     async_session: AsyncSession,
-    simple_lineage: LineageResult,
+    three_days_lineage: LineageResult,
 ):
-    # TODO: This test need a separate fixture with this structure: D --> 01; D --> 02;
-    lineage = simple_lineage
+    lineage = three_days_lineage
+    # We need a middle dataset, which has inputs and outputs
+    dataset = lineage.datasets[1]
 
-    dataset = lineage.datasets[0]
-    [dataset] = await enrich_datasets([dataset], async_session)
-    since = min(run.created_at for run in lineage.runs)
-    until = since + timedelta(seconds=0.1)
+    outputs = [output for output in lineage.outputs if output.dataset_id == dataset.id]
+    output_stats = relation_stats_by_runs(outputs)
+    assert outputs
 
-    outputs = [
-        output for output in lineage.outputs if output.dataset_id == dataset.id and since <= output.created_at <= until
-    ]
-    output_stats = relation_stats_by_operations(outputs)
-
-    operation_ids = {output.operation_id for output in outputs}
-    operations = [operation for operation in lineage.operations if operation.id in operation_ids]
-    run_ids = {operation.run_id for operation in operations}
+    run_ids = {output.run_id for output in outputs}
     runs = [run for run in lineage.runs if run.id in run_ids]
+    assert runs
+
     job_ids = {run.job_id for run in runs}
     jobs = [job for job in lineage.jobs if job.id in job_ids]
+    assert jobs
 
+    [dataset] = await enrich_datasets([dataset], async_session)
     jobs = await enrich_jobs(jobs, async_session)
     runs = await enrich_runs(runs, async_session)
+    since = min(output.created_at for output in outputs)
 
     response = await test_client.get(
         "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
-            "until": until.isoformat(),
             "start_node_id": dataset.id,
-            "granularity": "OPERATION",
             "direction": "UPSTREAM",
         },
     )
@@ -590,26 +614,18 @@ async def test_get_dataset_lineage_with_direction_and_until_and_granularity_oper
         ]
         + [
             {
-                "kind": "PARENT",
-                "from": {"kind": "RUN", "id": str(operation.run_id)},
-                "to": {"kind": "OPERATION", "id": str(operation.id)},
-            }
-            for operation in operations
-        ]
-        + [
-            {
                 "kind": "OUTPUT",
-                "from": {"kind": "OPERATION", "id": str(operation.id)},
-                "to": {"kind": "DATASET", "id": dataset.id},
-                "type": "APPEND",
-                "num_bytes": output_stats[(operation.id, dataset.id)]["num_bytes"],
-                "num_rows": output_stats[(operation.id, dataset.id)]["num_rows"],
-                "num_files": output_stats[(operation.id, dataset.id)]["num_files"],
-                "last_interaction_at": output_stats[(operation.id, dataset.id)]["created_at"].strftime(
+                "from": {"kind": "RUN", "id": str(output.run_id)},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for operation in operations
+            for output in sorted(outputs, key=lambda x: (x.run_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -661,28 +677,148 @@ async def test_get_dataset_lineage_with_direction_and_until_and_granularity_oper
                 "end_reason": run.end_reason,
             }
             for run in sorted(runs, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "OPERATION",
-                "id": str(operation.id),
-                "created_at": operation.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "run_id": str(operation.run_id),
-                "name": operation.name,
-                "status": operation.status.name,
-                "type": operation.type.value,
-                "position": operation.position,
-                "group": operation.group,
-                "description": operation.description,
-                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            }
-            for operation in sorted(operations, key=lambda x: x.id)
         ],
     }
 
 
-async def test_get_dataset_lineage_with_depth_and_granularity_run(
+async def test_get_dataset_lineage_with_until(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    three_days_lineage: LineageResult,
+):
+    lineage = three_days_lineage
+    # We need a middle dataset, which has inputs and outputs
+    dataset = lineage.datasets[1]
+
+    inputs = [input for input in lineage.inputs if input.dataset_id == dataset.id]
+    outputs = [output for output in lineage.outputs if output.dataset_id == dataset.id]
+
+    since = min([input.created_at for input in inputs] + [output.created_at for output in outputs])
+    until = since + timedelta(seconds=0.1)
+
+    inputs = [input for input in inputs if since <= input.created_at <= until]
+    input_stats = relation_stats_by_runs(inputs)
+    assert inputs
+
+    outputs = [output for output in outputs if since <= output.created_at <= until]
+    output_stats = relation_stats_by_runs(outputs)
+    assert outputs
+
+    run_ids = {input.run_id for input in inputs} | {output.run_id for output in outputs}
+    runs = [run for run in lineage.runs if run.id in run_ids]
+    assert runs
+
+    job_ids = {run.job_id for run in runs}
+    jobs = [job for job in lineage.jobs if job.id in job_ids]
+    assert jobs
+
+    [dataset] = await enrich_datasets([dataset], async_session)
+    jobs = await enrich_jobs(jobs, async_session)
+    runs = await enrich_runs(runs, async_session)
+
+    response = await test_client.get(
+        "v1/datasets/lineage",
+        params={
+            "since": since.isoformat(),
+            "until": until.isoformat(),
+            "start_node_id": dataset.id,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+            }
+            for run in runs
+        ]
+        + [
+            {
+                "kind": "INPUT",
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "RUN", "id": str(input.run_id)},
+                "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.run_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "RUN", "id": str(output.run_id)},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for output in sorted(outputs, key=lambda x: (x.run_id, x.dataset_id))
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "type": job.type,
+                "location": {
+                    "id": job.location.id,
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                    "external_id": job.location.external_id,
+                },
+            }
+            for job in sorted(jobs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "id": dataset.location.id,
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                    "external_id": dataset.location.external_id,
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.name,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ],
+    }
+
+
+async def test_get_dataset_lineage_with_depth(
     test_client: AsyncClient,
     async_session: AsyncSession,
     lineage_with_depth: LineageResult,
@@ -696,46 +832,61 @@ async def test_get_dataset_lineage_with_depth_and_granularity_run(
     # Go dataset -> runs[first level]
     first_level_dataset = lineage.datasets[0]
     first_level_inputs = [input for input in lineage.inputs if input.dataset_id == first_level_dataset.id]
-    first_level_run_ids = {input.run_id for input in first_level_inputs}
+    first_level_outputs = [output for output in lineage.outputs if output.dataset_id == first_level_dataset.id]
+    first_level_input_run_ids = {input.run_id for input in first_level_inputs}
+    first_level_output_run_ids = {output.run_id for output in first_level_outputs}
+    first_level_run_ids = first_level_input_run_ids | first_level_output_run_ids
     assert first_level_run_ids
 
     # Go runs[first level] -> datasets[second level]
-    second_level_outputs = [output for output in lineage.outputs if output.run_id in first_level_run_ids]
-    second_level_dataset_ids = {output.dataset_id for output in second_level_outputs} - {first_level_dataset.id}
+    second_level_inputs = [input for input in lineage.inputs if input.run_id in first_level_output_run_ids]
+    second_level_outputs = [output for output in lineage.outputs if output.run_id in first_level_input_run_ids]
+    second_level_input_dataset_ids = {input.dataset_id for input in second_level_inputs}
+    second_level_output_dataset_ids = {output.dataset_id for output in second_level_outputs}
+    second_level_dataset_ids = second_level_input_dataset_ids | second_level_output_dataset_ids - {
+        first_level_dataset.id,
+    }
     assert second_level_dataset_ids
 
     # Go datasets[second level] -> runs[third level]
     # There are more levels in this graph, but we stop here
-    third_level_inputs = [input for input in lineage.inputs if input.dataset_id in second_level_dataset_ids]
-    assert third_level_inputs
-    third_level_run_ids = {output.run_id for output in third_level_inputs} - first_level_run_ids
+    third_level_inputs = [input for input in lineage.inputs if input.dataset_id in second_level_output_dataset_ids]
+    third_level_outputs = [output for output in lineage.outputs if output.dataset_id in second_level_input_dataset_ids]
+    third_level_input_run_ids = {input.run_id for input in third_level_inputs}
+    third_level_output_run_ids = {output.run_id for output in third_level_outputs}
+    third_level_run_ids = third_level_input_run_ids | third_level_output_run_ids - first_level_run_ids
     assert third_level_run_ids
 
-    inputs = first_level_inputs + third_level_inputs
+    inputs = first_level_inputs + second_level_inputs + third_level_inputs
     input_stats = relation_stats_by_runs(inputs)
-    outputs = second_level_outputs
+    assert inputs
+
+    outputs = first_level_outputs + second_level_outputs + third_level_outputs
     output_stats = relation_stats_by_runs(outputs)
+    assert outputs
 
     dataset_ids = {first_level_dataset.id} | second_level_dataset_ids
     datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
 
     run_ids = first_level_run_ids | third_level_run_ids
     runs = [run for run in lineage.runs if run.id in run_ids]
+    assert runs
 
     job_ids = {run.job_id for run in runs}
     jobs = [job for job in lineage.jobs if job.id in job_ids]
+    assert jobs
 
     jobs = await enrich_jobs(jobs, async_session)
     runs = await enrich_runs(runs, async_session)
     datasets = await enrich_datasets(datasets, async_session)
-
     since = min(run.created_at for run in runs)
+
     response = await test_client.get(
         "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
             "start_node_id": first_level_dataset.id,
-            "direction": "DOWNSTREAM",
             "depth": 3,
         },
     )
@@ -762,14 +913,14 @@ async def test_get_dataset_lineage_with_depth_and_granularity_run(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for input in inputs
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.run_id))
         ]
         + [
             {
                 "kind": "OUTPUT",
                 "from": {"kind": "RUN", "id": str(output.run_id)},
                 "to": {"kind": "DATASET", "id": output.dataset_id},
-                "type": "APPEND",
+                "type": output.type,
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
@@ -777,7 +928,7 @@ async def test_get_dataset_lineage_with_depth_and_granularity_run(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for output in outputs
+            for output in sorted(outputs, key=lambda x: (x.run_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -848,43 +999,53 @@ async def test_get_dataset_lineage_with_depth_and_granularity_job(
     # Go dataset[first level] -> jobs[first level]
     first_level_dataset = lineage.datasets[0]
     first_level_inputs = [input for input in lineage.inputs if input.dataset_id == first_level_dataset.id]
-    assert first_level_inputs
-    first_level_job_ids = {input.job_id for input in first_level_inputs}
+    first_level_outputs = [output for output in lineage.outputs if output.dataset_id == first_level_dataset.id]
+    first_level_input_job_ids = {input.job_id for input in first_level_inputs}
+    first_level_output_job_ids = {output.job_id for output in first_level_outputs}
+    first_level_job_ids = first_level_input_job_ids | first_level_output_job_ids
     assert first_level_job_ids
 
     # Go job[first level] -> datasets[second level]
-    second_level_outputs = [output for output in lineage.outputs if output.job_id in first_level_job_ids]
-    assert second_level_outputs
-    second_level_dataset_ids = {output.dataset_id for output in second_level_outputs}
+    second_level_inputs = [input for input in lineage.inputs if input.job_id in first_level_output_job_ids]
+    second_level_outputs = [output for output in lineage.outputs if output.job_id in first_level_input_job_ids]
+    second_level_input_dataset_ids = {input.dataset_id for input in second_level_inputs}
+    second_level_output_dataset_ids = {output.dataset_id for output in second_level_outputs}
+    second_level_dataset_ids = second_level_input_dataset_ids | second_level_output_dataset_ids
     assert second_level_dataset_ids
 
     # Go datasets[second level] -> jobs[third level]
-    third_level_inputs = [input for input in lineage.inputs if input.dataset_id in second_level_dataset_ids]
-    assert third_level_inputs
-    third_level_job_ids = {input.job_id for input in third_level_inputs} - first_level_job_ids
+    third_level_inputs = [input for input in lineage.inputs if input.dataset_id in second_level_output_dataset_ids]
+    third_level_outputs = [output for output in lineage.outputs if output.dataset_id in second_level_input_dataset_ids]
+    third_level_input_job_ids = {input.job_id for input in third_level_inputs}
+    third_level_output_job_ids = {output.job_id for output in third_level_outputs}
+    third_level_job_ids = third_level_input_job_ids | third_level_output_job_ids - first_level_job_ids
     assert third_level_job_ids
 
-    outputs = second_level_outputs
-    output_stats = relation_stats_by_jobs(outputs)
-    inputs = first_level_inputs + third_level_inputs
+    inputs = first_level_inputs + second_level_inputs + third_level_inputs
     input_stats = relation_stats_by_jobs(inputs)
+    assert inputs
+
+    outputs = first_level_outputs + second_level_outputs + third_level_outputs
+    output_stats = relation_stats_by_jobs(outputs)
+    assert outputs
 
     dataset_ids = {first_level_dataset.id} | second_level_dataset_ids
     datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
 
     job_ids = first_level_job_ids | third_level_job_ids
     jobs = [job for job in lineage.jobs if job.id in job_ids]
+    assert jobs
 
-    jobs = await enrich_jobs(jobs, async_session)
     datasets = await enrich_datasets(datasets, async_session)
+    jobs = await enrich_jobs(jobs, async_session)
+    since = min(run.created_at for run in lineage.runs if run.job_id in job_ids)
 
-    since = min(run.created_at for run in lineage.runs)
     response = await test_client.get(
         "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
             "start_node_id": first_level_dataset.id,
-            "direction": "DOWNSTREAM",
             "depth": 3,
             "granularity": "JOB",
         },
@@ -904,14 +1065,14 @@ async def test_get_dataset_lineage_with_depth_and_granularity_job(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for input in inputs
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.job_id))
         ]
         + [
             {
                 "kind": "OUTPUT",
                 "from": {"kind": "JOB", "id": output.job_id},
                 "to": {"kind": "DATASET", "id": output.dataset_id},
-                "type": "APPEND",
+                "type": output.type,
                 "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
@@ -919,7 +1080,7 @@ async def test_get_dataset_lineage_with_depth_and_granularity_job(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for output in outputs
+            for output in sorted(outputs, key=lambda x: (x.job_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -963,57 +1124,71 @@ async def test_get_dataset_lineage_with_depth_and_granularity_operation(
 ):
     lineage = lineage_with_depth
     # Select only relations marked with *
-    # J1 -*> R1 -*> O1, D1 *-> O1 -*> D2
+    # J1 -*> R1 -*> O1, D1 -*> O1 -*> D2
     # J2 -*> R2 -*> O2, D2 -*> O2 --> D3
     # J3 --> R3 --> O3, D3 --> O3 --> D4
 
     # Go datasets[first level] -> operations[first level] + runs[first level] + jobs[first level]
     first_level_dataset = lineage.datasets[0]
     first_level_inputs = [input for input in lineage.inputs if input.dataset_id == first_level_dataset.id]
-    assert first_level_inputs
-    first_level_operation_ids = {input.operation_id for input in first_level_inputs}
+    first_level_outputs = [output for output in lineage.outputs if output.dataset_id == first_level_dataset.id]
+    first_level_input_operation_ids = {input.operation_id for input in first_level_inputs}
+    first_level_output_operation_ids = {output.operation_id for output in first_level_outputs}
+    first_level_operation_ids = first_level_input_operation_ids | first_level_output_operation_ids
     assert first_level_operation_ids
 
     # Go operations[first level] -> datasets[second level]
-    second_level_outputs = [output for output in lineage.outputs if output.operation_id in first_level_operation_ids]
-    assert second_level_outputs
-    second_level_dataset_ids = {output.dataset_id for output in second_level_outputs}
+    second_level_inputs = [input for input in lineage.inputs if input.operation_id in first_level_output_operation_ids]
+    second_level_outputs = [
+        output for output in lineage.outputs if output.operation_id in first_level_input_operation_ids
+    ]
+    second_level_input_dataset_ids = {input.dataset_id for input in second_level_inputs}
+    second_level_output_dataset_ids = {output.dataset_id for output in second_level_outputs}
+    second_level_dataset_ids = second_level_input_dataset_ids | second_level_output_dataset_ids
     assert second_level_dataset_ids
 
     # Go datasets[second level] -> operations[third level] + runs[third level] + jobs[third level]
-    third_level_inputs = [input for input in lineage.inputs if input.dataset_id in second_level_dataset_ids]
-    assert third_level_inputs
-    third_level_operation_ids = {input.operation_id for input in third_level_inputs} - first_level_operation_ids
+    third_level_inputs = [input for input in lineage.inputs if input.dataset_id in second_level_output_dataset_ids]
+    third_level_outputs = [output for output in lineage.outputs if output.dataset_id in second_level_input_dataset_ids]
+    third_level_input_operation_ids = {input.operation_id for input in third_level_inputs}
+    third_level_output_operation_ids = {output.operation_id for output in third_level_outputs}
+    third_level_operation_ids = (
+        third_level_input_operation_ids | third_level_output_operation_ids - first_level_operation_ids
+    )
     assert third_level_operation_ids
 
-    outputs = second_level_outputs
-    output_stats = relation_stats_by_operations(outputs)
-    inputs = first_level_inputs + third_level_inputs
-    input_stats = relation_stats_by_operations(inputs)
+    inputs = first_level_inputs + second_level_inputs + third_level_inputs
+    assert inputs
+
+    outputs = first_level_outputs + second_level_outputs + third_level_outputs
+    assert outputs
 
     dataset_ids = {first_level_dataset.id} | second_level_dataset_ids
     datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
 
     operation_ids = first_level_operation_ids | third_level_operation_ids
     operations = [operation for operation in lineage.operations if operation.id in operation_ids]
+    assert operations
 
     run_ids = {input.run_id for input in inputs}
     runs = [run for run in lineage.runs if run.id in run_ids]
+    assert runs
 
     job_ids = {input.job_id for input in inputs}
     jobs = [job for job in lineage.jobs if job.id in job_ids]
+    assert jobs
 
     datasets = await enrich_datasets(datasets, async_session)
     runs = await enrich_runs(runs, async_session)
     jobs = await enrich_jobs(jobs, async_session)
-
     since = min(run.created_at for run in runs)
+
     response = await test_client.get(
         "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
             "start_node_id": first_level_dataset.id,
-            "direction": "DOWNSTREAM",
             "depth": 3,
             "granularity": "OPERATION",
         },
@@ -1042,12 +1217,10 @@ async def test_get_dataset_lineage_with_depth_and_granularity_operation(
                 "kind": "INPUT",
                 "from": {"kind": "DATASET", "id": input.dataset_id},
                 "to": {"kind": "OPERATION", "id": str(input.operation_id)},
-                "num_bytes": input_stats[(input.operation_id, input.dataset_id)]["num_bytes"],
-                "num_rows": input_stats[(input.operation_id, input.dataset_id)]["num_rows"],
-                "num_files": input_stats[(input.operation_id, input.dataset_id)]["num_files"],
-                "last_interaction_at": input_stats[(input.operation_id, input.dataset_id)]["created_at"].strftime(
-                    "%Y-%m-%dT%H:%M:%S.%fZ",
-                ),
+                "num_bytes": input.num_bytes,
+                "num_rows": input.num_rows,
+                "num_files": input.num_files,
+                "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for input in sorted(inputs, key=lambda x: (x.dataset_id, x.operation_id))
         ]
@@ -1056,13 +1229,11 @@ async def test_get_dataset_lineage_with_depth_and_granularity_operation(
                 "kind": "OUTPUT",
                 "from": {"kind": "OPERATION", "id": str(output.operation_id)},
                 "to": {"kind": "DATASET", "id": output.dataset_id},
-                "type": "APPEND",
-                "num_bytes": output_stats[(output.operation_id, output.dataset_id)]["num_bytes"],
-                "num_rows": output_stats[(output.operation_id, output.dataset_id)]["num_rows"],
-                "num_files": output_stats[(output.operation_id, output.dataset_id)]["num_files"],
-                "last_interaction_at": output_stats[(output.operation_id, output.dataset_id)]["created_at"].strftime(
-                    "%Y-%m-%dT%H:%M:%S.%fZ",
-                ),
+                "type": output.type,
+                "num_bytes": output.num_bytes,
+                "num_rows": output.num_rows,
+                "num_files": output.num_files,
+                "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for output in sorted(outputs, key=lambda x: (x.operation_id, x.dataset_id))
         ],
@@ -1138,30 +1309,32 @@ async def test_get_dataset_lineage_with_depth_and_granularity_operation(
     }
 
 
-async def test_get_dataset_lineage_with_depth_and_granularity_run_ignore_cycles(
+async def test_get_dataset_lineage_with_depth_ignore_run_cycles(
     test_client: AsyncClient,
     async_session: AsyncSession,
     lineage_with_depth_and_cycle: LineageResult,
 ):
     lineage = lineage_with_depth_and_cycle
+    # Select all relations:
+    # J1 -*> R1 -*> O1, D1 -*> O1 -*> D2
+    # J2 -*> R2 -*> O2, D2 -*> O2 -*> D1
 
-    # The there is a cycle dataset -> operation, so there is only one level of lineage.
-    # All relations should be in the response, without duplicates.
+    # We can start at any dataset
+    dataset = lineage.datasets[0]
+
+    input_stats = relation_stats_by_runs(lineage.inputs)
+    output_stats = relation_stats_by_runs(lineage.outputs)
+
+    datasets = await enrich_datasets(lineage.datasets, async_session)
     jobs = await enrich_jobs(lineage.jobs, async_session)
     runs = await enrich_runs(lineage.runs, async_session)
-    [dataset] = await enrich_datasets(lineage.datasets, async_session)
-    inputs = [input for input in lineage.inputs if input.dataset_id == dataset.id]
-    input_stats = relation_stats_by_runs(inputs)
-    outputs = [output for output in lineage.outputs if output.dataset_id == dataset.id]
-    output_stats = relation_stats_by_runs(outputs)
-
     since = min(run.created_at for run in runs)
+
     response = await test_client.get(
         "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
             "start_node_id": dataset.id,
-            "direction": "DOWNSTREAM",
             "depth": 3,
         },
     )
@@ -1179,31 +1352,31 @@ async def test_get_dataset_lineage_with_depth_and_granularity_run_ignore_cycles(
         + [
             {
                 "kind": "INPUT",
-                "from": {"kind": "DATASET", "id": dataset.id},
-                "to": {"kind": "RUN", "id": str(run.id)},
-                "num_bytes": input_stats[(run.id, dataset.id)]["num_bytes"],
-                "num_rows": input_stats[(run.id, dataset.id)]["num_rows"],
-                "num_files": input_stats[(run.id, dataset.id)]["num_files"],
-                "last_interaction_at": input_stats[(run.id, dataset.id)]["created_at"].strftime(
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "RUN", "id": str(input.run_id)},
+                "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for run in sorted(runs, key=lambda x: x.id)
+            for input in sorted(lineage.inputs, key=lambda x: (x.dataset_id, x.run_id))
         ]
         + [
             {
                 "kind": "OUTPUT",
-                "from": {"kind": "RUN", "id": str(run.id)},
-                "to": {"kind": "DATASET", "id": dataset.id},
-                "type": "APPEND",
-                "num_bytes": output_stats[(run.id, dataset.id)]["num_bytes"],
-                "num_rows": output_stats[(run.id, dataset.id)]["num_rows"],
-                "num_files": output_stats[(run.id, dataset.id)]["num_files"],
-                "last_interaction_at": output_stats[(run.id, dataset.id)]["created_at"].strftime(
+                "from": {"kind": "RUN", "id": str(output.run_id)},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for run in sorted(runs, key=lambda x: x.id)
+            for output in sorted(lineage.outputs, key=lambda x: (x.run_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -1234,7 +1407,8 @@ async def test_get_dataset_lineage_with_depth_and_granularity_run_ignore_cycles(
                     "addresses": [{"url": address.url} for address in dataset.location.addresses],
                     "external_id": dataset.location.external_id,
                 },
-            },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
         ]
         + [
             {
@@ -1259,153 +1433,7 @@ async def test_get_dataset_lineage_with_depth_and_granularity_run_ignore_cycles(
     }
 
 
-async def test_get_dataset_lineage_with_depth_and_granularity_operation_ignore_cycles(
-    test_client: AsyncClient,
-    async_session: AsyncSession,
-    lineage_with_depth_and_cycle: LineageResult,
-):
-    # TODO: Maybe for this test we need another fixture
-    lineage = lineage_with_depth_and_cycle
-
-    # The there is a cycle dataset -> operation, so there is only one level of lineage.
-    # All relations should be in the response, without duplicates.
-    jobs = await enrich_jobs(lineage.jobs, async_session)
-    runs = await enrich_runs(lineage.runs, async_session)
-    [dataset] = await enrich_datasets(lineage.datasets, async_session)
-    input_stats = relation_stats_by_operations(lineage.inputs)
-    output_stats = relation_stats_by_operations(lineage.outputs)
-
-    since = min(run.created_at for run in runs)
-    response = await test_client.get(
-        "v1/datasets/lineage",
-        params={
-            "since": since.isoformat(),
-            "start_node_id": dataset.id,
-            "direction": "DOWNSTREAM",
-            "granularity": "OPERATION",
-            "depth": 3,
-        },
-    )
-
-    assert response.status_code == HTTPStatus.OK, response.json()
-    assert response.json() == {
-        "relations": [
-            {
-                "kind": "PARENT",
-                "from": {"kind": "JOB", "id": run.job_id},
-                "to": {"kind": "RUN", "id": str(run.id)},
-            }
-            for run in sorted(runs, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "PARENT",
-                "from": {"kind": "RUN", "id": str(operation.run_id)},
-                "to": {"kind": "OPERATION", "id": str(operation.id)},
-            }
-            for operation in sorted(lineage.operations, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "INPUT",
-                "from": {"kind": "DATASET", "id": dataset.id},
-                "to": {"kind": "OPERATION", "id": str(operation.id)},
-                "num_bytes": input_stats[(operation.id, dataset.id)]["num_bytes"],
-                "num_rows": input_stats[(operation.id, dataset.id)]["num_rows"],
-                "num_files": input_stats[(operation.id, dataset.id)]["num_files"],
-                "last_interaction_at": input_stats[(operation.id, dataset.id)]["created_at"].strftime(
-                    "%Y-%m-%dT%H:%M:%S.%fZ",
-                ),
-            }
-            for operation in sorted(lineage.operations, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "OUTPUT",
-                "from": {"kind": "OPERATION", "id": str(operation.id)},
-                "to": {"kind": "DATASET", "id": dataset.id},
-                "type": "APPEND",
-                "num_bytes": output_stats[(operation.id, dataset.id)]["num_bytes"],
-                "num_rows": output_stats[(operation.id, dataset.id)]["num_rows"],
-                "num_files": output_stats[(operation.id, dataset.id)]["num_files"],
-                "last_interaction_at": output_stats[(operation.id, dataset.id)]["created_at"].strftime(
-                    "%Y-%m-%dT%H:%M:%S.%fZ",
-                ),
-            }
-            for operation in sorted(lineage.operations, key=lambda x: x.id)
-        ],
-        "nodes": [
-            {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "name": job.location.name,
-                    "type": job.location.type,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
-                },
-            }
-            for job in sorted(jobs, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
-                },
-            },
-        ]
-        + [
-            {
-                "kind": "RUN",
-                "id": str(run.id),
-                "job_id": run.job_id,
-                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "parent_run_id": str(run.parent_run_id),
-                "status": run.status.name,
-                "external_id": run.external_id,
-                "attempt": run.attempt,
-                "persistent_log_url": run.persistent_log_url,
-                "running_log_url": run.running_log_url,
-                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "started_by_user": {"name": run.started_by_user.name},
-                "start_reason": run.start_reason.value,
-                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "end_reason": run.end_reason,
-            }
-            for run in sorted(runs, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "OPERATION",
-                "id": str(operation.id),
-                "created_at": operation.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "run_id": str(operation.run_id),
-                "name": operation.name,
-                "status": operation.status.name,
-                "type": operation.type.value,
-                "position": operation.position,
-                "group": operation.group,
-                "description": operation.description,
-                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            }
-            for operation in sorted(lineage.operations, key=lambda x: x.id)
-        ],
-    }
-
-
-async def test_get_dataset_lineage_with_symlink_and_granularity_run(
+async def test_get_dataset_lineage_with_symlink(
     test_client: AsyncClient,
     async_session: AsyncSession,
     lineage_with_symlinks: LineageResult,
@@ -1427,10 +1455,14 @@ async def test_get_dataset_lineage_with_symlink_and_granularity_run(
 
     # Threat all datasets from symlinks like they were passed as `start_node_id`
     inputs = [input for input in lineage.inputs if input.dataset_id in dataset_ids]
-    assert inputs
     input_stats = relation_stats_by_runs(inputs)
+    assert inputs
 
-    operation_ids = {input.operation_id for input in inputs}
+    outputs = [output for output in lineage.outputs if output.dataset_id in dataset_ids]
+    output_stats = relation_stats_by_runs(outputs)
+    assert outputs
+
+    operation_ids = {input.operation_id for input in inputs} | {output.operation_id for output in outputs}
     operations = [operation for operation in lineage.operations if operation.id in operation_ids]
     assert operations
 
@@ -1442,17 +1474,16 @@ async def test_get_dataset_lineage_with_symlink_and_granularity_run(
     jobs = [job for job in lineage.jobs if job.id in job_ids]
     assert jobs
 
+    datasets = await enrich_datasets(datasets, async_session)
     jobs = await enrich_jobs(jobs, async_session)
     runs = await enrich_runs(runs, async_session)
-    datasets = await enrich_datasets(datasets, async_session)
-
     since = min(run.created_at for run in runs)
+
     response = await test_client.get(
         "v1/datasets/lineage",
         params={
             "since": since.isoformat(),
             "start_node_id": initial_dataset.id,
-            "direction": "DOWNSTREAM",
         },
     )
 
@@ -1487,7 +1518,22 @@ async def test_get_dataset_lineage_with_symlink_and_granularity_run(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for input in inputs
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.run_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "RUN", "id": str(output.run_id)},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for output in sorted(outputs, key=lambda x: (x.run_id, x.dataset_id))
         ],
         "nodes": [
             {

--- a/tests/test_server/test_lineage/test_get_lineage_request_validators.py
+++ b/tests/test_server/test_lineage/test_get_lineage_request_validators.py
@@ -10,7 +10,7 @@ pytestmark = [pytest.mark.server, pytest.mark.asyncio, pytest.mark.lineage]
 
 
 @pytest.mark.parametrize(
-    "entity_kind,granularity",
+    ["entity_kind", "granularity"],
     [
         ("operations", None),
         ("datasets", "RUN"),
@@ -26,21 +26,14 @@ async def test_get_lineage_no_filter(test_client: AsyncClient, entity_kind: str,
                 {
                     "code": "missing",
                     "context": {},
-                    "input": {"depth": 1},
+                    "input": {"depth": 1, "direction": "BOTH"},
                     "location": ["query", "since"],
                     "message": "Field required",
                 },
                 {
                     "code": "missing",
                     "context": {},
-                    "input": {"depth": 1},
-                    "location": ["query", "direction"],
-                    "message": "Field required",
-                },
-                {
-                    "code": "missing",
-                    "context": {},
-                    "input": {"depth": 1},
+                    "input": {"depth": 1, "direction": "BOTH"},
                     "location": ["query", "start_node_id"],
                     "message": "Field required",
                 },
@@ -79,7 +72,6 @@ async def test_get_lineage_missing_id(
         params={
             "since": since.isoformat(),
             "start_node_id": start_node_id,
-            "direction": "DOWNSTREAM",
         },
     )
 
@@ -106,7 +98,6 @@ async def test_get_lineage_start_node_id_int_type_validation(
         params={
             "since": since.isoformat(),
             "start_node_id": start_node_id,
-            "direction": "DOWNSTREAM",
         },
     )
 
@@ -123,7 +114,7 @@ async def test_get_lineage_start_node_id_int_type_validation(
                         "query",
                         "start_node_id",
                     ],
-                    "message": f"Input should be a valid integer, unable to parse string as an integer",
+                    "message": "Input should be a valid integer, unable to parse string as an integer",
                 },
             ],
             "message": "Invalid request",
@@ -147,7 +138,6 @@ async def test_get_lineage_start_node_id_uuid_type_validation(
         params={
             "since": since.isoformat(),
             "start_node_id": start_node_id,
-            "direction": "DOWNSTREAM",
         },
     )
 
@@ -182,7 +172,6 @@ async def test_get_lineage_until_less_than_since(test_client: AsyncClient):
             "since": since.isoformat(),
             "until": until.isoformat(),
             "start_node_id": str(generate_new_uuid()),
-            "direction": "DOWNSTREAM",
         },
     )
 
@@ -225,7 +214,6 @@ async def test_get_lineage_depth_out_of_bounds(
         params={
             "since": since.isoformat(),
             "start_node_id": str(generate_new_uuid()),
-            "direction": "DOWNSTREAM",
             "depth": depth,
         },
     )

--- a/tests/test_server/test_lineage/test_job_lineage.py
+++ b/tests/test_server/test_lineage/test_job_lineage.py
@@ -8,23 +8,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from data_rentgen.db.models import Job, Run
 from tests.test_server.utils.enrich import enrich_datasets, enrich_jobs, enrich_runs
 from tests.test_server.utils.lineage_result import LineageResult
-from tests.test_server.utils.stats import relation_stats, relation_stats_by_jobs
+from tests.test_server.utils.stats import relation_stats_by_jobs, relation_stats_by_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio, pytest.mark.lineage]
 
 
-@pytest.mark.parametrize("direction", ["DOWNSTREAM", "UPSTREAM", "BOTH"])
 async def test_get_job_lineage_unknown_id(
     test_client: AsyncClient,
     new_job: Job,
-    direction: str,
 ):
     response = await test_client.get(
         "v1/jobs/lineage",
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "start_node_id": new_job.id,
-            "direction": direction,
         },
     )
 
@@ -35,19 +32,16 @@ async def test_get_job_lineage_unknown_id(
     }
 
 
-@pytest.mark.parametrize("direction", ["DOWNSTREAM", "UPSTREAM", "BOTH"])
 async def test_get_job_lineage_no_runs(
     test_client: AsyncClient,
     async_session: AsyncSession,
     job: Job,
-    direction: str,
 ):
     response = await test_client.get(
         "v1/jobs/lineage",
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "start_node_id": job.id,
-            "direction": direction,
         },
     )
 
@@ -75,20 +69,17 @@ async def test_get_job_lineage_no_runs(
     }
 
 
-@pytest.mark.parametrize("direction", ["DOWNSTREAM", "UPSTREAM", "BOTH"])
 async def test_get_job_lineage_no_operations(
     test_client: AsyncClient,
     async_session: AsyncSession,
     job: Job,
     run: Run,
-    direction: str,
 ):
     response = await test_client.get(
         "v1/jobs/lineage",
         params={
             "since": run.created_at.isoformat(),
             "start_node_id": job.id,
-            "direction": direction,
         },
     )
 
@@ -118,20 +109,17 @@ async def test_get_job_lineage_no_operations(
     }
 
 
-@pytest.mark.parametrize("direction", ["DOWNSTREAM", "UPSTREAM", "BOTH"])
 async def test_get_job_lineage_no_inputs_outputs(
     test_client: AsyncClient,
     async_session: AsyncSession,
     job: Job,
     run: Run,
-    direction: str,
 ):
     response = await test_client.get(
         "v1/jobs/lineage",
         params={
             "since": run.created_at.isoformat(),
             "start_node_id": job.id,
-            "direction": direction,
         },
     )
 
@@ -161,201 +149,35 @@ async def test_get_job_lineage_no_inputs_outputs(
     }
 
 
-async def test_get_job_lineage(
+async def test_get_job_lineage_simple(
     test_client: AsyncClient,
     async_session: AsyncSession,
     simple_lineage: LineageResult,
 ):
     lineage = simple_lineage
+    job = lineage.jobs[0]
 
-    [job] = await enrich_jobs(lineage.jobs, async_session)
-    runs = await enrich_runs(lineage.runs, async_session)
-    dataset_ids = {output.dataset_id for output in lineage.outputs}
+    inputs = [input for input in lineage.inputs if input.job_id == job.id]
+    input_stats = relation_stats_by_jobs(lineage.inputs)
+    assert inputs
+
+    outputs = [output for output in lineage.outputs if output.job_id == job.id]
+    output_stats = relation_stats_by_jobs(lineage.outputs)
+    assert outputs
+
+    dataset_ids = {input.dataset_id for input in inputs} | {output.dataset_id for output in outputs}
     datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    [job] = await enrich_jobs([job], async_session)
     datasets = await enrich_datasets(datasets, async_session)
-    output_stats = relation_stats(lineage.outputs)
+    since = min(run.created_at for run in lineage.runs)
 
-    since = min(run.created_at for run in runs)
     response = await test_client.get(
         "v1/jobs/lineage",
         params={
             "since": since.isoformat(),
             "start_node_id": job.id,
-            "direction": "DOWNSTREAM",
-        },
-    )
-
-    assert response.status_code == HTTPStatus.OK, response.json()
-    assert response.json() == {
-        "relations": [
-            {
-                "kind": "OUTPUT",
-                "from": {"kind": "JOB", "id": job.id},
-                "to": {"kind": "DATASET", "id": dataset.id},
-                "type": "APPEND",
-                "num_bytes": output_stats[dataset.id]["num_bytes"],
-                "num_rows": output_stats[dataset.id]["num_rows"],
-                "num_files": output_stats[dataset.id]["num_files"],
-                "last_interaction_at": output_stats[dataset.id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            }
-            for dataset in sorted(datasets, key=lambda x: x.id)
-        ],
-        "nodes": [
-            {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "type": job.location.type,
-                    "name": job.location.name,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
-                },
-            },
-        ]
-        + [
-            {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
-                },
-            }
-            for dataset in sorted(datasets, key=lambda x: x.id)
-        ],
-    }
-
-
-async def test_get_job_lineage_with_run_granularity(
-    test_client: AsyncClient,
-    async_session: AsyncSession,
-    simple_lineage: LineageResult,
-):
-    lineage = simple_lineage
-
-    [job] = await enrich_jobs(lineage.jobs, async_session)
-    runs = await enrich_runs(lineage.runs, async_session)
-    dataset_ids = {output.dataset_id for output in lineage.outputs}
-    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
-    datasets = await enrich_datasets(datasets, async_session)
-    output_stats = relation_stats(lineage.outputs)
-
-    since = min(run.created_at for run in runs)
-    response = await test_client.get(
-        "v1/jobs/lineage",
-        params={
-            "since": since.isoformat(),
-            "start_node_id": job.id,
-            "granularity": "RUN",
-            "direction": "DOWNSTREAM",
-        },
-    )
-
-    assert response.status_code == HTTPStatus.OK, response.json()
-    assert response.json() == {
-        "relations": [
-            {
-                "kind": "PARENT",
-                "from": {"kind": "JOB", "id": job.id},
-                "to": {"kind": "RUN", "id": str(run.id)},
-            }
-            for run in sorted(runs, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "OUTPUT",
-                "from": {"kind": "RUN", "id": str(output.run_id)},
-                "to": {"kind": "DATASET", "id": output.dataset_id},
-                "type": "APPEND",
-                "num_bytes": output_stats[output.dataset_id]["num_bytes"],
-                "num_rows": output_stats[output.dataset_id]["num_rows"],
-                "num_files": output_stats[output.dataset_id]["num_files"],
-                "last_interaction_at": output_stats[output.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            }
-            for output in sorted(lineage.outputs, key=lambda x: (x.run_id, x.dataset_id))
-        ],
-        "nodes": [
-            {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "type": job.location.type,
-                    "name": job.location.name,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
-                },
-            },
-        ]
-        + [
-            {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
-                },
-            }
-            for dataset in sorted(datasets, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "RUN",
-                "id": str(run.id),
-                "job_id": run.job_id,
-                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "parent_run_id": str(run.parent_run_id),
-                "status": run.status.name,
-                "external_id": run.external_id,
-                "attempt": run.attempt,
-                "persistent_log_url": run.persistent_log_url,
-                "running_log_url": run.running_log_url,
-                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "started_by_user": {"name": run.started_by_user.name},
-                "start_reason": run.start_reason.value,
-                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "end_reason": run.end_reason,
-            }
-            for run in sorted(runs, key=lambda x: x.id)
-        ],
-    }
-
-
-async def test_get_job_lineage_direction_both(
-    test_client: AsyncClient,
-    async_session: AsyncSession,
-    simple_lineage: LineageResult,
-):
-    lineage = simple_lineage
-
-    [job] = await enrich_jobs(lineage.jobs, async_session)
-    runs = await enrich_runs(lineage.runs, async_session)
-    datasets = await enrich_datasets(lineage.datasets, async_session)
-    output_stats = relation_stats(lineage.outputs)
-    input_stats = relation_stats(lineage.inputs)
-
-    since = min(run.created_at for run in runs)
-    response = await test_client.get(
-        "v1/jobs/lineage",
-        params={
-            "since": since.isoformat(),
-            "start_node_id": job.id,
-            "direction": "BOTH",
         },
     )
 
@@ -366,25 +188,29 @@ async def test_get_job_lineage_direction_both(
                 "kind": "INPUT",
                 "from": {"kind": "DATASET", "id": input.dataset_id},
                 "to": {"kind": "JOB", "id": input.job_id},
-                "num_bytes": input_stats[input.dataset_id]["num_bytes"],
-                "num_rows": input_stats[input.dataset_id]["num_rows"],
-                "num_files": input_stats[input.dataset_id]["num_files"],
-                "last_interaction_at": input_stats[input.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
             }
-            for input in lineage.inputs
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.job_id))
         ]
         + [
             {
                 "kind": "OUTPUT",
                 "from": {"kind": "JOB", "id": output.job_id},
                 "to": {"kind": "DATASET", "id": output.dataset_id},
-                "type": "APPEND",
-                "num_bytes": output_stats[output.dataset_id]["num_bytes"],
-                "num_rows": output_stats[output.dataset_id]["num_rows"],
-                "num_files": output_stats[output.dataset_id]["num_files"],
-                "last_interaction_at": output_stats[output.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "type": output.type,
+                "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
             }
-            for output in lineage.outputs
+            for output in sorted(outputs, key=lambda x: (x.job_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -420,37 +246,110 @@ async def test_get_job_lineage_direction_both(
     }
 
 
-async def test_get_job_lineage_with_direction_and_until(
+async def test_get_job_lineage_with_direction_downstream(
     test_client: AsyncClient,
     async_session: AsyncSession,
-    three_days_lineage: LineageResult,
+    simple_lineage: LineageResult,
 ):
-    lineage = three_days_lineage
-
+    lineage = simple_lineage
     job = lineage.jobs[0]
 
-    since = min(run.created_at for run in lineage.runs if run.job_id == job.id)
-    until = since + timedelta(seconds=1)
+    outputs = [output for output in lineage.outputs if output.job_id == job.id]
+    output_stats = relation_stats_by_jobs(lineage.outputs)
+    assert outputs
 
-    raw_runs = [run for run in lineage.runs if run.job_id == job.id and since <= run.created_at <= until]
-    run_ids = {run.id for run in raw_runs}
-    assert raw_runs
-
-    inputs = [input for input in lineage.inputs if input.run_id in run_ids and since <= input.created_at <= until]
-    assert inputs
-    input_stats = relation_stats(inputs)
-
-    dataset_ids = {input.dataset_id for input in inputs}
+    dataset_ids = {output.dataset_id for output in outputs}
     datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
 
     [job] = await enrich_jobs([job], async_session)
     datasets = await enrich_datasets(datasets, async_session)
+    since = min(run.created_at for run in lineage.runs if run.job_id == job.id)
 
     response = await test_client.get(
         "v1/jobs/lineage",
         params={
             "since": since.isoformat(),
-            "until": until.isoformat(),
+            "start_node_id": job.id,
+            "direction": "DOWNSTREAM",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "JOB", "id": output.job_id},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for output in sorted(outputs, key=lambda x: (x.job_id, x.dataset_id))
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "type": job.type,
+                "location": {
+                    "id": job.location.id,
+                    "type": job.location.type,
+                    "name": job.location.name,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                    "external_id": job.location.external_id,
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "id": dataset.location.id,
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                    "external_id": dataset.location.external_id,
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ],
+    }
+
+
+async def test_get_job_lineage_with_direction_upstream(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    simple_lineage: LineageResult,
+):
+    lineage = simple_lineage
+    job = lineage.jobs[0]
+
+    inputs = [input for input in lineage.inputs if input.job_id == job.id]
+    input_stats = relation_stats_by_jobs(lineage.inputs)
+    assert inputs
+
+    dataset_ids = {input.dataset_id for input in inputs}
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    [job] = await enrich_jobs([job], async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+    since = min(run.created_at for run in lineage.runs if run.job_id == job.id)
+
+    response = await test_client.get(
+        "v1/jobs/lineage",
+        params={
+            "since": since.isoformat(),
             "start_node_id": job.id,
             "direction": "UPSTREAM",
         },
@@ -463,12 +362,14 @@ async def test_get_job_lineage_with_direction_and_until(
                 "kind": "INPUT",
                 "from": {"kind": "DATASET", "id": input.dataset_id},
                 "to": {"kind": "JOB", "id": input.job_id},
-                "num_bytes": input_stats[input.dataset_id]["num_bytes"],
-                "num_rows": input_stats[input.dataset_id]["num_rows"],
-                "num_files": input_stats[input.dataset_id]["num_files"],
-                "last_interaction_at": input_stats[input.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
             }
-            for input in inputs
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.job_id))
         ],
         "nodes": [
             {
@@ -504,32 +405,126 @@ async def test_get_job_lineage_with_direction_and_until(
     }
 
 
-async def test_get_job_lineage_with_direction_and_until_and_run_granularity(
+async def test_get_job_lineage_with_until(
     test_client: AsyncClient,
     async_session: AsyncSession,
     three_days_lineage: LineageResult,
 ):
     lineage = three_days_lineage
-
     job = lineage.jobs[0]
-
     since = min(run.created_at for run in lineage.runs if run.job_id == job.id)
     until = since + timedelta(seconds=1)
 
-    raw_runs = [run for run in lineage.runs if run.job_id == job.id and since <= run.created_at <= until]
-    run_ids = {run.id for run in raw_runs}
-    assert raw_runs
-
-    inputs = [input for input in lineage.inputs if input.run_id in run_ids and since <= input.created_at <= until]
+    inputs = [input for input in lineage.inputs if input.job_id == job.id and since <= input.created_at <= until]
+    input_stats = relation_stats_by_jobs(inputs)
     assert inputs
-    input_stats = relation_stats(inputs)
 
-    # Only runs with some inputs are returned
-    run_ids = {input.run_id for input in inputs}
+    outputs = [output for output in lineage.outputs if output.job_id == job.id and since <= output.created_at <= until]
+    output_stats = relation_stats_by_jobs(outputs)
+    assert outputs
+
+    dataset_ids = {input.dataset_id for input in inputs} | {output.dataset_id for output in outputs}
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    [job] = await enrich_jobs([job], async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+
+    response = await test_client.get(
+        "v1/jobs/lineage",
+        params={
+            "since": since.isoformat(),
+            "until": until.isoformat(),
+            "start_node_id": job.id,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "INPUT",
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "JOB", "id": input.job_id},
+                "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.job_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "JOB", "id": output.job_id},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for output in sorted(outputs, key=lambda x: (x.job_id, x.dataset_id))
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "type": job.type,
+                "location": {
+                    "id": job.location.id,
+                    "type": job.location.type,
+                    "name": job.location.name,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                    "external_id": job.location.external_id,
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "id": dataset.location.id,
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                    "external_id": dataset.location.external_id,
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ],
+    }
+
+
+async def test_get_job_lineage_with_granularity_run(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    simple_lineage: LineageResult,
+):
+    lineage = simple_lineage
+    job = lineage.jobs[0]
+    since = min(run.created_at for run in lineage.runs if run.job_id == job.id)
+
+    inputs = [input for input in lineage.inputs if input.job_id == job.id and since <= input.created_at]
+    input_stats = relation_stats_by_runs(inputs)
+
+    outputs = [output for output in lineage.outputs if output.job_id == job.id and since <= output.created_at]
+    output_stats = relation_stats_by_runs(outputs)
+
+    # Only runs with relations are returned
+    run_ids = {input.run_id for input in inputs} | {output.run_id for output in outputs}
     runs = [run for run in lineage.runs if run.id in run_ids]
     assert runs
 
-    dataset_ids = {input.dataset_id for input in inputs}
+    dataset_ids = {input.dataset_id for input in inputs} | {output.dataset_id for output in outputs}
     datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
 
     [job] = await enrich_jobs([job], async_session)
@@ -540,10 +535,8 @@ async def test_get_job_lineage_with_direction_and_until_and_run_granularity(
         "v1/jobs/lineage",
         params={
             "since": since.isoformat(),
-            "until": until.isoformat(),
             "start_node_id": job.id,
             "granularity": "RUN",
-            "direction": "UPSTREAM",
         },
     )
 
@@ -562,12 +555,29 @@ async def test_get_job_lineage_with_direction_and_until_and_run_granularity(
                 "kind": "INPUT",
                 "from": {"kind": "DATASET", "id": input.dataset_id},
                 "to": {"kind": "RUN", "id": str(input.run_id)},
-                "num_bytes": input_stats[input.dataset_id]["num_bytes"],
-                "num_rows": input_stats[input.dataset_id]["num_rows"],
-                "num_files": input_stats[input.dataset_id]["num_files"],
-                "last_interaction_at": input_stats[input.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
             }
-            for input in inputs
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.run_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "RUN", "id": str(output.run_id)},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for output in sorted(outputs, key=lambda x: (x.run_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -630,33 +640,42 @@ async def test_get_job_lineage_with_depth(
 ):
     lineage = lineage_with_depth
     # Select only relations marked with *
-    # D1 --> J1 -*> D2
+    # D1 -*> J1 -*> D2
     # D2 -*> J2 -*> D3
     # D3 --> J3 --> D4
 
     job = lineage.jobs[0]
 
     # Go job[first level] -> datasets[second level]
+    first_level_inputs = [input for input in lineage.inputs if input.job_id == job.id]
     first_level_outputs = [output for output in lineage.outputs if output.job_id == job.id]
-    first_level_dataset_ids = {output.dataset_id for output in first_level_outputs}
+    first_level_input_dataset_ids = {input.dataset_id for input in first_level_inputs}
+    first_level_output_dataset_ids = {output.dataset_id for output in first_level_outputs}
+    first_level_dataset_ids = first_level_input_dataset_ids | first_level_output_dataset_ids
     assert first_level_dataset_ids
 
     # Go datasets[second level] -> jobs[second level]
-    second_level_inputs = [input for input in lineage.inputs if input.dataset_id in first_level_dataset_ids]
-    second_level_job_ids = {input.job_id for input in second_level_inputs} - {job.id}
+    second_level_inputs = [input for input in lineage.inputs if input.dataset_id in first_level_output_dataset_ids]
+    second_level_outputs = [output for output in lineage.outputs if output.dataset_id in first_level_input_dataset_ids]
+    second_level_input_job_ids = {input.job_id for input in second_level_inputs}
+    second_level_output_job_ids = {output.job_id for output in second_level_outputs}
+    second_level_job_ids = second_level_input_job_ids | second_level_output_job_ids - {job.id}
     second_level_jobs = [job for job in lineage.jobs if job.id in second_level_job_ids]
     assert second_level_jobs
 
     # Go jobs[second level] -> datasets[third level]
     # There are more levels in this graph, but we stop here
-    third_level_outputs = [output for output in lineage.outputs if output.job_id in second_level_job_ids]
-    third_level_dataset_ids = {output.dataset_id for output in third_level_outputs} - first_level_dataset_ids
+    third_level_inputs = [input for input in lineage.inputs if input.job_id in second_level_output_job_ids]
+    third_level_outputs = [output for output in lineage.outputs if output.job_id in second_level_input_job_ids]
+    third_level_input_dataset_ids = {input.dataset_id for input in third_level_inputs}
+    third_level_output_dataset_ids = {output.dataset_id for output in third_level_outputs}
+    third_level_dataset_ids = third_level_input_dataset_ids | third_level_output_dataset_ids - first_level_dataset_ids
     assert third_level_dataset_ids
 
-    inputs = second_level_inputs
-    input_stats = relation_stats(inputs)
-    outputs = first_level_outputs + third_level_outputs
-    output_stats = relation_stats(outputs)
+    inputs = first_level_inputs + second_level_inputs + third_level_inputs
+    outputs = first_level_outputs + second_level_outputs + third_level_outputs
+    input_stats = relation_stats_by_jobs(inputs)
+    output_stats = relation_stats_by_jobs(outputs)
 
     dataset_ids = first_level_dataset_ids | third_level_dataset_ids
     datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
@@ -665,14 +684,13 @@ async def test_get_job_lineage_with_depth(
 
     jobs = await enrich_jobs(jobs, async_session)
     datasets = await enrich_datasets(datasets, async_session)
+    since = min(run.created_at for run in lineage.runs if run.job_id == job.id)
 
-    since = min(run.created_at for run in lineage.runs)
     response = await test_client.get(
         "v1/jobs/lineage",
         params={
             "since": since.isoformat(),
             "start_node_id": job.id,
-            "direction": "DOWNSTREAM",
             "depth": 3,
         },
     )
@@ -684,25 +702,29 @@ async def test_get_job_lineage_with_depth(
                 "kind": "INPUT",
                 "from": {"kind": "DATASET", "id": input.dataset_id},
                 "to": {"kind": "JOB", "id": input.job_id},
-                "num_bytes": input_stats[input.dataset_id]["num_bytes"],
-                "num_rows": input_stats[input.dataset_id]["num_rows"],
-                "num_files": input_stats[input.dataset_id]["num_files"],
-                "last_interaction_at": input_stats[input.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
             }
-            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.job_id))
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.run_id))
         ]
         + [
             {
                 "kind": "OUTPUT",
                 "from": {"kind": "JOB", "id": output.job_id},
                 "to": {"kind": "DATASET", "id": output.dataset_id},
-                "type": "APPEND",
-                "num_bytes": output_stats[output.dataset_id]["num_bytes"],
-                "num_rows": output_stats[output.dataset_id]["num_rows"],
-                "num_files": output_stats[output.dataset_id]["num_files"],
-                "last_interaction_at": output_stats[output.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "type": output.type,
+                "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
             }
-            for output in sorted(outputs, key=lambda x: (x.job_id, x.dataset_id))
+            for output in sorted(outputs, key=lambda x: (x.run_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -739,63 +761,70 @@ async def test_get_job_lineage_with_depth(
     }
 
 
-async def test_get_job_lineage_with_depth_and_run_granularity(
+async def test_get_job_lineage_with_depth_and_granularity_run(
     test_client: AsyncClient,
     async_session: AsyncSession,
     lineage_with_depth: LineageResult,
 ):
     lineage = lineage_with_depth
     # Select only relations marked with *
-    # J1 -*> R1, D1 --> R1 -*> D2
+    # J1 -*> R1, D1 -*> R1 -*> D2
     # J2 -*> R2, D2 -*> R2 -*> D3
     # J3 --> R3, D3 --> R3 --> D4
 
     first_level_job_id = lineage.jobs[0].id
 
     # Go job[first level] -> runs[first level] -> datasets[first level]
+    first_level_inputs = [input for input in lineage.inputs if input.job_id == first_level_job_id]
     first_level_outputs = [output for output in lineage.outputs if output.job_id == first_level_job_id]
-    first_level_run_ids = {output.run_id for output in first_level_outputs}
-    assert first_level_run_ids
-    first_level_dataset_ids = {output.dataset_id for output in first_level_outputs}
+    first_level_input_run_ids = {input.run_id for input in first_level_inputs}
+    first_level_output_run_ids = {output.run_id for output in first_level_outputs}
+    first_level_run_ids = first_level_input_run_ids | first_level_output_run_ids
+    first_level_input_dataset_ids = {input.dataset_id for input in first_level_inputs}
+    first_level_output_dataset_ids = {output.dataset_id for output in first_level_outputs}
+    first_level_dataset_ids = first_level_input_dataset_ids | first_level_output_dataset_ids
     assert first_level_dataset_ids
 
     # Go datasets[first level] -> runs[second level] -> jobs[second level]
-    second_level_inputs = [input for input in lineage.inputs if input.dataset_id in first_level_dataset_ids]
-    second_level_run_ids = {input.run_id for input in second_level_inputs} - first_level_run_ids
+    second_level_inputs = [input for input in lineage.inputs if input.dataset_id in first_level_output_dataset_ids]
+    second_level_outputs = [output for output in lineage.outputs if output.dataset_id in first_level_input_dataset_ids]
+    second_level_input_run_ids = {input.run_id for input in second_level_inputs}
+    second_level_output_run_ids = {output.run_id for output in second_level_outputs}
+    second_level_run_ids = second_level_input_run_ids | second_level_output_run_ids - first_level_run_ids
     assert second_level_run_ids
-    second_level_job_ids = {input.job_id for input in second_level_inputs} - {first_level_job_id}
-    assert second_level_job_ids
 
     # Go runs[second level] -> datasets[third level]
-    third_level_outputs = [output for output in lineage.outputs if output.run_id in second_level_run_ids]
-    third_level_dataset_ids = {output.dataset_id for output in third_level_outputs} - first_level_dataset_ids
+    third_level_inputs = [input for input in lineage.inputs if input.run_id in second_level_output_run_ids]
+    third_level_outputs = [output for output in lineage.outputs if output.run_id in second_level_input_run_ids]
+    third_level_input_dataset_ids = {input.dataset_id for input in third_level_inputs}
+    third_level_output_dataset_ids = {output.dataset_id for output in third_level_outputs}
+    third_level_dataset_ids = third_level_input_dataset_ids | third_level_output_dataset_ids - first_level_dataset_ids
     assert third_level_dataset_ids
 
-    inputs = second_level_inputs
-    input_stats = relation_stats(inputs)
-    outputs = first_level_outputs + third_level_outputs
-    output_stats = relation_stats(outputs)
+    inputs = first_level_inputs + second_level_inputs + third_level_inputs
+    outputs = first_level_outputs + second_level_outputs + third_level_outputs
+    input_stats = relation_stats_by_runs(inputs)
+    output_stats = relation_stats_by_runs(outputs)
 
     dataset_ids = first_level_dataset_ids | third_level_dataset_ids
     datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
 
-    job_ids = {first_level_job_id} | second_level_job_ids
-    jobs = [job for job in lineage.jobs if job.id in job_ids]
-
     run_ids = first_level_run_ids | second_level_run_ids
     runs = [run for run in lineage.runs if run.id in run_ids]
+
+    job_ids = {run.job_id for run in runs}
+    jobs = [job for job in lineage.jobs if job.id in job_ids]
 
     jobs = await enrich_jobs(jobs, async_session)
     runs = await enrich_runs(runs, async_session)
     datasets = await enrich_datasets(datasets, async_session)
-
     since = min(run.created_at for run in runs)
+
     response = await test_client.get(
         "v1/jobs/lineage",
         params={
             "since": since.isoformat(),
             "start_node_id": first_level_job_id,
-            "direction": "DOWNSTREAM",
             "granularity": "RUN",
             "depth": 3,
         },
@@ -816,25 +845,29 @@ async def test_get_job_lineage_with_depth_and_run_granularity(
                 "kind": "INPUT",
                 "from": {"kind": "DATASET", "id": input.dataset_id},
                 "to": {"kind": "RUN", "id": str(input.run_id)},
-                "num_bytes": input_stats[input.dataset_id]["num_bytes"],
-                "num_rows": input_stats[input.dataset_id]["num_rows"],
-                "num_files": input_stats[input.dataset_id]["num_files"],
-                "last_interaction_at": input_stats[input.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
             }
-            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.run_id))
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.job_id))
         ]
         + [
             {
                 "kind": "OUTPUT",
                 "from": {"kind": "RUN", "id": str(output.run_id)},
                 "to": {"kind": "DATASET", "id": output.dataset_id},
-                "type": "APPEND",
-                "num_bytes": output_stats[output.dataset_id]["num_bytes"],
-                "num_rows": output_stats[output.dataset_id]["num_rows"],
-                "num_files": output_stats[output.dataset_id]["num_files"],
-                "last_interaction_at": output_stats[output.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "type": output.type,
+                "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
             }
-            for output in sorted(outputs, key=lambda x: (x.run_id, x.dataset_id))
+            for output in sorted(outputs, key=lambda x: (x.job_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -897,21 +930,25 @@ async def test_get_job_lineage_with_depth_ignore_cycles(
     lineage_with_depth_and_cycle: LineageResult,
 ):
     lineage = lineage_with_depth_and_cycle
+    # Select all relations:
+    # J1 -*> R1 -*> O1, D1 -*> O1 -*> D2
+    # J2 -*> R2 -*> O2, D2 -*> O2 -*> D1
+
+    # We can start at any job
     job = lineage.jobs[0]
-    jobs = await enrich_jobs(lineage.jobs, async_session)
 
     output_stats = relation_stats_by_jobs(lineage.outputs)
     input_stats = relation_stats_by_jobs(lineage.inputs)
 
-    [dataset] = await enrich_datasets(lineage.datasets, async_session)
-
+    jobs = await enrich_jobs(lineage.jobs, async_session)
+    datasets = await enrich_datasets(lineage.datasets, async_session)
     since = min(run.created_at for run in lineage.runs)
+
     response = await test_client.get(
         "v1/jobs/lineage",
         params={
             "since": since.isoformat(),
             "start_node_id": job.id,
-            "direction": "DOWNSTREAM",
             "depth": 3,
         },
     )
@@ -921,31 +958,31 @@ async def test_get_job_lineage_with_depth_ignore_cycles(
         "relations": [
             {
                 "kind": "INPUT",
-                "from": {"kind": "DATASET", "id": dataset.id},
-                "to": {"kind": "JOB", "id": job.id},
-                "num_bytes": input_stats[(job.id, dataset.id)]["num_bytes"],
-                "num_rows": input_stats[(job.id, dataset.id)]["num_rows"],
-                "num_files": input_stats[(job.id, dataset.id)]["num_files"],
-                "last_interaction_at": input_stats[(job.id, dataset.id)]["created_at"].strftime(
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "JOB", "id": input.job_id},
+                "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for job in jobs
+            for input in sorted(lineage.inputs, key=lambda x: (x.dataset_id, x.job_id))
         ]
         + [
             {
                 "kind": "OUTPUT",
-                "from": {"kind": "JOB", "id": job.id},
-                "to": {"kind": "DATASET", "id": dataset.id},
-                "type": "APPEND",
-                "num_bytes": output_stats[(job.id, dataset.id)]["num_bytes"],
-                "num_rows": output_stats[(job.id, dataset.id)]["num_rows"],
-                "num_files": output_stats[(job.id, dataset.id)]["num_files"],
-                "last_interaction_at": output_stats[(job.id, dataset.id)]["created_at"].strftime(
+                "from": {"kind": "JOB", "id": output.job_id},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for job in jobs
+            for output in sorted(lineage.outputs, key=lambda x: (x.job_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -976,7 +1013,8 @@ async def test_get_job_lineage_with_depth_ignore_cycles(
                     "addresses": [{"url": address.url} for address in dataset.location.addresses],
                     "external_id": dataset.location.external_id,
                 },
-            },
+            }
+            for dataset in datasets
         ],
     }
 
@@ -989,11 +1027,18 @@ async def test_get_job_lineage_with_symlinks(
     lineage = lineage_with_symlinks
 
     job = lineage.jobs[1]
-    outputs = [output for output in lineage.outputs if output.job_id == job.id]
-    output_stats = relation_stats(outputs)
-    dataset_ids = {output.dataset_id for output in outputs}
+    inputs = [input for input in lineage.inputs if input.job_id == job.id]
+    input_stats = relation_stats_by_jobs(inputs)
+    assert inputs
 
-    # Dataset from symlinks appear only as SYMLINK location, but not as INPUT, because of depth=1
+    outputs = [output for output in lineage.outputs if output.job_id == job.id]
+    output_stats = relation_stats_by_jobs(outputs)
+    assert outputs
+
+    dataset_ids = {input.dataset_id for input in inputs} | {output.dataset_id for output in outputs}
+    assert dataset_ids
+
+    # Dataset from symlinks appear only as SYMLINK relation, but not as INPUT, because of depth=1
     dataset_symlinks = [
         dataset_symlink
         for dataset_symlink in lineage.dataset_symlinks
@@ -1001,20 +1046,19 @@ async def test_get_job_lineage_with_symlinks(
     ]
     dataset_ids_from_symlink = {dataset_symlink.from_dataset_id for dataset_symlink in dataset_symlinks}
     dataset_ids_to_symlink = {dataset_symlink.to_dataset_id for dataset_symlink in dataset_symlinks}
-    dataset_ids = dataset_ids | dataset_ids_from_symlink | dataset_ids_to_symlink
-    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    dataset_ids_include_symlinks = dataset_ids | dataset_ids_from_symlink | dataset_ids_to_symlink
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids_include_symlinks]
     assert datasets
 
     [job] = await enrich_jobs([job], async_session)
     datasets = await enrich_datasets(datasets, async_session)
+    since = min(run.created_at for run in lineage.runs if run.job_id == job.id)
 
-    since = min(run.created_at for run in lineage.runs)
     response = await test_client.get(
         "v1/jobs/lineage",
         params={
             "since": since.isoformat(),
             "start_node_id": job.id,
-            "direction": "DOWNSTREAM",
         },
     )
 
@@ -1031,16 +1075,32 @@ async def test_get_job_lineage_with_symlinks(
         ]
         + [
             {
-                "kind": "OUTPUT",
-                "from": {"kind": "JOB", "id": job.id},
-                "to": {"kind": "DATASET", "id": output.dataset_id},
-                "type": "APPEND",
-                "num_bytes": output_stats[output.dataset_id]["num_bytes"],
-                "num_rows": output_stats[output.dataset_id]["num_rows"],
-                "num_files": output_stats[output.dataset_id]["num_files"],
-                "last_interaction_at": output_stats[output.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "kind": "INPUT",
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "JOB", "id": input.job_id},
+                "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
             }
-            for output in outputs
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.job_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "JOB", "id": output.job_id},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for output in sorted(outputs, key=lambda x: (x.job_id, x.dataset_id))
         ],
         "nodes": [
             {

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -5,41 +5,23 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from data_rentgen.db.models import (
-    Dataset,
-    DatasetSymlink,
-    Input,
-    Job,
-    Operation,
-    Output,
-    Run,
-)
+from data_rentgen.db.models import Job, Run
 from tests.test_server.utils.enrich import enrich_datasets, enrich_jobs, enrich_runs
 from tests.test_server.utils.lineage_result import LineageResult
-from tests.test_server.utils.stats import (
-    relation_stats,
-    relation_stats_by_operations,
-    relation_stats_by_runs,
-)
+from tests.test_server.utils.stats import relation_stats_by_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio, pytest.mark.lineage]
 
-LINEAGE_FIXTURE_ANNOTATION = tuple[list[Job], list[Run], list[Operation], list[Dataset], list[Input], list[Output]]
 
-
-@pytest.mark.parametrize("direction", ["DOWNSTREAM", "UPSTREAM", "BOTH"])
 async def test_get_run_lineage_unknown_id(
     test_client: AsyncClient,
     new_run: Run,
-    direction: str,
 ):
     response = await test_client.get(
         "v1/runs/lineage",
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "start_node_id": str(new_run.id),
-            "direction": direction,
-            "granularity": "OPERATION",
         },
     )
 
@@ -50,20 +32,17 @@ async def test_get_run_lineage_unknown_id(
     }
 
 
-@pytest.mark.parametrize("direction", ["DOWNSTREAM", "UPSTREAM", "BOTH"])
 async def test_get_run_lineage_no_operations(
     test_client: AsyncClient,
     async_session: AsyncSession,
     job: Job,
     run: Run,
-    direction: str,
 ):
     response = await test_client.get(
         "v1/runs/lineage",
         params={
             "since": datetime.now(tz=timezone.utc).isoformat(),
             "start_node_id": str(run.id),
-            "direction": direction,
         },
     )
 
@@ -114,20 +93,17 @@ async def test_get_run_lineage_no_operations(
     }
 
 
-@pytest.mark.parametrize("direction", ["DOWNSTREAM", "UPSTREAM", "BOTH"])
 async def test_get_run_lineage_no_inputs_outputs(
     test_client: AsyncClient,
     async_session: AsyncSession,
     job: Job,
     run: Run,
-    direction: str,
 ):
     response = await test_client.get(
         "v1/runs/lineage",
         params={
             "since": run.created_at.isoformat(),
             "start_node_id": str(run.id),
-            "direction": direction,
         },
     )
 
@@ -180,264 +156,36 @@ async def test_get_run_lineage_no_inputs_outputs(
     }
 
 
-async def test_get_run_lineage(
+async def test_get_run_lineage_simple(
     test_client: AsyncClient,
     async_session: AsyncSession,
     simple_lineage: LineageResult,
 ):
     lineage = simple_lineage
-
-    jobs = await enrich_jobs(lineage.jobs, async_session)
-    run = lineage.runs[0]
-    [run] = await enrich_runs([run], async_session)
-    outputs = [output for output in lineage.outputs if output.run_id == run.id]
-    output_stats = relation_stats(outputs)
-    dataset_ids = {output.dataset_id for output in outputs}
-    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
-    datasets = await enrich_datasets(datasets, async_session)
-
-    response = await test_client.get(
-        "v1/runs/lineage",
-        params={
-            "since": run.created_at.isoformat(),
-            "start_node_id": str(run.id),
-            "direction": "DOWNSTREAM",
-        },
-    )
-
-    assert response.status_code == HTTPStatus.OK, response.json()
-    assert response.json() == {
-        "relations": [
-            {
-                "kind": "PARENT",
-                "from": {"kind": "JOB", "id": run.job_id},
-                "to": {"kind": "RUN", "id": str(run.id)},
-            },
-        ]
-        + [
-            {
-                "kind": "OUTPUT",
-                "from": {"kind": "RUN", "id": str(run.id)},
-                "to": {"kind": "DATASET", "id": dataset.id},
-                "type": "APPEND",
-                "num_bytes": output_stats[dataset.id]["num_bytes"],
-                "num_rows": output_stats[dataset.id]["num_rows"],
-                "num_files": output_stats[dataset.id]["num_files"],
-                "last_interaction_at": output_stats[dataset.id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            }
-            for dataset in sorted(datasets, key=lambda x: x.id)
-        ],
-        "nodes": [
-            {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "type": job.location.type,
-                    "name": job.location.name,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
-                },
-            }
-            for job in sorted(jobs, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
-                },
-            }
-            for dataset in sorted(datasets, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "RUN",
-                "id": str(run.id),
-                "job_id": run.job_id,
-                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "parent_run_id": str(run.parent_run_id),
-                "status": run.status.name,
-                "external_id": run.external_id,
-                "attempt": run.attempt,
-                "persistent_log_url": run.persistent_log_url,
-                "running_log_url": run.running_log_url,
-                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "started_by_user": {"name": run.started_by_user.name},
-                "start_reason": run.start_reason.value,
-                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "end_reason": run.end_reason,
-            },
-        ],
-    }
-
-
-async def test_get_run_lineage_with_operation_granularity(
-    test_client: AsyncClient,
-    async_session: AsyncSession,
-    simple_lineage: LineageResult,
-):
-    lineage = simple_lineage
-
-    run = lineage.runs[0]
-    [run] = await enrich_runs([run], async_session)
-    job = next(job for job in lineage.jobs if job.id == run.job_id)
-    [job] = await enrich_jobs([job], async_session)
-    operations = [operation for operation in lineage.operations if operation.run_id == run.id]
-    outputs = [output for output in lineage.outputs if output.run_id == run.id]
-    output_stats = relation_stats(outputs)
-    dataset_ids = {output.dataset_id for output in outputs}
-    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
-    datasets = await enrich_datasets(datasets, async_session)
-
-    response = await test_client.get(
-        "v1/runs/lineage",
-        params={
-            "since": run.created_at.isoformat(),
-            "start_node_id": str(run.id),
-            "direction": "DOWNSTREAM",
-            "granularity": "OPERATION",
-        },
-    )
-
-    assert response.status_code == HTTPStatus.OK, response.json()
-    assert response.json() == {
-        "relations": [
-            {
-                "kind": "PARENT",
-                "from": {"kind": "JOB", "id": run.job_id},
-                "to": {"kind": "RUN", "id": str(run.id)},
-            },
-        ]
-        + [
-            {
-                "kind": "PARENT",
-                "from": {"kind": "RUN", "id": str(operation.run_id)},
-                "to": {"kind": "OPERATION", "id": str(operation.id)},
-            }
-            for operation in sorted(operations, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "OUTPUT",
-                "from": {"kind": "OPERATION", "id": str(operation.id)},
-                "to": {"kind": "DATASET", "id": dataset.id},
-                "type": "APPEND",
-                "num_bytes": output_stats[dataset.id]["num_bytes"],
-                "num_rows": output_stats[dataset.id]["num_rows"],
-                "num_files": output_stats[dataset.id]["num_files"],
-                "last_interaction_at": output_stats[dataset.id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            }
-            for dataset, operation in zip(datasets, operations)
-        ],
-        "nodes": [
-            {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "type": job.location.type,
-                    "name": job.location.name,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
-                },
-            },
-        ]
-        + [
-            {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
-                },
-            }
-            for dataset in sorted(datasets, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "RUN",
-                "id": str(run.id),
-                "job_id": run.job_id,
-                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "parent_run_id": str(run.parent_run_id),
-                "status": run.status.name,
-                "external_id": run.external_id,
-                "attempt": run.attempt,
-                "persistent_log_url": run.persistent_log_url,
-                "running_log_url": run.running_log_url,
-                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "started_by_user": {"name": run.started_by_user.name},
-                "start_reason": run.start_reason.value,
-                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "end_reason": run.end_reason,
-            },
-        ]
-        + [
-            {
-                "kind": "OPERATION",
-                "id": str(operation.id),
-                "created_at": operation.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "run_id": str(operation.run_id),
-                "name": operation.name,
-                "status": operation.status.name,
-                "type": operation.type.value,
-                "position": operation.position,
-                "group": operation.group,
-                "description": operation.description,
-                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            }
-            for operation in sorted(operations, key=lambda x: x.id)
-        ],
-    }
-
-
-async def test_get_run_lineage_with_direction_both(
-    test_client: AsyncClient,
-    async_session: AsyncSession,
-    simple_lineage: LineageResult,
-):
-    lineage = simple_lineage
-
     run = lineage.runs[0]
     job = next(job for job in lineage.jobs if job.id == run.job_id)
 
     inputs = [input for input in lineage.inputs if input.run_id == run.id]
-    input_stats = relation_stats(inputs)
-    input_dataset_ids = {input.dataset_id for input in inputs}
-    outputs = [output for output in lineage.outputs if output.run_id == run.id]
-    output_stats = relation_stats(outputs)
-    output_dataset_ids = {output.dataset_id for output in outputs}
-    datasets = [dataset for dataset in lineage.datasets if dataset.id in input_dataset_ids | output_dataset_ids]
+    input_stats = relation_stats_by_runs(inputs)
+    assert inputs
 
-    datasets = await enrich_datasets(datasets, async_session)
+    outputs = [output for output in lineage.outputs if output.run_id == run.id]
+    output_stats = relation_stats_by_runs(outputs)
+    assert outputs
+
+    dataset_ids = {input.dataset_id for input in inputs} | {output.dataset_id for output in outputs}
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
+
     [job] = await enrich_jobs([job], async_session)
     [run] = await enrich_runs([run], async_session)
+    datasets = await enrich_datasets(datasets, async_session)
 
-    since = run.created_at
     response = await test_client.get(
         "v1/runs/lineage",
         params={
-            "since": since.isoformat(),
+            "since": run.created_at.isoformat(),
             "start_node_id": str(run.id),
-            "direction": "BOTH",
         },
     )
 
@@ -455,25 +203,29 @@ async def test_get_run_lineage_with_direction_both(
                 "kind": "INPUT",
                 "from": {"kind": "DATASET", "id": input.dataset_id},
                 "to": {"kind": "RUN", "id": str(input.run_id)},
-                "num_bytes": input_stats[input.dataset_id]["num_bytes"],
-                "num_rows": input_stats[input.dataset_id]["num_rows"],
-                "num_files": input_stats[input.dataset_id]["num_files"],
-                "last_interaction_at": input_stats[input.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
             }
-            for input in inputs
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.run_id))
         ]
         + [
             {
                 "kind": "OUTPUT",
                 "from": {"kind": "RUN", "id": str(output.run_id)},
                 "to": {"kind": "DATASET", "id": output.dataset_id},
-                "type": "APPEND",
-                "num_bytes": output_stats[output.dataset_id]["num_bytes"],
-                "num_rows": output_stats[output.dataset_id]["num_rows"],
-                "num_files": output_stats[output.dataset_id]["num_files"],
-                "last_interaction_at": output_stats[output.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "type": output.type,
+                "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
             }
-            for output in outputs
+            for output in sorted(outputs, key=lambda x: (x.run_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -528,154 +280,39 @@ async def test_get_run_lineage_with_direction_both(
     }
 
 
-async def test_get_run_lineage_with_direction_and_until(
+async def test_get_run_lineage_with_granularity_operation(
     test_client: AsyncClient,
     async_session: AsyncSession,
     simple_lineage: LineageResult,
 ):
     lineage = simple_lineage
-
-    # Each run has two operations split in time by 0.2 seconds
     run = lineage.runs[0]
     job = next(job for job in lineage.jobs if job.id == run.job_id)
 
-    since = run.created_at
-    until = since + timedelta(seconds=0.1)
-
-    inputs = [input for input in lineage.inputs if input.run_id == run.id and since <= input.created_at <= until]
-    assert inputs
-    input_stats = relation_stats(inputs)
-
-    dataset_ids = {input.dataset_id for input in inputs}
-    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
-
-    [job] = await enrich_jobs([job], async_session)
-    [run] = await enrich_runs([run], async_session)
-    datasets = await enrich_datasets(datasets, async_session)
-
-    response = await test_client.get(
-        "v1/runs/lineage",
-        params={
-            "since": since.isoformat(),
-            "until": until.isoformat(),
-            "start_node_id": str(run.id),
-            "direction": "UPSTREAM",
-        },
-    )
-
-    assert response.status_code == HTTPStatus.OK, response.json()
-    assert response.json() == {
-        "relations": [
-            {
-                "kind": "PARENT",
-                "from": {"kind": "JOB", "id": run.job_id},
-                "to": {"kind": "RUN", "id": str(run.id)},
-            },
-        ]
-        + [
-            {
-                "kind": "INPUT",
-                "from": {"kind": "DATASET", "id": input.dataset_id},
-                "to": {"kind": "RUN", "id": str(input.run_id)},
-                "num_bytes": input_stats[input.dataset_id]["num_bytes"],
-                "num_rows": input_stats[input.dataset_id]["num_rows"],
-                "num_files": input_stats[input.dataset_id]["num_files"],
-                "last_interaction_at": input_stats[input.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            }
-            for input in inputs
-        ],
-        "nodes": [
-            {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "type": job.location.type,
-                    "name": job.location.name,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
-                },
-            },
-        ]
-        + [
-            {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
-                },
-            }
-            for dataset in sorted(datasets, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "RUN",
-                "id": str(run.id),
-                "job_id": run.job_id,
-                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "parent_run_id": str(run.parent_run_id),
-                "status": run.status.name,
-                "external_id": run.external_id,
-                "attempt": run.attempt,
-                "persistent_log_url": run.persistent_log_url,
-                "running_log_url": run.running_log_url,
-                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "started_by_user": {"name": run.started_by_user.name},
-                "start_reason": run.start_reason.value,
-                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "end_reason": run.end_reason,
-            },
-        ],
-    }
-
-
-async def test_get_run_lineage_with_direction_and_until_and_operation_granularity(
-    test_client: AsyncClient,
-    async_session: AsyncSession,
-    simple_lineage: LineageResult,
-):
-    lineage = simple_lineage
-
-    # Each run has two operations split in time by 0.2 seconds
-    run = lineage.runs[0]
-    job = next(job for job in lineage.jobs if job.id == run.job_id)
-    since = run.created_at
-    until = since + timedelta(seconds=0.1)
-
-    operations = [
-        operation
-        for operation in lineage.operations
-        if operation.run_id == run.id and since <= operation.created_at <= until
-    ]
+    operations = [operation for operation in lineage.operations if operation.run_id == run.id]
+    operation_ids = {operation.id for operation in operations}
     assert operations
 
-    inputs = [input for input in lineage.inputs if input.run_id == run.id and since <= input.created_at <= until]
+    inputs = [input for input in lineage.inputs if input.operation_id in operation_ids]
     assert inputs
-    input_stats = relation_stats(inputs)
 
-    dataset_ids = {input.dataset_id for input in inputs}
+    outputs = [output for output in lineage.outputs if output.operation_id in operation_ids]
+    assert outputs
+
+    dataset_ids = {input.dataset_id for input in inputs} | {output.dataset_id for output in outputs}
     datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
 
-    [job] = await enrich_jobs([job], async_session)
     [run] = await enrich_runs([run], async_session)
+    [job] = await enrich_jobs([job], async_session)
     datasets = await enrich_datasets(datasets, async_session)
 
     response = await test_client.get(
         "v1/runs/lineage",
         params={
-            "since": since.isoformat(),
-            "until": until.isoformat(),
+            "since": run.created_at.isoformat(),
             "start_node_id": str(run.id),
             "granularity": "OPERATION",
-            "direction": "UPSTREAM",
         },
     )
 
@@ -701,12 +338,25 @@ async def test_get_run_lineage_with_direction_and_until_and_operation_granularit
                 "kind": "INPUT",
                 "from": {"kind": "DATASET", "id": input.dataset_id},
                 "to": {"kind": "OPERATION", "id": str(input.operation_id)},
-                "num_bytes": input_stats[input.dataset_id]["num_bytes"],
-                "num_rows": input_stats[input.dataset_id]["num_rows"],
-                "num_files": input_stats[input.dataset_id]["num_files"],
-                "last_interaction_at": input_stats[input.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "num_bytes": input.num_bytes,
+                "num_rows": input.num_rows,
+                "num_files": input.num_files,
+                "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
-            for input in inputs
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.operation_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "OPERATION", "id": str(output.operation_id)},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output.num_bytes,
+                "num_rows": output.num_rows,
+                "num_files": output.num_files,
+                "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            }
+            for output in sorted(outputs, key=lambda x: (x.operation_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -776,8 +426,349 @@ async def test_get_run_lineage_with_direction_and_until_and_operation_granularit
             for operation in sorted(operations, key=lambda x: x.id)
         ],
     }
-    assert len(response.json()["relations"]) == 3
-    assert len(response.json()["nodes"]) == 4
+
+
+async def test_get_run_lineage_with_direction_downstream(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    simple_lineage: LineageResult,
+):
+    lineage = simple_lineage
+    run = lineage.runs[0]
+    job = next(job for job in lineage.jobs if job.id == run.job_id)
+
+    outputs = [output for output in lineage.outputs if output.run_id == run.id]
+    output_stats = relation_stats_by_runs(outputs)
+    assert outputs
+
+    dataset_ids = {output.dataset_id for output in outputs}
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    [job] = await enrich_jobs([job], async_session)
+    [run] = await enrich_runs([run], async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+
+    response = await test_client.get(
+        "v1/runs/lineage",
+        params={
+            "since": run.created_at.isoformat(),
+            "start_node_id": str(run.id),
+            "direction": "DOWNSTREAM",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+            },
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "RUN", "id": str(output.run_id)},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for output in sorted(outputs, key=lambda x: (x.run_id, x.dataset_id))
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "type": job.type,
+                "location": {
+                    "id": job.location.id,
+                    "type": job.location.type,
+                    "name": job.location.name,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                    "external_id": job.location.external_id,
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "id": dataset.location.id,
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                    "external_id": dataset.location.external_id,
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.name,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            },
+        ],
+    }
+
+
+async def test_get_run_lineage_with_direction_upstream(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    simple_lineage: LineageResult,
+):
+    lineage = simple_lineage
+    run = lineage.runs[0]
+    job = next(job for job in lineage.jobs if job.id == run.job_id)
+
+    inputs = [input for input in lineage.inputs if input.run_id == run.id]
+    input_stats = relation_stats_by_runs(inputs)
+    assert inputs
+
+    dataset_ids = {input.dataset_id for input in inputs}
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    [job] = await enrich_jobs([job], async_session)
+    [run] = await enrich_runs([run], async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+
+    response = await test_client.get(
+        "v1/runs/lineage",
+        params={
+            "since": run.created_at.isoformat(),
+            "start_node_id": str(run.id),
+            "direction": "UPSTREAM",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+            },
+        ]
+        + [
+            {
+                "kind": "INPUT",
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "RUN", "id": str(input.run_id)},
+                "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.run_id))
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "type": job.type,
+                "location": {
+                    "id": job.location.id,
+                    "type": job.location.type,
+                    "name": job.location.name,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                    "external_id": job.location.external_id,
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "id": dataset.location.id,
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                    "external_id": dataset.location.external_id,
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.name,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            },
+        ],
+    }
+
+
+async def test_get_run_lineage_with_until(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    simple_lineage: LineageResult,
+):
+    lineage = simple_lineage
+
+    # Each run has two operations split in time by 0.2 seconds
+    run = lineage.runs[0]
+    job = next(job for job in lineage.jobs if job.id == run.job_id)
+
+    since = run.created_at
+    until = since + timedelta(seconds=0.1)
+
+    inputs = [input for input in lineage.inputs if input.run_id == run.id and since <= input.created_at <= until]
+    input_stats = relation_stats_by_runs(inputs)
+    assert inputs
+
+    outputs = [output for output in lineage.outputs if output.run_id == run.id and since <= output.created_at <= until]
+    output_stats = relation_stats_by_runs(outputs)
+    assert outputs
+
+    dataset_ids = {input.dataset_id for input in inputs} | {output.dataset_id for output in outputs}
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    [job] = await enrich_jobs([job], async_session)
+    [run] = await enrich_runs([run], async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+
+    response = await test_client.get(
+        "v1/runs/lineage",
+        params={
+            "since": since.isoformat(),
+            "until": until.isoformat(),
+            "start_node_id": str(run.id),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+            },
+        ]
+        + [
+            {
+                "kind": "INPUT",
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "RUN", "id": str(input.run_id)},
+                "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.run_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "RUN", "id": str(output.run_id)},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for output in sorted(outputs, key=lambda x: (x.run_id, x.dataset_id))
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "type": job.type,
+                "location": {
+                    "id": job.location.id,
+                    "type": job.location.type,
+                    "name": job.location.name,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                    "external_id": job.location.external_id,
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "id": dataset.location.id,
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                    "external_id": dataset.location.external_id,
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.name,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            },
+        ],
+    }
 
 
 async def test_get_run_lineage_with_depth(
@@ -787,42 +778,57 @@ async def test_get_run_lineage_with_depth(
 ):
     lineage = lineage_with_depth
     # Select only relations marked with *
-    # J1 -*> R1, D1 --> R1 -*> D2
+    # J1 -*> R1, D1 -*> R1 -*> D2
     # J2 -*> R2, D2 -*> R2 -*> D3
     # J3 --> R3, D3 --> R3 --> D4
 
     first_level_run = lineage.runs[0]
 
     # Go runs[first level] -> datasets[second level]
+    first_level_inputs = [input for input in lineage.inputs if input.run_id == first_level_run.id]
     first_level_outputs = [output for output in lineage.outputs if output.run_id == first_level_run.id]
-    first_level_dataset_ids = {output.dataset_id for output in first_level_outputs}
+    first_level_input_dataset_ids = {input.dataset_id for input in first_level_inputs}
+    first_level_output_dataset_ids = {output.dataset_id for output in first_level_outputs}
+    first_level_dataset_ids = first_level_input_dataset_ids | first_level_output_dataset_ids
     first_level_datasets = [dataset for dataset in lineage.datasets if dataset.id in first_level_dataset_ids]
     assert first_level_datasets
 
     # Go datasets[second level] -> runs[second level]
-    second_level_inputs = [input for input in lineage.inputs if input.dataset_id in first_level_dataset_ids]
-    second_level_run_ids = {input.run_id for input in second_level_inputs} - {first_level_run.id}
+    second_level_inputs = [input for input in lineage.inputs if input.dataset_id in first_level_output_dataset_ids]
+    second_level_outputs = [output for output in lineage.outputs if output.dataset_id in first_level_input_dataset_ids]
+    second_level_input_run_ids = {input.run_id for input in second_level_inputs}
+    second_level_output_run_ids = {output.run_id for output in second_level_outputs}
+    second_level_run_ids = second_level_input_run_ids | second_level_output_run_ids - {first_level_run.id}
     assert second_level_run_ids
 
     # Go runs[second level] -> datasets[third level]
     # There are more levels in this graph, but we stop here
-    third_level_outputs = [output for output in lineage.outputs if output.run_id in second_level_run_ids]
-    third_level_dataset_ids = {output.dataset_id for output in third_level_outputs} - first_level_dataset_ids
+    third_level_inputs = [input for input in lineage.inputs if input.run_id in second_level_output_run_ids]
+    third_level_outputs = [output for output in lineage.outputs if output.run_id in second_level_input_run_ids]
+    third_level_input_dataset_ids = {input.dataset_id for input in third_level_inputs}
+    third_level_output_dataset_ids = {output.dataset_id for output in third_level_outputs}
+    third_level_dataset_ids = third_level_input_dataset_ids | third_level_output_dataset_ids - first_level_dataset_ids
     assert third_level_dataset_ids
 
-    inputs = second_level_inputs
-    input_stats = relation_stats(inputs)
-    outputs = first_level_outputs + third_level_outputs
-    output_stats = relation_stats(outputs)
+    inputs = first_level_inputs + second_level_inputs + third_level_inputs
+    input_stats = relation_stats_by_runs(inputs)
+    assert inputs
+
+    outputs = first_level_outputs + second_level_outputs + third_level_outputs
+    output_stats = relation_stats_by_runs(outputs)
+    assert outputs
 
     dataset_ids = first_level_dataset_ids | third_level_dataset_ids
     datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
 
     run_ids = {first_level_run.id} | second_level_run_ids
     runs = [run for run in lineage.runs if run.id in run_ids]
+    assert runs
 
     job_ids = {run.job_id for run in runs}
     jobs = [job for job in lineage.jobs if job.id in job_ids]
+    assert jobs
 
     jobs = await enrich_jobs(jobs, async_session)
     runs = await enrich_runs(runs, async_session)
@@ -833,7 +839,6 @@ async def test_get_run_lineage_with_depth(
         params={
             "since": first_level_run.created_at.isoformat(),
             "start_node_id": str(first_level_run.id),
-            "direction": "DOWNSTREAM",
             "depth": 3,
         },
     )
@@ -853,10 +858,12 @@ async def test_get_run_lineage_with_depth(
                 "kind": "INPUT",
                 "from": {"kind": "DATASET", "id": input.dataset_id},
                 "to": {"kind": "RUN", "id": str(input.run_id)},
-                "num_bytes": input_stats[input.dataset_id]["num_bytes"],
-                "num_rows": input_stats[input.dataset_id]["num_rows"],
-                "num_files": input_stats[input.dataset_id]["num_files"],
-                "last_interaction_at": input_stats[input.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
             }
             for input in sorted(inputs, key=lambda x: (x.dataset_id, x.run_id))
         ]
@@ -865,11 +872,13 @@ async def test_get_run_lineage_with_depth(
                 "kind": "OUTPUT",
                 "from": {"kind": "RUN", "id": str(output.run_id)},
                 "to": {"kind": "DATASET", "id": output.dataset_id},
-                "type": "APPEND",
-                "num_bytes": output_stats[output.dataset_id]["num_bytes"],
-                "num_rows": output_stats[output.dataset_id]["num_rows"],
-                "num_files": output_stats[output.dataset_id]["num_files"],
-                "last_interaction_at": output_stats[output.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "type": output.type,
+                "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
             }
             for output in sorted(outputs, key=lambda x: (x.run_id, x.dataset_id))
         ],
@@ -928,14 +937,14 @@ async def test_get_run_lineage_with_depth(
     }
 
 
-async def test_get_run_lineage_with_depth_and_operation_granularity(
+async def test_get_run_lineage_with_depth_and_granularity_operation(
     test_client: AsyncClient,
     async_session: AsyncSession,
     lineage_with_depth: LineageResult,
 ):
     lineage = lineage_with_depth
     # Select only relations marked with *
-    # J1 -*> R1 -*> O1, D1 --> O1 -*> D2
+    # J1 -*> R1 -*> O1, D1 -*> O1 -*> D2
     # J2 -*> R2 -*> O2, D2 -*> O2 -*> D3
     # J3 --> R3 --> O3, D3 --> O3 --> D4
 
@@ -943,17 +952,22 @@ async def test_get_run_lineage_with_depth_and_operation_granularity(
 
     # Go operations[first level] -> datasets[second level]
     first_level_operations = [operation for operation in lineage.operations if operation.run_id == first_level_run.id]
-    assert first_level_operations
     first_level_operation_ids = {operation.id for operation in first_level_operations}
+    first_level_inputs = [input for input in lineage.inputs if input.operation_id in first_level_operation_ids]
     first_level_outputs = [output for output in lineage.outputs if output.operation_id in first_level_operation_ids]
-    assert first_level_outputs
-    first_level_dataset_ids = {output.dataset_id for output in first_level_outputs}
+    first_level_input_dataset_ids = {input.dataset_id for input in first_level_inputs}
+    first_level_output_dataset_ids = {output.dataset_id for output in first_level_outputs}
+    first_level_dataset_ids = first_level_input_dataset_ids | first_level_output_dataset_ids
     assert first_level_dataset_ids
 
     # Go datasets[second level] -> operations[second level]
-    second_level_inputs = [input for input in lineage.inputs if input.dataset_id in first_level_dataset_ids]
-    assert second_level_inputs
-    second_level_operation_ids = {input.operation_id for input in second_level_inputs} - first_level_operation_ids
+    second_level_inputs = [input for input in lineage.inputs if input.dataset_id in first_level_output_dataset_ids]
+    second_level_outputs = [output for output in lineage.outputs if output.dataset_id in first_level_input_dataset_ids]
+    second_level_input_operation_ids = {input.operation_id for input in second_level_inputs}
+    second_level_output_operation_ids = {output.operation_id for output in second_level_outputs}
+    second_level_operation_ids = (
+        second_level_input_operation_ids | second_level_output_operation_ids - first_level_operation_ids
+    )
     second_level_operations = [
         operation for operation in lineage.operations if operation.id in second_level_operation_ids
     ]
@@ -961,26 +975,36 @@ async def test_get_run_lineage_with_depth_and_operation_granularity(
 
     # Go operations[second level] -> datasets[third level]
     # There are more levels in this graph, but we stop here
-    third_level_outputs = [output for output in lineage.outputs if output.operation_id in second_level_operation_ids]
-    third_level_dataset_ids = {output.dataset_id for output in third_level_outputs} - first_level_dataset_ids
+    third_level_inputs = [input for input in lineage.inputs if input.operation_id in second_level_output_operation_ids]
+    third_level_outputs = [
+        output for output in lineage.outputs if output.operation_id in second_level_input_operation_ids
+    ]
+    third_level_input_dataset_ids = {input.dataset_id for input in third_level_inputs}
+    third_level_output_dataset_ids = {output.dataset_id for output in third_level_outputs}
+    third_level_dataset_ids = third_level_input_dataset_ids | third_level_output_dataset_ids - first_level_dataset_ids
     assert third_level_dataset_ids
 
-    inputs = second_level_inputs
-    input_stats = relation_stats(inputs)
-    outputs = first_level_outputs + third_level_outputs
-    output_stats = relation_stats(outputs)
+    inputs = first_level_inputs + second_level_inputs + third_level_inputs
+    assert inputs
+
+    outputs = first_level_outputs + second_level_outputs + third_level_outputs
+    assert outputs
 
     dataset_ids = first_level_dataset_ids | third_level_dataset_ids
     datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
 
     operation_ids = first_level_operation_ids | second_level_operation_ids
     operations = [operation for operation in lineage.operations if operation.id in operation_ids]
+    assert operations
 
     run_ids = {operation.run_id for operation in operations}
     runs = [run for run in lineage.runs if run.id in run_ids]
+    assert runs
 
     job_ids = {run.job_id for run in runs}
     jobs = [job for job in lineage.jobs if job.id in job_ids]
+    assert jobs
 
     jobs = await enrich_jobs(jobs, async_session)
     runs = await enrich_runs(runs, async_session)
@@ -991,7 +1015,6 @@ async def test_get_run_lineage_with_depth_and_operation_granularity(
         params={
             "since": first_level_run.created_at.isoformat(),
             "start_node_id": str(first_level_run.id),
-            "direction": "DOWNSTREAM",
             "granularity": "OPERATION",
             "depth": 3,
         },
@@ -1020,10 +1043,10 @@ async def test_get_run_lineage_with_depth_and_operation_granularity(
                 "kind": "INPUT",
                 "from": {"kind": "DATASET", "id": input.dataset_id},
                 "to": {"kind": "OPERATION", "id": str(input.operation_id)},
-                "num_bytes": input_stats[input.dataset_id]["num_bytes"],
-                "num_rows": input_stats[input.dataset_id]["num_rows"],
-                "num_files": input_stats[input.dataset_id]["num_files"],
-                "last_interaction_at": input_stats[input.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "num_bytes": input.num_bytes,
+                "num_rows": input.num_rows,
+                "num_files": input.num_files,
+                "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for input in sorted(inputs, key=lambda x: (x.dataset_id, x.operation_id))
         ]
@@ -1032,11 +1055,11 @@ async def test_get_run_lineage_with_depth_and_operation_granularity(
                 "kind": "OUTPUT",
                 "from": {"kind": "OPERATION", "id": str(output.operation_id)},
                 "to": {"kind": "DATASET", "id": output.dataset_id},
-                "type": "APPEND",
-                "num_bytes": output_stats[output.dataset_id]["num_bytes"],
-                "num_rows": output_stats[output.dataset_id]["num_rows"],
-                "num_files": output_stats[output.dataset_id]["num_files"],
-                "last_interaction_at": output_stats[output.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "type": output.type,
+                "num_bytes": output.num_bytes,
+                "num_rows": output.num_rows,
+                "num_files": output.num_files,
+                "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for output in sorted(outputs, key=lambda x: (x.operation_id, x.dataset_id))
         ],
@@ -1118,20 +1141,25 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
     lineage_with_depth_and_cycle: LineageResult,
 ):
     lineage = lineage_with_depth_and_cycle
+    # Select all relations:
+    # J1 -*> R1 -*> O1, D1 -*> O1 -*> D2
+    # J2 -*> R2 -*> O2, D2 -*> O2 -*> D1
+
+    # We can start at any run
     run = lineage.runs[0]
-    runs = await enrich_runs(lineage.runs, async_session)
-    jobs = await enrich_jobs(lineage.jobs, async_session)
-    [dataset] = await enrich_datasets(lineage.datasets, async_session)
+
     input_stats = relation_stats_by_runs(lineage.inputs)
     output_stats = relation_stats_by_runs(lineage.outputs)
 
-    since = min(run.created_at for run in runs)
+    runs = await enrich_runs(lineage.runs, async_session)
+    jobs = await enrich_jobs(lineage.jobs, async_session)
+    datasets = await enrich_datasets(lineage.datasets, async_session)
+
     response = await test_client.get(
         "v1/runs/lineage",
         params={
-            "since": since.isoformat(),
+            "since": run.created_at.isoformat(),
             "start_node_id": str(run.id),
-            "direction": "DOWNSTREAM",
             "depth": 3,
         },
     )
@@ -1149,31 +1177,31 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
         + [
             {
                 "kind": "INPUT",
-                "from": {"kind": "DATASET", "id": dataset.id},
-                "to": {"kind": "RUN", "id": str(run.id)},
-                "num_bytes": input_stats[(run.id, dataset.id)]["num_bytes"],
-                "num_rows": input_stats[(run.id, dataset.id)]["num_rows"],
-                "num_files": input_stats[(run.id, dataset.id)]["num_files"],
-                "last_interaction_at": input_stats[(run.id, dataset.id)]["created_at"].strftime(
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "RUN", "id": str(input.run_id)},
+                "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for run in runs
+            for input in sorted(lineage.inputs, key=lambda x: (x.dataset_id, x.run_id))
         ]
         + [
             {
                 "kind": "OUTPUT",
-                "from": {"kind": "RUN", "id": str(run.id)},
-                "to": {"kind": "DATASET", "id": dataset.id},
-                "type": "APPEND",
-                "num_bytes": output_stats[(run.id, dataset.id)]["num_bytes"],
-                "num_rows": output_stats[(run.id, dataset.id)]["num_rows"],
-                "num_files": output_stats[(run.id, dataset.id)]["num_files"],
-                "last_interaction_at": output_stats[(run.id, dataset.id)]["created_at"].strftime(
+                "from": {"kind": "RUN", "id": str(output.run_id)},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
             }
-            for run in runs
+            for output in sorted(lineage.outputs, key=lambda x: (x.run_id, x.dataset_id))
         ],
         "nodes": [
             {
@@ -1204,7 +1232,8 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
                     "addresses": [{"url": address.url} for address in dataset.location.addresses],
                     "external_id": dataset.location.external_id,
                 },
-            },
+            }
+            for dataset in datasets
         ]
         + [
             {
@@ -1225,150 +1254,6 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
                 "end_reason": run.end_reason,
             }
             for run in runs
-        ],
-    }
-
-
-async def test_get_run_lineage_with_depth_ignore_cycles_with_operation_granularity(
-    test_client: AsyncClient,
-    async_session: AsyncSession,
-    lineage_with_depth_and_cycle: LineageResult,
-):
-    lineage = lineage_with_depth_and_cycle
-    run = lineage.runs[0]
-
-    [dataset] = await enrich_datasets(lineage.datasets, async_session)
-    jobs = await enrich_jobs(lineage.jobs, async_session)
-    runs = await enrich_runs(lineage.runs, async_session)
-    input_stats = relation_stats_by_operations(lineage.inputs)
-    output_stats = relation_stats_by_operations(lineage.outputs)
-
-    since = min(run.created_at for run in runs)
-    response = await test_client.get(
-        "v1/runs/lineage",
-        params={
-            "since": since.isoformat(),
-            "start_node_id": str(run.id),
-            "direction": "DOWNSTREAM",
-            "granularity": "OPERATION",
-            "depth": 3,
-        },
-    )
-
-    assert response.status_code == HTTPStatus.OK, response.json()
-    assert response.json() == {
-        "relations": [
-            {
-                "kind": "PARENT",
-                "from": {"kind": "JOB", "id": run.job_id},
-                "to": {"kind": "RUN", "id": str(run.id)},
-            }
-            for run in runs
-        ]
-        + [
-            {
-                "kind": "PARENT",
-                "from": {"kind": "RUN", "id": str(operation.run_id)},
-                "to": {"kind": "OPERATION", "id": str(operation.id)},
-            }
-            for operation in sorted(lineage.operations, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "INPUT",
-                "from": {"kind": "DATASET", "id": dataset.id},
-                "to": {"kind": "OPERATION", "id": str(operation.id)},
-                "num_bytes": input_stats[(operation.id, dataset.id)]["num_bytes"],
-                "num_rows": input_stats[(operation.id, dataset.id)]["num_rows"],
-                "num_files": input_stats[(operation.id, dataset.id)]["num_files"],
-                "last_interaction_at": input_stats[(operation.id, dataset.id)]["created_at"].strftime(
-                    "%Y-%m-%dT%H:%M:%S.%fZ",
-                ),
-            }
-            for operation in sorted(lineage.operations, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "OUTPUT",
-                "from": {"kind": "OPERATION", "id": str(operation.id)},
-                "to": {"kind": "DATASET", "id": dataset.id},
-                "type": "APPEND",
-                "num_bytes": output_stats[(operation.id, dataset.id)]["num_bytes"],
-                "num_rows": output_stats[(operation.id, dataset.id)]["num_rows"],
-                "num_files": output_stats[(operation.id, dataset.id)]["num_files"],
-                "last_interaction_at": output_stats[(operation.id, dataset.id)]["created_at"].strftime(
-                    "%Y-%m-%dT%H:%M:%S.%fZ",
-                ),
-            }
-            for operation in sorted(lineage.operations, key=lambda x: x.id)
-        ],
-        "nodes": [
-            {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "name": job.location.name,
-                    "type": job.location.type,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
-                },
-            }
-            for job in sorted(jobs, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
-                },
-            },
-        ]
-        + [
-            {
-                "kind": "RUN",
-                "id": str(run.id),
-                "job_id": run.job_id,
-                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "parent_run_id": str(run.parent_run_id),
-                "status": run.status.name,
-                "external_id": run.external_id,
-                "attempt": run.attempt,
-                "persistent_log_url": run.persistent_log_url,
-                "running_log_url": run.running_log_url,
-                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "started_by_user": {"name": run.started_by_user.name},
-                "start_reason": run.start_reason.value,
-                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "end_reason": run.end_reason,
-            }
-            for run in sorted(runs, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "OPERATION",
-                "id": str(operation.id),
-                "created_at": operation.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "run_id": str(operation.run_id),
-                "name": operation.name,
-                "status": operation.status.name,
-                "type": operation.type.value,
-                "position": operation.position,
-                "group": operation.group,
-                "description": operation.description,
-                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            }
-            for operation in sorted(lineage.operations, key=lambda x: x.id)
         ],
     }
 
@@ -1379,19 +1264,18 @@ async def test_get_run_lineage_with_symlinks(
     lineage_with_symlinks: LineageResult,
 ):
     lineage = lineage_with_symlinks
-
-    input = lineage.inputs[1]
-    operation = next(operation for operation in lineage.operations if operation.id == input.operation_id)
-    run = next(run for run in lineage.runs if run.id == operation.run_id)
+    run = lineage.runs[1]
     job = next(job for job in lineage.jobs if job.id == run.job_id)
 
-    operations = [operation for operation in lineage.operations if operation.run_id == run.id]
-    operation_ids = {operation.id for operation in operations}
-    assert operations
+    inputs = [input for input in lineage.inputs if input.run_id == run.id]
+    input_stats = relation_stats_by_runs(inputs)
+    assert inputs
 
-    outputs = [output for output in lineage.outputs if output.operation_id in operation_ids]
-    output_stats = relation_stats(outputs)
-    dataset_ids = {output.dataset_id for output in outputs}
+    outputs = [output for output in lineage.outputs if output.run_id == run.id]
+    output_stats = relation_stats_by_runs(outputs)
+    assert outputs
+
+    dataset_ids = {input.dataset_id for input in inputs} | {output.dataset_id for output in outputs}
 
     # Dataset from symlinks appear only as SYMLINK location, but not as INPUT, because of depth=1
     dataset_symlinks = [
@@ -1401,8 +1285,8 @@ async def test_get_run_lineage_with_symlinks(
     ]
     dataset_ids_from_symlink = {dataset_symlink.from_dataset_id for dataset_symlink in dataset_symlinks}
     dataset_ids_to_symlink = {dataset_symlink.to_dataset_id for dataset_symlink in dataset_symlinks}
-    dataset_ids = dataset_ids | dataset_ids_from_symlink | dataset_ids_to_symlink
-    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    dataset_ids_with_symlinks = dataset_ids | dataset_ids_from_symlink | dataset_ids_to_symlink
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids_with_symlinks]
     assert datasets
 
     [job] = await enrich_jobs([job], async_session)
@@ -1414,7 +1298,6 @@ async def test_get_run_lineage_with_symlinks(
         params={
             "since": run.created_at.isoformat(),
             "start_node_id": str(run.id),
-            "direction": "DOWNSTREAM",
         },
     )
 
@@ -1438,14 +1321,30 @@ async def test_get_run_lineage_with_symlinks(
         ]
         + [
             {
+                "kind": "INPUT",
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "RUN", "id": str(input.run_id)},
+                "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.run_id))
+        ]
+        + [
+            {
                 "kind": "OUTPUT",
                 "from": {"kind": "RUN", "id": str(output.run_id)},
                 "to": {"kind": "DATASET", "id": output.dataset_id},
-                "type": "APPEND",
-                "num_bytes": output_stats[output.dataset_id]["num_bytes"],
-                "num_rows": output_stats[output.dataset_id]["num_rows"],
-                "num_files": output_stats[output.dataset_id]["num_files"],
-                "last_interaction_at": output_stats[output.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "type": output.type,
+                "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
             }
             for output in sorted(outputs, key=lambda x: (x.run_id, x.dataset_id))
         ],
@@ -1498,160 +1397,5 @@ async def test_get_run_lineage_with_symlinks(
                 "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "end_reason": run.end_reason,
             },
-        ],
-    }
-
-
-async def test_get_run_lineage_with_symlinks_and_operation_granularity(
-    test_client: AsyncClient,
-    async_session: AsyncSession,
-    lineage_with_symlinks: LineageResult,
-):
-    lineage = lineage_with_symlinks
-
-    input = lineage.inputs[1]
-    operation = next(operation for operation in lineage.operations if operation.id == input.operation_id)
-    run = next(run for run in lineage.runs if run.id == operation.run_id)
-    job = next(job for job in lineage.jobs if job.id == run.job_id)
-
-    operations = [operation for operation in lineage.operations if operation.run_id == run.id]
-    operation_ids = {operation.id for operation in operations}
-    assert operations
-
-    outputs = [output for output in lineage.outputs if output.operation_id in operation_ids]
-    output_stats = relation_stats(outputs)
-    dataset_ids = {output.dataset_id for output in outputs}
-
-    # Dataset from symlinks appear only as SYMLINK location, but not as INPUT, because of depth=1
-    dataset_symlinks = [
-        dataset_symlink
-        for dataset_symlink in lineage.dataset_symlinks
-        if dataset_symlink.from_dataset_id in dataset_ids or dataset_symlink.to_dataset_id in dataset_ids
-    ]
-    dataset_ids_from_symlink = {dataset_symlink.from_dataset_id for dataset_symlink in dataset_symlinks}
-    dataset_ids_to_symlink = {dataset_symlink.to_dataset_id for dataset_symlink in dataset_symlinks}
-    dataset_ids = dataset_ids | dataset_ids_from_symlink | dataset_ids_to_symlink
-    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
-    assert datasets
-
-    [job] = await enrich_jobs([job], async_session)
-    [run] = await enrich_runs([run], async_session)
-    datasets = await enrich_datasets(datasets, async_session)
-
-    response = await test_client.get(
-        "v1/runs/lineage",
-        params={
-            "since": run.created_at.isoformat(),
-            "start_node_id": str(run.id),
-            "direction": "DOWNSTREAM",
-            "granularity": "OPERATION",
-        },
-    )
-
-    assert response.status_code == HTTPStatus.OK, response.json()
-    assert response.json() == {
-        "relations": [
-            {
-                "kind": "PARENT",
-                "from": {"kind": "JOB", "id": run.job_id},
-                "to": {"kind": "RUN", "id": str(run.id)},
-            },
-        ]
-        + [
-            {
-                "kind": "PARENT",
-                "from": {"kind": "RUN", "id": str(operation.run_id)},
-                "to": {"kind": "OPERATION", "id": str(operation.id)},
-            }
-            for operation in sorted(operations, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "SYMLINK",
-                "from": {"kind": "DATASET", "id": symlink.from_dataset_id},
-                "to": {"kind": "DATASET", "id": symlink.to_dataset_id},
-                "type": symlink.type.value,
-            }
-            for symlink in sorted(dataset_symlinks, key=lambda x: (x.from_dataset_id, x.to_dataset_id))
-        ]
-        + [
-            {
-                "kind": "OUTPUT",
-                "from": {"kind": "OPERATION", "id": str(output.operation_id)},
-                "to": {"kind": "DATASET", "id": output.dataset_id},
-                "type": "APPEND",
-                "num_bytes": output_stats[output.dataset_id]["num_bytes"],
-                "num_rows": output_stats[output.dataset_id]["num_rows"],
-                "num_files": output_stats[output.dataset_id]["num_files"],
-                "last_interaction_at": output_stats[output.dataset_id]["created_at"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            }
-            for output in outputs
-        ],
-        "nodes": [
-            {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "name": job.location.name,
-                    "type": job.location.type,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
-                },
-            },
-        ]
-        + [
-            {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
-                },
-            }
-            for dataset in sorted(datasets, key=lambda x: x.id)
-        ]
-        + [
-            {
-                "kind": "RUN",
-                "id": str(run.id),
-                "job_id": run.job_id,
-                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "parent_run_id": str(run.parent_run_id),
-                "status": run.status.name,
-                "external_id": run.external_id,
-                "attempt": run.attempt,
-                "persistent_log_url": run.persistent_log_url,
-                "running_log_url": run.running_log_url,
-                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "started_by_user": {"name": run.started_by_user.name},
-                "start_reason": run.start_reason.value,
-                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "end_reason": run.end_reason,
-            },
-        ]
-        + [
-            {
-                "kind": "OPERATION",
-                "id": str(operation.id),
-                "created_at": operation.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "run_id": str(operation.run_id),
-                "name": operation.name,
-                "status": operation.status.name,
-                "type": operation.type.value,
-                "position": operation.position,
-                "group": operation.group,
-                "description": operation.description,
-                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            }
-            for operation in sorted(operations, key=lambda x: x.id)
         ],
     }

--- a/tests/test_server/utils/stats.py
+++ b/tests/test_server/utils/stats.py
@@ -1,38 +1,6 @@
 from data_rentgen.db.models import Input, Output
 
 
-def relation_stats(relations: list[Input] | list[Output]):
-    stats = {}
-    for relation in relations:
-        if relation.dataset_id not in stats:
-            stats[relation.dataset_id] = {"num_bytes": 0, "num_rows": 0, "num_files": 0, "created_at": None}
-
-        stats[relation.dataset_id]["num_bytes"] += relation.num_bytes
-        stats[relation.dataset_id]["num_rows"] += relation.num_rows
-        stats[relation.dataset_id]["num_files"] += relation.num_files
-        stats[relation.dataset_id]["created_at"] = max(
-            stats[relation.dataset_id]["created_at"] or relation.created_at,
-            relation.created_at,
-        )
-
-    return stats
-
-
-def relation_stats_by_operations(relations: list[Input] | list[Output]):
-    stats = {}
-    for relation in relations:
-        key = (relation.operation_id, relation.dataset_id)
-        if key not in stats:
-            stats[key] = {"num_bytes": 0, "num_rows": 0, "num_files": 0, "created_at": None}
-
-        stats[key]["num_bytes"] += relation.num_bytes
-        stats[key]["num_rows"] += relation.num_rows
-        stats[key]["num_files"] += relation.num_files
-        stats[key]["created_at"] = max(stats[key]["created_at"] or relation.created_at, relation.created_at)
-
-    return stats
-
-
 def relation_stats_by_runs(relations: list[Input] | list[Output]):
     stats = {}
     for relation in relations:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

* Set `direction=BOTH` as default in all API entpoints.
* Instead of test like `with_direction_both` make tests `with_direction_downstream` & `with_direction_upstream`. By default, tests do not set `direction` at all, so `BOTH` is used.
* Remove lineage tests which passed multiple options to API, like `with_until_granularity` or `with_until_direction`. Instead, make separated tests `with_until`, `with_granularity`. The only exception is `with_depth_granularity` because these ones are deeply related.
* Drop `relation_stats` and `relation_stats_by_operations` helpers - first one is not used anymore, second one is replaced with just accessing the original `input` or `output` object (`granularity=OPERATION` returns original inputs & outputs, without aggregation).
* During rewrite, I've discovered that `test_with_depth_ignore_cycles` actually didn't checked any cycles, because it was run only with `direction=DOWNSTREAM` or `direction=UPSTREAM`, when cycles appears only with `direction=BOTH`. Fixed by replacing `list[Input]` with `dict[Input.unique_keys, Input]`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
