### PR TITLE
[DOP-20062] Add schema to relations in a lineage response

### DIFF
--- a/data_rentgen/db/models/input.py
+++ b/data_rentgen/db/models/input.py
@@ -94,7 +94,7 @@ class Input(Base):
     schema: Mapped[Schema | None] = relationship(
         Schema,
         primaryjoin="Input.schema_id == Schema.id",
-        lazy="noload",
+        lazy="selectin",
         foreign_keys=[schema_id],
     )
 

--- a/data_rentgen/db/models/output.py
+++ b/data_rentgen/db/models/output.py
@@ -119,7 +119,7 @@ class Output(Base):
     schema: Mapped[Schema | None] = relationship(
         Schema,
         primaryjoin="Output.schema_id == Schema.id",
-        lazy="noload",
+        lazy="selectin",
         foreign_keys=[schema_id],
     )
 

--- a/data_rentgen/db/repositories/input.py
+++ b/data_rentgen/db/repositories/input.py
@@ -174,7 +174,11 @@ class InputRepository(Repository[Input]):
         inputs: list[Input],
     ) -> list[Input]:
         # Add schema to inputs
-        query = select(Input).where(Input.id.in_([input.id for input in inputs])).options(selectinload(Input.schema))
+        query = (
+            select(Input)
+            .where(Input.id == any_([input.id for input in inputs]))  # type: ignore[arg-type]
+            .options(selectinload(Input.schema))
+        )
         result = await self._session.scalars(query)
         return list(result.all())
 
@@ -207,7 +211,7 @@ class InputRepository(Repository[Input]):
                 func.sum(Input.num_bytes).label("num_bytes"),
                 func.sum(Input.num_rows).label("num_rows"),
                 func.sum(Input.num_files).label("num_files"),
