### PR TITLE
[DOP-21295] Do not include unrelated datasets to lineage with depth>1

### DIFF
--- a/tests/test_server/test_lineage/test_job_lineage.py
+++ b/tests/test_server/test_lineage/test_job_lineage.py
@@ -939,9 +939,9 @@ async def test_get_job_lineage_with_depth_and_granularity_run(
 async def test_get_job_lineage_with_depth_ignore_cycles(
     test_client: AsyncClient,
     async_session: AsyncSession,
-    lineage_with_depth_and_cycle: LineageResult,
+    cyclic_lineage: LineageResult,
 ):
-    lineage = lineage_with_depth_and_cycle
+    lineage = cyclic_lineage
     # Select all relations:
     # J1 -*> R1 -*> O1, D1 -*> O1 -*> D2
     # J2 -*> R2 -*> O2, D2 -*> O2 -*> D1
@@ -1029,6 +1029,134 @@ async def test_get_job_lineage_with_depth_ignore_cycles(
                 },
             }
             for dataset in datasets
+        ],
+    }
+
+
+async def test_get_job_lineage_with_depth_ignore_unrelated_datasets(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    branchy_lineage: LineageResult,
+):
+    lineage = branchy_lineage
+    # Start from J1, build lineage with direction=BOTH
+    job = lineage.jobs[1]
+
+    # Select only relations marked with *
+    # D0   D1
+    #  *\ /*
+    #    J0 -> D2
+    #     *\
+    #      D3  D4
+    #       *\ /*
+    #         J1 -*> D5
+    #         *\
+    #          D6  D7
+    #           *\ /
+    #             J2 -*> D8
+    #              *\
+    #                D9
+
+    datasets = [
+        lineage.datasets[0],
+        lineage.datasets[1],
+        # D2 is not a part of (J1,D3,J0,D0,D1) input chain
+        lineage.datasets[3],
+        lineage.datasets[4],
+        lineage.datasets[5],
+        lineage.datasets[6],
+        # D7 is not a part of (J1,D6,J2,D8,D9) output chain
+        lineage.datasets[8],
+        lineage.datasets[9],
+    ]
+    dataset_ids = {dataset.id for dataset in datasets}
+
+    inputs = [input for input in lineage.inputs if input.dataset_id in dataset_ids]
+    input_stats = relation_stats_by_jobs(inputs)
+    assert inputs
+
+    outputs = [output for output in lineage.outputs if output.dataset_id in dataset_ids]
+    output_stats = relation_stats_by_jobs(outputs)
+    assert outputs
+
+    jobs = await enrich_jobs(lineage.jobs, async_session)
+    runs = await enrich_runs(lineage.runs, async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+    since = min(run.created_at for run in runs)
+
+    response = await test_client.get(
+        "v1/jobs/lineage",
+        params={
+            "since": since.isoformat(),
+            "start_node_id": str(job.id),
+            "depth": 3,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "INPUT",
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "JOB", "id": input.job_id},
+                "num_bytes": input_stats[(input.job_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.job_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.job_id, input.dataset_id)]["num_files"],
+                "schema": None,
+                "last_interaction_at": input_stats[(input.job_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.job_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "JOB", "id": output.job_id},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.job_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.job_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.job_id, output.dataset_id)]["num_files"],
+                "schema": None,
+                "last_interaction_at": output_stats[(output.job_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for output in sorted(outputs, key=lambda x: (x.job_id, x.dataset_id))
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "type": job.type,
+                "location": {
+                    "id": job.location.id,
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                    "external_id": job.location.external_id,
+                },
+            }
+            for job in sorted(jobs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "id": dataset.location.id,
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                    "external_id": dataset.location.external_id,
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
         ],
     }
 

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -1198,9 +1198,9 @@ async def test_get_run_lineage_with_depth_and_granularity_operation(
 async def test_get_run_lineage_with_depth_ignore_cycles(
     test_client: AsyncClient,
     async_session: AsyncSession,
-    lineage_with_depth_and_cycle: LineageResult,
+    cyclic_lineage: LineageResult,
 ):
-    lineage = lineage_with_depth_and_cycle
+    lineage = cyclic_lineage
     # Select all relations:
     # J1 -*> R1 -*> O1, D1 -*> O1 -*> D2
     # J2 -*> R2 -*> O2, D2 -*> O2 -*> D1
@@ -1316,6 +1316,162 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
                 "end_reason": run.end_reason,
             }
             for run in runs
+        ],
+    }
+
+
+async def test_get_run_lineage_with_depth_ignore_unrelated_datasets(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    branchy_lineage: LineageResult,
+):
+    lineage = branchy_lineage
+    # Start from R1, build lineage with direction=BOTH
+    run = lineage.runs[1]
+
+    # Select only relations marked with *
+    #     D0   D1
+    #      *\ /*
+    # J0 -*> R0 -> D2
+    #        *\
+    #         D3  D4
+    #          *\ /*
+    #     J1 -*> R1 -*> D5
+    #            *\
+    #             D6  D7
+    #              *\ /
+    #         J2 -*> R2 -*> D8
+    #                 *\
+    #                   D9
+
+    datasets = [
+        lineage.datasets[0],
+        lineage.datasets[1],
+        # D2 is not a part of (R1,D3,R0,D0,D1) input chain
+        lineage.datasets[3],
+        lineage.datasets[4],
+        lineage.datasets[5],
+        lineage.datasets[6],
+        # D7 is not a part of (R1,D6,R2,D8,D9) output chain
+        lineage.datasets[8],
+        lineage.datasets[9],
+    ]
+    dataset_ids = {dataset.id for dataset in datasets}
+
+    inputs = [input for input in lineage.inputs if input.dataset_id in dataset_ids]
+    input_stats = relation_stats_by_runs(inputs)
+    assert inputs
+
+    outputs = [output for output in lineage.outputs if output.dataset_id in dataset_ids]
+    output_stats = relation_stats_by_runs(outputs)
+    assert outputs
+
+    jobs = await enrich_jobs(lineage.jobs, async_session)
+    runs = await enrich_runs(lineage.runs, async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+    since = min(run.created_at for run in runs)
+
+    response = await test_client.get(
+        "v1/runs/lineage",
+        params={
+            "since": since.isoformat(),
+            "start_node_id": str(run.id),
+            "depth": 3,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "INPUT",
+                "from": {"kind": "DATASET", "id": input.dataset_id},
+                "to": {"kind": "RUN", "id": str(input.run_id)},
+                "num_bytes": input_stats[(input.run_id, input.dataset_id)]["num_bytes"],
+                "num_rows": input_stats[(input.run_id, input.dataset_id)]["num_rows"],
+                "num_files": input_stats[(input.run_id, input.dataset_id)]["num_files"],
+                "schema": None,
+                "last_interaction_at": input_stats[(input.run_id, input.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for input in sorted(inputs, key=lambda x: (x.dataset_id, x.run_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "RUN", "id": str(output.run_id)},
+                "to": {"kind": "DATASET", "id": output.dataset_id},
+                "type": output.type,
+                "num_bytes": output_stats[(output.run_id, output.dataset_id)]["num_bytes"],
+                "num_rows": output_stats[(output.run_id, output.dataset_id)]["num_rows"],
+                "num_files": output_stats[(output.run_id, output.dataset_id)]["num_files"],
+                "schema": None,
+                "last_interaction_at": output_stats[(output.run_id, output.dataset_id)]["created_at"].strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                ),
+            }
+            for output in sorted(outputs, key=lambda x: (x.run_id, x.dataset_id))
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "type": job.type,
+                "location": {
+                    "id": job.location.id,
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                    "external_id": job.location.external_id,
+                },
+            }
+            for job in sorted(jobs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "id": dataset.location.id,
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                    "external_id": dataset.location.external_id,
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.name,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
         ],
     }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Case - there is a full lineage graph like this:
```
            / dataset3
dataset1 - job1 -> current_dataset -> job2 -> dataset2
                             dataset4 /
```

And we call `GET /v1/datasets/lineage` for `current_dataset` with `direction=BOTH` and `depth>1`.
We expect this endpoint to receive only nodes & relations which are a part of either input chain of `current_dataset`, or output chain, e.g.:
```
dataset1 - job1 -> current_dataset -> job2 -> dataset2
```

But instead we receive full graph.

What changed:
* Respect `direction=BOTH` only for building the first level lineage (`job1 -> current_dataset -> job2`). While getting lineage for nested nodes (job1, job2), use more specific direction (`direction=UPSTREAM` for job1, `direction=DOWNSTREAM` for job2).
* Add `branchy_lineage` fixture creating a complex graph like the one above, add tests for all node types.

Few questions:
* Do we need tests with `granularity` other than default?
* Do we need tests with `direction` other than `BOTH`?

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
