### PR TITLE
[DOP-21572] Remove unused fields from schema response

### DIFF
--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -112,11 +112,17 @@ class LineageParentRelationV1(BaseModel):
     to: LineageEntityV1 = Field(description="End point of relation")
 
 
-class LineageOutputRelationSchemaV1(BaseModel):
-    name: str | None = Field(default=None)
+class LineageOutputRelationSchemaFieldV1(BaseModel):
+    name: str
     type: str | None = Field(default=None)
     description: str | None = Field(default=None)
-    fields: list["LineageOutputRelationSchemaV1"] = Field(description="Schema fields", default_factory=list)
+    fields: list["LineageOutputRelationSchemaFieldV1"] = Field(description="Nested fields", default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LineageOutputRelationSchemaV1(BaseModel):
+    fields: list[LineageOutputRelationSchemaFieldV1] = Field(description="Schema fields")
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tests/test_server/test_lineage/test_dataset_lineage.py
+++ b/tests/test_server/test_lineage/test_dataset_lineage.py
@@ -371,9 +371,6 @@ async def test_get_dataset_lineage_with_granularity_operation(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -397,9 +394,6 @@ async def test_get_dataset_lineage_with_granularity_operation(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -1259,9 +1253,6 @@ async def test_get_dataset_lineage_with_depth_and_granularity_operation(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -1285,9 +1276,6 @@ async def test_get_dataset_lineage_with_depth_and_granularity_operation(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,

--- a/tests/test_server/test_lineage/test_operation_lineage.py
+++ b/tests/test_server/test_lineage/test_operation_lineage.py
@@ -168,9 +168,6 @@ async def test_get_operation_lineage_simple(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -194,9 +191,6 @@ async def test_get_operation_lineage_simple(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -335,9 +329,6 @@ async def test_get_operation_lineage_with_direction_downstream(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -475,9 +466,6 @@ async def test_get_operation_lineage_with_direction_upstream(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -628,9 +616,6 @@ async def test_get_operation_lineage_with_until(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -654,9 +639,6 @@ async def test_get_operation_lineage_with_until(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -842,9 +824,6 @@ async def test_get_operation_lineage_with_depth(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -868,9 +847,6 @@ async def test_get_operation_lineage_with_depth(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -1010,9 +986,6 @@ async def test_get_operation_lineage_with_depth_ignore_cycles(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -1036,9 +1009,6 @@ async def test_get_operation_lineage_with_depth_ignore_cycles(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -1209,9 +1179,6 @@ async def test_get_operation_lineage_with_depth_ignore_unrelated_datasets(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -1235,9 +1202,6 @@ async def test_get_operation_lineage_with_depth_ignore_unrelated_datasets(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -1397,9 +1361,6 @@ async def test_get_operation_lineage_with_symlinks(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -1423,9 +1384,6 @@ async def test_get_operation_lineage_with_symlinks(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -1564,9 +1522,6 @@ async def test_get_operation_lineage_with_empty_relation_stats(
                 "num_rows": None,
                 "num_files": None,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -1590,9 +1545,6 @@ async def test_get_operation_lineage_with_empty_relation_stats(
                 "num_rows": None,
                 "num_files": None,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -344,9 +344,6 @@ async def test_get_run_lineage_with_granularity_operation(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -370,9 +367,6 @@ async def test_get_run_lineage_with_granularity_operation(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -1081,9 +1075,6 @@ async def test_get_run_lineage_with_depth_and_granularity_operation(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,
@@ -1107,9 +1098,6 @@ async def test_get_run_lineage_with_depth_and_granularity_operation(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
-                    "description": None,
-                    "name": None,
-                    "type": None,
                     "fields": [
                         {
                             "description": None,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

According to OpenLineage spec, dataset `schema` facet has only `fields` attribute:
https://github.com/OpenLineage/OpenLineage/blob/2130ab9fa46cda0a02db13b5b7b265f1bbfe8b51/spec/facets/SchemaDatasetFacet.json#L40

Other attributes, like `name`, `type`, `description` are present only in nested `field`.
Change response schema accordingly and update tests.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