-                literal_column("NULL").label("schema"),
+                literal_column("NULL").label("schema_id"),
             ).group_by(
                 Input.run_id,
                 Input.job_id,
@@ -224,7 +228,7 @@ class InputRepository(Repository[Input]):
             func.sum(Input.num_bytes).label("num_bytes"),
             func.sum(Input.num_rows).label("num_rows"),
             func.sum(Input.num_files).label("num_files"),
-            literal_column("NULL").label("schema"),
+            literal_column("NULL").label("schema_id"),
         ).group_by(
             Input.job_id,
             Input.dataset_id,

--- a/data_rentgen/db/repositories/input.py
+++ b/data_rentgen/db/repositories/input.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from sqlalchemy import Select, any_, func, literal_column, select
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import selectinload
 
 from data_rentgen.db.models import Input
 from data_rentgen.db.repositories.base import Repository
@@ -108,7 +109,12 @@ class InputRepository(Repository[Input]):
 
         results = await self._session.execute(query)
         # convert tuple of fields to Input object
-        return [Input(**row._asdict()) for row in results.all()]  # noqa: WPS437
+        inputs = [Input(**row._asdict()) for row in results.all()]  # noqa: WPS437
+        if granularity == "OPERATION":
+            # Add schema to inputs
+            return await self._add_schemas(inputs)
+
+        return inputs
 
     async def list_by_job_ids(
         self,
@@ -129,7 +135,12 @@ class InputRepository(Repository[Input]):
 
         results = await self._session.execute(query)
         # convert tuple of fields to Input object
-        return [Input(**row._asdict()) for row in results.all()]  # noqa: WPS437
+        inputs = [Input(**row._asdict()) for row in results.all()]  # noqa: WPS437
+        if granularity == "OPERATION":
+            # Add schema to inputs
+            return await self._add_schemas(inputs)
+
+        return inputs
 
     async def list_by_dataset_ids(
         self,
@@ -150,7 +161,22 @@ class InputRepository(Repository[Input]):
 
         results = await self._session.execute(query)
         # convert tuple of fields to Input object
-        return [Input(**row._asdict()) for row in results.all()]  # noqa: WPS437
+        inputs = [Input(**row._asdict()) for row in results.all()]  # noqa: WPS437
+
+        if granularity == "OPERATION":
+            # Add schema to inputs
+            return await self._add_schemas(inputs)
+
+        return inputs
+
+    async def _add_schemas(
+        self,
+        inputs: list[Input],
+    ) -> list[Input]:
+        # Add schema to inputs
+        query = select(Input).where(Input.id.in_([input.id for input in inputs])).options(selectinload(Input.schema))
+        result = await self._session.scalars(query)
+        return list(result.all())
 
     def _get_select(
         self,
@@ -167,6 +193,7 @@ class InputRepository(Repository[Input]):
                 Input.num_bytes,
                 Input.num_rows,
                 Input.num_files,
+                Input.schema_id,
             )
 
         if granularity == "RUN":
@@ -180,6 +207,7 @@ class InputRepository(Repository[Input]):
                 func.sum(Input.num_bytes).label("num_bytes"),
                 func.sum(Input.num_rows).label("num_rows"),
                 func.sum(Input.num_files).label("num_files"),
+                literal_column("NULL").label("schema"),
             ).group_by(
                 Input.run_id,
                 Input.job_id,
@@ -196,6 +224,7 @@ class InputRepository(Repository[Input]):
             func.sum(Input.num_bytes).label("num_bytes"),
             func.sum(Input.num_rows).label("num_rows"),
             func.sum(Input.num_files).label("num_files"),
+            literal_column("NULL").label("schema"),
         ).group_by(
             Input.job_id,
             Input.dataset_id,

--- a/data_rentgen/db/repositories/output.py
+++ b/data_rentgen/db/repositories/output.py
@@ -175,7 +175,9 @@ class OutputRepository(Repository[Output]):
     ) -> list[Output]:
         # Add schema to inputs
         query = (
-            select(Output).where(Output.id.in_([output.id for output in outputs])).options(selectinload(Output.schema))
+            select(Output)
+            .where(Output.id == any_([output.id for output in outputs]))  # type: ignore[arg-type]
+            .options(selectinload(Output.schema))
         )
         result = await self._session.scalars(query)
         return list(result.all())
@@ -211,7 +213,7 @@ class OutputRepository(Repository[Output]):
                 func.sum(Output.num_bytes).label("num_bytes"),
                 func.sum(Output.num_rows).label("num_rows"),
                 func.sum(Output.num_files).label("num_files"),
-                literal_column("NULL").label("schema"),
+                literal_column("NULL").label("schema_id"),
             ).group_by(
                 Output.run_id,
                 Output.job_id,
@@ -230,7 +232,7 @@ class OutputRepository(Repository[Output]):
             func.sum(Output.num_bytes).label("num_bytes"),
             func.sum(Output.num_rows).label("num_rows"),
             func.sum(Output.num_files).label("num_files"),
-            literal_column("NULL").label("schema"),
+            literal_column("NULL").label("schema_id"),
         ).group_by(
             Output.job_id,
             Output.dataset_id,

--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -112,11 +112,11 @@ class LineageParentRelationV1(BaseModel):
     to: LineageEntityV1 = Field(description="End point of relation")
 
 
-class Schema(BaseModel):
+class LineageOutputRelationSchemaV1(BaseModel):
     name: str | None = Field(default=None)
     type: str | None = Field(default=None)
     description: str | None = Field(default=None)
-    fields: list["Schema"] = Field(description="Schema fields", default_factory=list)
+    fields: list["LineageOutputRelationSchemaV1"] = Field(description="Schema fields", default_factory=list)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -129,7 +129,11 @@ class LineageInputRelationV1(BaseModel):
     num_bytes: int | None = Field(description="Number of bytes", examples=[42], default=None)
     num_rows: int | None = Field(description="Number of rows", examples=[42], default=None)
     num_files: int | None = Field(description="Number of files", examples=[42], default=None)
-    i_schema: Schema | None = Field(description="Schema", default=None, serialization_alias="schema")
+    i_schema: LineageOutputRelationSchemaV1 | None = Field(
+        description="Schema",
+        default=None,
+        serialization_alias="schema",
+    )
 
 
 class LineageOutputRelationV1(BaseModel):
@@ -141,7 +145,11 @@ class LineageOutputRelationV1(BaseModel):
     num_bytes: int | None = Field(description="Number of bytes", examples=[42], default=None)
     num_rows: int | None = Field(description="Number of rows", examples=[42], default=None)
     num_files: int | None = Field(description="Number of files", examples=[42], default=None)
-    o_schema: Schema | None = Field(description="Schema", default=None, serialization_alias="schema")
+    o_schema: LineageOutputRelationSchemaV1 | None = Field(
+        description="Schema",
+        default=None,
+        serialization_alias="schema",
+    )
 
 
 class LineageSymlinkRelationV1(BaseModel):

--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -112,6 +112,15 @@ class LineageParentRelationV1(BaseModel):
     to: LineageEntityV1 = Field(description="End point of relation")
 
 
+class Schema(BaseModel):
+    name: str | None = Field(default=None)
+    type: str | None = Field(default=None)
+    description: str | None = Field(default=None)
+    fields: list["Schema"] = Field(description="Schema fields", default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class LineageInputRelationV1(BaseModel):
     kind: Literal["INPUT"] = "INPUT"
     from_: LineageEntityV1 = Field(description="Start point of relation", serialization_alias="from")
@@ -120,6 +129,7 @@ class LineageInputRelationV1(BaseModel):
     num_bytes: int | None = Field(description="Number of bytes", examples=[42], default=None)
     num_rows: int | None = Field(description="Number of rows", examples=[42], default=None)
     num_files: int | None = Field(description="Number of files", examples=[42], default=None)
+    i_schema: Schema | None = Field(description="Schema", default=None, serialization_alias="schema")
 
 
 class LineageOutputRelationV1(BaseModel):
@@ -131,6 +141,7 @@ class LineageOutputRelationV1(BaseModel):
     num_bytes: int | None = Field(description="Number of bytes", examples=[42], default=None)
     num_rows: int | None = Field(description="Number of rows", examples=[42], default=None)
     num_files: int | None = Field(description="Number of files", examples=[42], default=None)
+    o_schema: Schema | None = Field(description="Schema", default=None, serialization_alias="schema")
 
 
 class LineageSymlinkRelationV1(BaseModel):

--- a/data_rentgen/server/utils/lineage_response.py
+++ b/data_rentgen/server/utils/lineage_response.py
@@ -85,6 +85,7 @@ async def _add_input_relations(
             num_bytes=input.num_bytes,
             num_rows=input.num_rows,
             num_files=input.num_files,
+            i_schema=input.schema,
         )
         relations.append(relation)
     return sorted(relations, key=lambda x: (x.from_.id, x.to.id))
@@ -109,6 +110,7 @@ async def _add_output_relations(
             num_bytes=output.num_bytes,
             num_rows=output.num_rows,
             num_files=output.num_files,
+            o_schema=output.schema,
         )
         relations.append(relation)
     return sorted(relations, key=lambda x: (x.from_.id, x.to.id, x.type))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,7 @@ docstring_style = "sphinx"
 
 [tool.codespell]
 exclude-file = "poetry.lock"
+ignore-words-list = "selectin"
 
 [tool.flake8]
 jobs = 4

--- a/tests/test_server/fixtures/factories/input.py
+++ b/tests/test_server/fixtures/factories/input.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from data_rentgen.db.models import Input
 from data_rentgen.db.utils.uuid import extract_timestamp_from_uuid, generate_new_uuid
+from tests.test_server.fixtures.factories.schema import create_schema
 
 
 def input_factory(**kwargs) -> Input:
@@ -25,8 +26,14 @@ def input_factory(**kwargs) -> Input:
     return Input(**data)
 
 
-async def create_input(async_session: AsyncSession, input_kwargs: dict | None = None) -> Input:
+async def create_input(
+    async_session: AsyncSession,
+    input_kwargs: dict | None = None,
+    schema_kwargs: dict | None = None,
+) -> Input:
     input_kwargs = input_kwargs or {}
+    schema = await create_schema(async_session, schema_kwargs)
+    input_kwargs.update({"schema_id": schema.id})
     input = input_factory(**input_kwargs)
     async_session.add(input)
     await async_session.commit()

--- a/tests/test_server/fixtures/factories/output.py
+++ b/tests/test_server/fixtures/factories/output.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from data_rentgen.db.models import Output, OutputType
 from data_rentgen.db.utils.uuid import extract_timestamp_from_uuid, generate_new_uuid
+from tests.test_server.fixtures.factories.schema import create_schema
 
 
 def output_factory(**kwargs) -> Output:
@@ -26,8 +27,14 @@ def output_factory(**kwargs) -> Output:
     return Output(**data)
 
 
-async def create_output(async_session: AsyncSession, output_kwargs: dict | None = None) -> Output:
+async def create_output(
+    async_session: AsyncSession,
+    output_kwargs: dict | None = None,
+    schema_kwargs: dict | None = None,
+) -> Output:
     output_kwargs = output_kwargs or {}
+    schema = await create_schema(async_session, schema_kwargs)
+    output_kwargs.update({"schema_id": schema.id})
     output = output_factory(**output_kwargs)
     async_session.add(output)
     await async_session.commit()

--- a/tests/test_server/fixtures/factories/schema.py
+++ b/tests/test_server/fixtures/factories/schema.py
@@ -1,0 +1,30 @@
+from random import randint
+from uuid import uuid4
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from data_rentgen.db.models import Schema
+
+
+def schema_factory(**kwargs) -> Schema:
+    data = {
+        "id": randint(0, 10000000),
+        "digest": uuid4(),
+        "fields": [
+            {"name": "dt", "type": "timestamp"},
+            {"name": "customer_id", "type": "decimal(20,0)"},
+            {"name": "total_spent", "type": "float"},
+        ],
+    }
+    data.update(kwargs)
+    return Schema(**data)
+
+
+async def create_schema(session: AsyncSession, schema_kwargs: dict | None = None) -> Schema:
+    schema_kwargs = schema_kwargs or {}
+    schema = schema_factory(**schema_kwargs)
+    del schema.id
+    session.add(schema)
+    await session.commit()
+    await session.refresh(schema)
+    return schema

--- a/tests/test_server/fixtures/factories/schema.py
+++ b/tests/test_server/fixtures/factories/schema.py
@@ -20,11 +20,11 @@ def schema_factory(**kwargs) -> Schema:
     return Schema(**data)
 
 
-async def create_schema(session: AsyncSession, schema_kwargs: dict | None = None) -> Schema:
+async def create_schema(async_session: AsyncSession, schema_kwargs: dict | None = None) -> Schema:
     schema_kwargs = schema_kwargs or {}
     schema = schema_factory(**schema_kwargs)
     del schema.id
-    session.add(schema)
-    await session.commit()
-    await session.refresh(schema)
+    async_session.add(schema)
+    await async_session.commit()
+    await async_session.refresh(schema)
     return schema

--- a/tests/test_server/test_lineage/test_dataset_lineage.py
+++ b/tests/test_server/test_lineage/test_dataset_lineage.py
@@ -125,6 +125,7 @@ async def test_get_dataset_lineage_with_granularity_run(
                 "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -140,6 +141,7 @@ async def test_get_dataset_lineage_with_granularity_run(
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -244,6 +246,7 @@ async def test_get_dataset_lineage_with_granularity_job(
                 "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -259,6 +262,7 @@ async def test_get_dataset_lineage_with_granularity_job(
                 "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -366,6 +370,19 @@ async def test_get_dataset_lineage_with_granularity_operation(
                 "num_bytes": input.num_bytes,
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in input.schema.fields
+                    ],
+                },
                 "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for input in sorted(inputs, key=lambda x: (x.dataset_id, x.operation_id))
@@ -379,6 +396,19 @@ async def test_get_dataset_lineage_with_granularity_operation(
                 "num_bytes": output.num_bytes,
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in output.schema.fields
+                    ],
+                },
                 "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for output in sorted(outputs, key=lambda x: (x.operation_id, x.dataset_id))
@@ -507,6 +537,7 @@ async def test_get_dataset_lineage_with_direction_downstream(
                 "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -621,6 +652,7 @@ async def test_get_dataset_lineage_with_direction_upstream(
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -743,6 +775,7 @@ async def test_get_dataset_lineage_with_until(
                 "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -758,6 +791,7 @@ async def test_get_dataset_lineage_with_until(
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -909,6 +943,7 @@ async def test_get_dataset_lineage_with_depth(
                 "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -924,6 +959,7 @@ async def test_get_dataset_lineage_with_depth(
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -1061,6 +1097,7 @@ async def test_get_dataset_lineage_with_depth_and_granularity_job(
                 "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -1076,6 +1113,7 @@ async def test_get_dataset_lineage_with_depth_and_granularity_job(
                 "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -1220,6 +1258,19 @@ async def test_get_dataset_lineage_with_depth_and_granularity_operation(
                 "num_bytes": input.num_bytes,
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in input.schema.fields
+                    ],
+                },
                 "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for input in sorted(inputs, key=lambda x: (x.dataset_id, x.operation_id))
@@ -1233,6 +1284,19 @@ async def test_get_dataset_lineage_with_depth_and_granularity_operation(
                 "num_bytes": output.num_bytes,
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in output.schema.fields
+                    ],
+                },
                 "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for output in sorted(outputs, key=lambda x: (x.operation_id, x.dataset_id))
@@ -1357,6 +1421,7 @@ async def test_get_dataset_lineage_with_depth_ignore_run_cycles(
                 "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -1372,6 +1437,7 @@ async def test_get_dataset_lineage_with_depth_ignore_run_cycles(
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -1514,6 +1580,7 @@ async def test_get_dataset_lineage_with_symlink(
                 "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -1529,6 +1596,7 @@ async def test_get_dataset_lineage_with_symlink(
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),

--- a/tests/test_server/test_lineage/test_job_lineage.py
+++ b/tests/test_server/test_lineage/test_job_lineage.py
@@ -191,6 +191,7 @@ async def test_get_job_lineage_simple(
                 "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -206,6 +207,7 @@ async def test_get_job_lineage_simple(
                 "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -286,6 +288,7 @@ async def test_get_job_lineage_with_direction_downstream(
                 "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -365,6 +368,7 @@ async def test_get_job_lineage_with_direction_upstream(
                 "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -449,6 +453,7 @@ async def test_get_job_lineage_with_until(
                 "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -464,6 +469,7 @@ async def test_get_job_lineage_with_until(
                 "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -558,6 +564,7 @@ async def test_get_job_lineage_with_granularity_run(
                 "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -573,6 +580,7 @@ async def test_get_job_lineage_with_granularity_run(
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -705,6 +713,7 @@ async def test_get_job_lineage_with_depth(
                 "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -720,6 +729,7 @@ async def test_get_job_lineage_with_depth(
                 "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -848,6 +858,7 @@ async def test_get_job_lineage_with_depth_and_granularity_run(
                 "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -863,6 +874,7 @@ async def test_get_job_lineage_with_depth_and_granularity_run(
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -963,6 +975,7 @@ async def test_get_job_lineage_with_depth_ignore_cycles(
                 "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -978,6 +991,7 @@ async def test_get_job_lineage_with_depth_ignore_cycles(
                 "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -1081,6 +1095,7 @@ async def test_get_job_lineage_with_symlinks(
                 "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -1096,6 +1111,7 @@ async def test_get_job_lineage_with_symlinks(
                 "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),

--- a/tests/test_server/test_lineage/test_operation_lineage.py
+++ b/tests/test_server/test_lineage/test_operation_lineage.py
@@ -167,6 +167,19 @@ async def test_get_operation_lineage_simple(
                 "num_bytes": input.num_bytes,
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in input.schema.fields
+                    ],
+                },
                 "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for input in sorted(inputs, key=lambda x: (x.dataset_id, x.operation_id))
@@ -180,6 +193,19 @@ async def test_get_operation_lineage_simple(
                 "num_bytes": output.num_bytes,
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in output.schema.fields
+                    ],
+                },
                 "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for output in sorted(outputs, key=lambda x: (x.operation_id, x.dataset_id))
@@ -308,6 +334,19 @@ async def test_get_operation_lineage_with_direction_downstream(
                 "num_bytes": output.num_bytes,
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in output.schema.fields
+                    ],
+                },
                 "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for output in sorted(outputs, key=lambda x: (x.operation_id, x.dataset_id))
@@ -435,6 +474,19 @@ async def test_get_operation_lineage_with_direction_upstream(
                 "num_bytes": input.num_bytes,
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in input.schema.fields
+                    ],
+                },
                 "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for input in sorted(inputs, key=lambda x: (x.dataset_id, x.operation_id))
@@ -575,6 +627,19 @@ async def test_get_operation_lineage_with_until(
                 "num_bytes": input.num_bytes,
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in input.schema.fields
+                    ],
+                },
                 "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for input in sorted(inputs, key=lambda x: (x.dataset_id, x.operation_id))
@@ -588,6 +653,19 @@ async def test_get_operation_lineage_with_until(
                 "num_bytes": output.num_bytes,
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in output.schema.fields
+                    ],
+                },
                 "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for output in sorted(outputs, key=lambda x: (x.operation_id, x.dataset_id))
@@ -763,6 +841,19 @@ async def test_get_operation_lineage_with_depth(
                 "num_bytes": input.num_bytes,
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in input.schema.fields
+                    ],
+                },
                 "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for input in sorted(inputs, key=lambda x: (x.dataset_id, x.operation_id))
@@ -776,6 +867,19 @@ async def test_get_operation_lineage_with_depth(
                 "num_bytes": output.num_bytes,
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in output.schema.fields
+                    ],
+                },
                 "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for output in sorted(outputs, key=lambda x: (x.operation_id, x.dataset_id))
@@ -905,6 +1009,19 @@ async def test_get_operation_lineage_with_depth_ignore_cycles(
                 "num_bytes": input.num_bytes,
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in input.schema.fields
+                    ],
+                },
                 "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for input in sorted(lineage.inputs, key=lambda x: (x.dataset_id, x.operation_id))
@@ -918,6 +1035,19 @@ async def test_get_operation_lineage_with_depth_ignore_cycles(
                 "num_bytes": output.num_bytes,
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in output.schema.fields
+                    ],
+                },
                 "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for output in sorted(lineage.outputs, key=lambda x: (x.operation_id, x.dataset_id))
@@ -1067,6 +1197,19 @@ async def test_get_operation_lineage_with_symlinks(
                 "num_bytes": input.num_bytes,
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in input.schema.fields
+                    ],
+                },
                 "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for input in sorted(inputs, key=lambda x: (x.dataset_id, x.operation_id))
@@ -1080,6 +1223,19 @@ async def test_get_operation_lineage_with_symlinks(
                 "num_bytes": output.num_bytes,
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in output.schema.fields
+                    ],
+                },
                 "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for output in sorted(outputs, key=lambda x: (x.operation_id, x.dataset_id))
@@ -1208,6 +1364,19 @@ async def test_get_operation_lineage_with_empty_relation_stats(
                 "num_bytes": None,
                 "num_rows": None,
                 "num_files": None,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in input.schema.fields
+                    ],
+                },
                 "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for input in sorted(inputs, key=lambda x: (x.dataset_id, x.operation_id))
@@ -1221,6 +1390,19 @@ async def test_get_operation_lineage_with_empty_relation_stats(
                 "num_bytes": None,
                 "num_rows": None,
                 "num_files": None,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in output.schema.fields
+                    ],
+                },
                 "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for output in sorted(outputs, key=lambda x: (x.operation_id, x.dataset_id))

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -206,6 +206,7 @@ async def test_get_run_lineage_simple(
                 "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -221,6 +222,7 @@ async def test_get_run_lineage_simple(
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -341,6 +343,19 @@ async def test_get_run_lineage_with_granularity_operation(
                 "num_bytes": input.num_bytes,
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in input.schema.fields
+                    ],
+                },
                 "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for input in sorted(inputs, key=lambda x: (x.dataset_id, x.operation_id))
@@ -354,6 +369,19 @@ async def test_get_run_lineage_with_granularity_operation(
                 "num_bytes": output.num_bytes,
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in output.schema.fields
+                    ],
+                },
                 "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for output in sorted(outputs, key=lambda x: (x.operation_id, x.dataset_id))
@@ -476,6 +504,7 @@ async def test_get_run_lineage_with_direction_downstream(
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -582,6 +611,7 @@ async def test_get_run_lineage_with_direction_upstream(
                 "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -697,6 +727,7 @@ async def test_get_run_lineage_with_until(
                 "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -712,6 +743,7 @@ async def test_get_run_lineage_with_until(
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -861,6 +893,7 @@ async def test_get_run_lineage_with_depth(
                 "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -876,6 +909,7 @@ async def test_get_run_lineage_with_depth(
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -1046,6 +1080,19 @@ async def test_get_run_lineage_with_depth_and_granularity_operation(
                 "num_bytes": input.num_bytes,
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in input.schema.fields
+                    ],
+                },
                 "last_interaction_at": input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for input in sorted(inputs, key=lambda x: (x.dataset_id, x.operation_id))
@@ -1059,6 +1106,19 @@ async def test_get_run_lineage_with_depth_and_granularity_operation(
                 "num_bytes": output.num_bytes,
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
+                "schema": {
+                    "description": None,
+                    "name": None,
+                    "type": None,
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in output.schema.fields
+                    ],
+                },
                 "last_interaction_at": output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for output in sorted(outputs, key=lambda x: (x.operation_id, x.dataset_id))
@@ -1182,6 +1242,7 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
                 "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -1197,6 +1258,7 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -1327,6 +1389,7 @@ async def test_get_run_lineage_with_symlinks(
                 "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
                 "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
                 "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),
@@ -1342,6 +1405,7 @@ async def test_get_run_lineage_with_symlinks(
                 "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
                 "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
                 "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
                 "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
                     "%Y-%m-%dT%H:%M:%S.%fZ",
                 ),


### PR DESCRIPTION
## Change Summary

- `Schema` add as Pydantic model to `LineageOutputRelationV1` and `LineageInputRelationV1`.

- add `_add_schema()` to `input` and `ouput` repositories. Which calls if `granularity=='OPERATION'`.
Mb it's not best way, but I am not sure where else we have `inputs\outputs` + `granularity`.

## Related issue number

[DOP-20062]

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
