### PR TITLE
[DOP-21572] Return interaction schema with granularity=RUN|JOB

### DIFF
--- a/data_rentgen/db/models/input.py
+++ b/data_rentgen/db/models/input.py
@@ -94,7 +94,7 @@ class Input(Base):
     schema: Mapped[Schema | None] = relationship(
         Schema,
         primaryjoin="Input.schema_id == Schema.id",
-        lazy="selectin",
+        lazy="noload",
         foreign_keys=[schema_id],
     )
 

--- a/data_rentgen/db/models/output.py
+++ b/data_rentgen/db/models/output.py
@@ -119,7 +119,7 @@ class Output(Base):
     schema: Mapped[Schema | None] = relationship(
         Schema,
         primaryjoin="Output.schema_id == Schema.id",
-        lazy="selectin",
+        lazy="noload",
         foreign_keys=[schema_id],
     )
 

--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -138,6 +138,7 @@ class LineageInputRelationV1(BaseModel):
     i_schema: LineageOutputRelationSchemaV1 | None = Field(
         description="Schema",
         default=None,
+        # pydantic models have reserved "schema" attribute, using alias
         serialization_alias="schema",
     )
 
@@ -146,7 +147,7 @@ class LineageOutputRelationV1(BaseModel):
     kind: Literal["OUTPUT"] = "OUTPUT"
     from_: LineageEntityV1 = Field(description="Start point of relation", serialization_alias="from")
     to: LineageEntityV1 = Field(description="End point of relation")
-    type: str = Field(description="Type of relation", examples=["CREATE", "APPEND"])
+    type: str | None = Field(description="Type of relation", examples=["CREATE", "APPEND"], default=None)
     last_interaction_at: datetime = Field(description="Last interaction at", examples=["2008-09-15T15:53:00+05:00"])
     num_bytes: int | None = Field(description="Number of bytes", examples=[42], default=None)
     num_rows: int | None = Field(description="Number of rows", examples=[42], default=None)
@@ -154,6 +155,7 @@ class LineageOutputRelationV1(BaseModel):
     o_schema: LineageOutputRelationSchemaV1 | None = Field(
         description="Schema",
         default=None,
+        # pydantic models have reserved "schema" attribute, using alias
         serialization_alias="schema",
     )
 

--- a/data_rentgen/server/services/lineage.py
+++ b/data_rentgen/server/services/lineage.py
@@ -73,7 +73,7 @@ class LineageService:
     def __init__(self, uow: Annotated[UnitOfWork, Depends()]):
         self._uow = uow
 
-    async def get_lineage_by_jobs(
+    async def get_lineage_by_jobs(  # noqa: WPS217, WPS210
         self,
         start_node_ids: list[int],
         direction: LineageDirectionV1,
@@ -119,6 +119,18 @@ class LineageService:
                 until=until,
                 granularity=granularity,
             )
+
+        input_schema_ids = {input.schema_id for input in inputs if input.schema_id is not None}
+        output_schema_ids = {output.schema_id for output in outputs if output.schema_id is not None}
+        schemas = await self._uow.schema.list_by_ids(sorted(input_schema_ids | output_schema_ids))
+        schemas_by_id = {schema.id: schema for schema in schemas}
+
+        for input in inputs:
+            if input.schema_id is not None:
+                input.schema = schemas_by_id.get(input.schema_id)
+        for output in outputs:
+            if output.schema_id is not None:
+                output.schema = schemas_by_id.get(output.schema_id)
 
         ids_to_skip = ids_to_skip or IdsToSkip()
 
@@ -197,7 +209,7 @@ class LineageService:
             )
         return result
 
-    async def get_lineage_by_runs(  # noqa: WPS217
+    async def get_lineage_by_runs(  # noqa: WPS217, WPS210
         self,
         start_node_ids: list[UUID],
         direction: LineageDirectionV1,
@@ -243,6 +255,18 @@ class LineageService:
                 until=until,
                 granularity=granularity,
             )
+
+        input_schema_ids = {input.schema_id for input in inputs if input.schema_id is not None}
+        output_schema_ids = {output.schema_id for output in outputs if output.schema_id is not None}
+        schemas = await self._uow.schema.list_by_ids(sorted(input_schema_ids | output_schema_ids))
+        schemas_by_id = {schema.id: schema for schema in schemas}
+
+        for input in inputs:
+            if input.schema_id is not None:
+                input.schema = schemas_by_id.get(input.schema_id)
+        for output in outputs:
+            if output.schema_id is not None:
+                output.schema = schemas_by_id.get(output.schema_id)
 
         # Include only operations which have at least one input or output.
         # In case granularity == "RUN", all operation_id are None.
@@ -323,7 +347,7 @@ class LineageService:
             )
         return result
 
-    async def get_lineage_by_operations(  # noqa: WPS217
+    async def get_lineage_by_operations(  # noqa: WPS217, WPS210
         self,
         start_node_ids: list[UUID],
         direction: LineageDirectionV1,
@@ -370,6 +394,18 @@ class LineageService:
             outputs = await self._uow.output.list_by_operation_ids(operation_ids)
         if direction in {LineageDirectionV1.UPSTREAM, LineageDirectionV1.BOTH}:
             inputs = await self._uow.input.list_by_operation_ids(operation_ids)
+
+        input_schema_ids = {input.schema_id for input in inputs if input.schema_id is not None}
+        output_schema_ids = {output.schema_id for output in outputs if output.schema_id is not None}
+        schemas = await self._uow.schema.list_by_ids(sorted(input_schema_ids | output_schema_ids))
+        schemas_by_id = {schema.id: schema for schema in schemas}
+
+        for input in inputs:
+            if input.schema_id is not None:
+                input.schema = schemas_by_id.get(input.schema_id)
+        for output in outputs:
+            if output.schema_id is not None:
+                output.schema = schemas_by_id.get(output.schema_id)
 
         result = LineageServiceResult(
             jobs=jobs_by_id,
@@ -578,6 +614,18 @@ class LineageService:
                 granularity="OPERATION",
             )
 
+        input_schema_ids = {input.schema_id for input in inputs if input.schema_id is not None}
+        output_schema_ids = {output.schema_id for output in outputs if output.schema_id is not None}
+        schemas = await self._uow.schema.list_by_ids(sorted(input_schema_ids | output_schema_ids))
+        schemas_by_id = {schema.id: schema for schema in schemas}
+
+        for input in inputs:
+            if input.schema_id is not None:
+                input.schema = schemas_by_id.get(input.schema_id)
+        for output in outputs:
+            if output.schema_id is not None:
+                output.schema = schemas_by_id.get(output.schema_id)
+
         result = LineageServiceResult(
             datasets=datasets_by_id,
             dataset_symlinks=dataset_symlinks_by_id,
@@ -659,6 +707,18 @@ class LineageService:
                 granularity="RUN",
             )
 
+        input_schema_ids = {input.schema_id for input in inputs if input.schema_id is not None}
+        output_schema_ids = {output.schema_id for output in outputs if output.schema_id is not None}
+        schemas = await self._uow.schema.list_by_ids(sorted(input_schema_ids | output_schema_ids))
+        schemas_by_id = {schema.id: schema for schema in schemas}
+
+        for input in inputs:
+            if input.schema_id is not None:
+                input.schema = schemas_by_id.get(input.schema_id)
+        for output in outputs:
+            if output.schema_id is not None:
+                output.schema = schemas_by_id.get(output.schema_id)
+
         result = LineageServiceResult(
             datasets=datasets_by_id,
             dataset_symlinks=dataset_symlinks_by_id,
@@ -737,6 +797,18 @@ class LineageService:
                 until=until,
                 granularity="JOB",
             )
+
+        input_schema_ids = {input.schema_id for input in inputs if input.schema_id is not None}
+        output_schema_ids = {output.schema_id for output in outputs if output.schema_id is not None}
+        schemas = await self._uow.schema.list_by_ids(sorted(input_schema_ids | output_schema_ids))
+        schemas_by_id = {schema.id: schema for schema in schemas}
+
+        for input in inputs:
+            if input.schema_id is not None:
+                input.schema = schemas_by_id.get(input.schema_id)
+        for output in outputs:
+            if output.schema_id is not None:
+                output.schema = schemas_by_id.get(output.schema_id)
 
         result = LineageServiceResult(
             datasets=datasets_by_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -429,6 +429,8 @@ per-file-ignores = [
   "data_rentgen/db/*.py:WPS102,WPS432",
 # WPS237 Found a too complex `f` string
   "data_rentgen/server/exceptions/*.py:WPS237",
+# WPS441 Found control variable used after block: input
+  "data_rentgen/server/services/lineage.py:WPS441",
 # N815 variable 'openlineageAdapterVersion' in class scope should not be mixedCase
   "data_rentgen/consumer/openlineage/*.py:N815",
 # TAE001 too few type annotations

--- a/tests/test_server/test_lineage/test_dataset_lineage.py
+++ b/tests/test_server/test_lineage/test_dataset_lineage.py
@@ -6,6 +6,8 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from data_rentgen.db.models import Dataset
+from data_rentgen.db.models.output import OutputType
+from tests.test_server.fixtures.factories.schema import create_schema
 from tests.test_server.utils.enrich import enrich_datasets, enrich_jobs, enrich_runs
 from tests.test_server.utils.lineage_result import LineageResult
 from tests.test_server.utils.merge import merge_io_by_jobs, merge_io_by_runs
@@ -125,7 +127,16 @@ async def test_get_dataset_lineage_with_granularity_run(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -139,7 +150,16 @@ async def test_get_dataset_lineage_with_granularity_run(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -242,7 +262,16 @@ async def test_get_dataset_lineage_with_granularity_job(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.job_id))
@@ -256,7 +285,16 @@ async def test_get_dataset_lineage_with_granularity_job(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.job_id, x.dataset_id))
@@ -523,7 +561,16 @@ async def test_get_dataset_lineage_with_direction_downstream(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -636,7 +683,16 @@ async def test_get_dataset_lineage_with_direction_upstream(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -757,7 +813,16 @@ async def test_get_dataset_lineage_with_until(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -771,7 +836,16 @@ async def test_get_dataset_lineage_with_until(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -921,7 +995,16 @@ async def test_get_dataset_lineage_with_depth(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -935,7 +1018,16 @@ async def test_get_dataset_lineage_with_depth(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -1071,7 +1163,16 @@ async def test_get_dataset_lineage_with_depth_and_granularity_job(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.job_id))
@@ -1085,7 +1186,16 @@ async def test_get_dataset_lineage_with_depth_and_granularity_job(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.job_id, x.dataset_id))
@@ -1385,7 +1495,16 @@ async def test_get_dataset_lineage_with_depth_ignore_cycles(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -1399,7 +1518,16 @@ async def test_get_dataset_lineage_with_depth_ignore_cycles(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -1536,7 +1664,16 @@ async def test_get_dataset_lineage_with_depth_ignore_unrelated_datasets(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -1550,7 +1687,16 @@ async def test_get_dataset_lineage_with_depth_ignore_unrelated_datasets(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -1691,7 +1837,16 @@ async def test_get_dataset_lineage_with_symlink(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -1705,7 +1860,16 @@ async def test_get_dataset_lineage_with_symlink(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -1761,5 +1925,312 @@ async def test_get_dataset_lineage_with_symlink(
                 "end_reason": run.end_reason,
             }
             for run in runs
+        ],
+    }
+
+
+@pytest.mark.parametrize("dataset_index", [0, 1], ids=["output", "input"])
+async def test_get_dataset_lineage_unmergeable_schema_and_output_type(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    duplicated_lineage: LineageResult,
+    dataset_index: int,
+):
+    lineage = duplicated_lineage
+
+    # make every input and output a different schema -> grouping by Run returns None.
+    # make every output a different type -> grouping by Run returns None.
+    for raw_input in lineage.inputs:
+        schema = await create_schema(async_session)
+        raw_input.schema_id = schema.id
+        raw_input.schema = schema
+        await async_session.merge(raw_input)
+
+    output_types = list(OutputType)
+    for i, raw_output in enumerate(lineage.outputs):
+        schema = await create_schema(async_session)
+        raw_output.schema_id = schema.id
+        raw_output.schema = schema
+        raw_output.type = output_types[i % len(output_types)]
+        await async_session.merge(raw_output)
+
+    await async_session.commit()
+
+    # one dataset has only inputs, another only outputs - test both
+    dataset = lineage.datasets[dataset_index]
+
+    raw_inputs = [input for input in lineage.inputs if input.dataset_id == dataset.id]
+    merged_inputs = merge_io_by_runs(raw_inputs)
+
+    raw_outputs = [output for output in lineage.outputs if output.dataset_id == dataset.id]
+    merged_outputs = merge_io_by_runs(raw_outputs)
+
+    dataset_ids = {input.dataset_id for input in raw_inputs} | {output.dataset_id for output in raw_outputs}
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    run_ids = {input.run_id for input in raw_inputs} | {output.run_id for output in raw_outputs}
+    runs = [run for run in lineage.runs if run.id in run_ids]
+    assert runs
+
+    job_ids = {run.job_id for run in runs}
+    jobs = [job for job in lineage.jobs if job.id in job_ids]
+    assert jobs
+
+    jobs = await enrich_jobs(jobs, async_session)
+    runs = await enrich_runs(runs, async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+    since = min(run.created_at for run in runs)
+
+    response = await test_client.get(
+        "v1/datasets/lineage",
+        params={
+            "since": since.isoformat(),
+            "start_node_id": dataset.id,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "INPUT",
+                "from": {"kind": "DATASET", "id": merged_input.dataset_id},
+                "to": {"kind": "RUN", "id": str(merged_input.run_id)},
+                "num_bytes": merged_input.num_bytes,
+                "num_rows": merged_input.num_rows,
+                "num_files": merged_input.num_files,
+                "schema": None,
+                "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            }
+            for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "RUN", "id": str(merged_output.run_id)},
+                "to": {"kind": "DATASET", "id": merged_output.dataset_id},
+                "type": None,
+                "num_bytes": merged_output.num_bytes,
+                "num_rows": merged_output.num_rows,
+                "num_files": merged_output.num_files,
+                "schema": None,
+                "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            }
+            for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "type": job.type,
+                "location": {
+                    "id": job.location.id,
+                    "type": job.location.type,
+                    "name": job.location.name,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                    "external_id": job.location.external_id,
+                },
+            }
+            for job in sorted(jobs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "id": dataset.location.id,
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                    "external_id": dataset.location.external_id,
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.name,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ],
+    }
+
+
+@pytest.mark.parametrize("dataset_index", [0, 1], ids=["output", "input"])
+async def test_get_dataset_lineage_empty_io_stats_and_schema(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    duplicated_lineage: LineageResult,
+    dataset_index: int,
+):
+    lineage = duplicated_lineage
+
+    # clear input/output stats and schema.
+    for raw_input in lineage.inputs:
+        raw_input.schema_id = None
+        raw_input.schema = None
+        raw_input.num_bytes = None
+        raw_input.num_rows = None
+        raw_input.num_files = None
+        await async_session.merge(raw_input)
+
+    for raw_output in lineage.outputs:
+        raw_output.schema_id = None
+        raw_output.schema = None
+        raw_output.num_bytes = None
+        raw_output.num_rows = None
+        raw_output.num_files = None
+        await async_session.merge(raw_output)
+
+    await async_session.commit()
+
+    # one dataset has only inputs, another only outputs - test both
+    dataset = lineage.datasets[dataset_index]
+
+    raw_inputs = [input for input in lineage.inputs if input.dataset_id == dataset.id]
+    merged_inputs = merge_io_by_runs(raw_inputs)
+
+    raw_outputs = [output for output in lineage.outputs if output.dataset_id == dataset.id]
+    merged_outputs = merge_io_by_runs(raw_outputs)
+
+    dataset_ids = {input.dataset_id for input in raw_inputs} | {output.dataset_id for output in raw_outputs}
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    run_ids = {input.run_id for input in raw_inputs} | {output.run_id for output in raw_outputs}
+    runs = [run for run in lineage.runs if run.id in run_ids]
+    assert runs
+
+    job_ids = {run.job_id for run in runs}
+    jobs = [job for job in lineage.jobs if job.id in job_ids]
+    assert jobs
+
+    jobs = await enrich_jobs(jobs, async_session)
+    runs = await enrich_runs(runs, async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+    since = min(run.created_at for run in runs)
+
+    response = await test_client.get(
+        "v1/datasets/lineage",
+        params={
+            "since": since.isoformat(),
+            "start_node_id": dataset.id,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+            }
+            for run in sorted(runs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "INPUT",
+                "from": {"kind": "DATASET", "id": merged_input.dataset_id},
+                "to": {"kind": "RUN", "id": str(merged_input.run_id)},
+                "num_bytes": None,
+                "num_rows": None,
+                "num_files": None,
+                "schema": None,
+                "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            }
+            for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "RUN", "id": str(merged_output.run_id)},
+                "to": {"kind": "DATASET", "id": merged_output.dataset_id},
+                "type": merged_output.type,
+                "num_bytes": None,
+                "num_rows": None,
+                "num_files": None,
+                "schema": None,
+                "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            }
+            for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "type": job.type,
+                "location": {
+                    "id": job.location.id,
+                    "type": job.location.type,
+                    "name": job.location.name,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                    "external_id": job.location.external_id,
+                },
+            }
+            for job in sorted(jobs, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "id": dataset.location.id,
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                    "external_id": dataset.location.external_id,
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.name,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            }
+            for run in sorted(runs, key=lambda x: x.id)
         ],
     }

--- a/tests/test_server/test_lineage/test_job_lineage.py
+++ b/tests/test_server/test_lineage/test_job_lineage.py
@@ -5,7 +5,8 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from data_rentgen.db.models import Job, Run
+from data_rentgen.db.models import Job, OutputType, Run
+from tests.test_server.fixtures.factories.schema import create_schema
 from tests.test_server.utils.enrich import enrich_datasets, enrich_jobs, enrich_runs
 from tests.test_server.utils.lineage_result import LineageResult
 from tests.test_server.utils.merge import merge_io_by_jobs, merge_io_by_runs
@@ -191,7 +192,16 @@ async def test_get_job_lineage_simple(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.job_id))
@@ -205,7 +215,16 @@ async def test_get_job_lineage_simple(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.job_id, x.dataset_id))
@@ -284,7 +303,16 @@ async def test_get_job_lineage_with_direction_downstream(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.job_id, x.dataset_id))
@@ -362,7 +390,16 @@ async def test_get_job_lineage_with_direction_upstream(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.job_id))
@@ -447,7 +484,16 @@ async def test_get_job_lineage_with_until(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.job_id))
@@ -461,7 +507,16 @@ async def test_get_job_lineage_with_until(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.job_id, x.dataset_id))
@@ -556,7 +611,16 @@ async def test_get_job_lineage_with_granularity_run(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -570,7 +634,16 @@ async def test_get_job_lineage_with_granularity_run(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -702,7 +775,16 @@ async def test_get_job_lineage_with_depth(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -716,7 +798,16 @@ async def test_get_job_lineage_with_depth(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -844,7 +935,16 @@ async def test_get_job_lineage_with_depth_and_granularity_run(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.job_id))
@@ -858,7 +958,16 @@ async def test_get_job_lineage_with_depth_and_granularity_run(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.job_id, x.dataset_id))
@@ -957,7 +1066,16 @@ async def test_get_job_lineage_with_depth_ignore_cycles(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.job_id))
@@ -971,7 +1089,16 @@ async def test_get_job_lineage_with_depth_ignore_cycles(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.job_id, x.dataset_id))
@@ -1081,7 +1208,16 @@ async def test_get_job_lineage_with_depth_ignore_unrelated_datasets(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.job_id))
@@ -1095,7 +1231,16 @@ async def test_get_job_lineage_with_depth_ignore_unrelated_datasets(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.job_id, x.dataset_id))
@@ -1197,7 +1342,16 @@ async def test_get_job_lineage_with_symlinks(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.job_id))
@@ -1208,6 +1362,131 @@ async def test_get_job_lineage_with_symlinks(
                 "from": {"kind": "JOB", "id": merged_output.job_id},
                 "to": {"kind": "DATASET", "id": merged_output.dataset_id},
                 "type": merged_output.type,
+                "num_bytes": merged_output.num_bytes,
+                "num_rows": merged_output.num_rows,
+                "num_files": merged_output.num_files,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
+                "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            }
+            for merged_output in sorted(merged_outputs, key=lambda x: (x.job_id, x.dataset_id))
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "type": job.type,
+                "location": {
+                    "id": job.location.id,
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                    "external_id": job.location.external_id,
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "id": dataset.location.id,
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                    "external_id": dataset.location.external_id,
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ],
+    }
+
+
+async def test_get_job_lineage_unmergeable_inputs_and_outputs(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    duplicated_lineage: LineageResult,
+):
+    lineage = duplicated_lineage
+
+    # make every input and output a different schema -> grouping by Job returns None.
+    # make every output a different type -> grouping by Job returns None.
+    for raw_input in lineage.inputs:
+        schema = await create_schema(async_session)
+        raw_input.schema_id = schema.id
+        raw_input.schema = schema
+        await async_session.merge(raw_input)
+
+    output_types = list(OutputType)
+    for i, raw_output in enumerate(lineage.outputs):
+        schema = await create_schema(async_session)
+        raw_output.schema_id = schema.id
+        raw_output.schema = schema
+        raw_output.type = output_types[i % len(output_types)]
+        await async_session.merge(raw_output)
+
+    await async_session.commit()
+
+    job = lineage.jobs[0]
+    runs = [run for run in lineage.runs if run.job_id == job.id]
+
+    raw_inputs = [input for input in lineage.inputs if input.job_id == job.id]
+    merged_inputs = merge_io_by_jobs(raw_inputs)
+    assert merged_inputs
+
+    raw_outputs = [output for output in lineage.outputs if output.job_id == job.id]
+    merged_outputs = merge_io_by_jobs(raw_outputs)
+    assert merged_outputs
+
+    dataset_ids = {input.dataset_id for input in raw_inputs} | {output.dataset_id for output in raw_outputs}
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    [job] = await enrich_jobs([job], async_session)
+    runs = await enrich_runs(runs, async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+    since = min(run.created_at for run in runs)
+
+    response = await test_client.get(
+        "v1/jobs/lineage",
+        params={
+            "since": since.isoformat(),
+            "start_node_id": job.id,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "INPUT",
+                "from": {"kind": "DATASET", "id": merged_input.dataset_id},
+                "to": {"kind": "JOB", "id": merged_input.job_id},
+                "num_bytes": merged_input.num_bytes,
+                "num_rows": merged_input.num_rows,
+                "num_files": merged_input.num_files,
+                "schema": None,
+                "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            }
+            for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.job_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "JOB", "id": merged_output.job_id},
+                "to": {"kind": "DATASET", "id": merged_output.dataset_id},
+                "type": None,
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
@@ -1224,8 +1503,125 @@ async def test_get_job_lineage_with_symlinks(
                 "type": job.type,
                 "location": {
                     "id": job.location.id,
-                    "name": job.location.name,
                     "type": job.location.type,
+                    "name": job.location.name,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                    "external_id": job.location.external_id,
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "id": dataset.location.id,
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                    "external_id": dataset.location.external_id,
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ],
+    }
+
+
+async def test_get_dataset_lineage_empty_io_stats_and_schema(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    duplicated_lineage: LineageResult,
+):
+    lineage = duplicated_lineage
+
+    # clear input/output stats and schema.
+    for raw_input in lineage.inputs:
+        raw_input.schema_id = None
+        raw_input.schema = None
+        raw_input.num_bytes = None
+        raw_input.num_rows = None
+        raw_input.num_files = None
+        await async_session.merge(raw_input)
+
+    for raw_output in lineage.outputs:
+        raw_output.schema_id = None
+        raw_output.schema = None
+        raw_output.num_bytes = None
+        raw_output.num_rows = None
+        raw_output.num_files = None
+        await async_session.merge(raw_output)
+
+    await async_session.commit()
+
+    job = lineage.jobs[0]
+    runs = [run for run in lineage.runs if run.job_id == job.id]
+
+    raw_inputs = [input for input in lineage.inputs if input.job_id == job.id]
+    merged_inputs = merge_io_by_jobs(raw_inputs)
+    assert merged_inputs
+
+    raw_outputs = [output for output in lineage.outputs if output.job_id == job.id]
+    merged_outputs = merge_io_by_jobs(raw_outputs)
+    assert merged_outputs
+
+    dataset_ids = {input.dataset_id for input in raw_inputs} | {output.dataset_id for output in raw_outputs}
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    [job] = await enrich_jobs([job], async_session)
+    runs = await enrich_runs(runs, async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+    since = min(run.created_at for run in runs)
+
+    response = await test_client.get(
+        "v1/jobs/lineage",
+        params={
+            "since": since.isoformat(),
+            "start_node_id": job.id,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "INPUT",
+                "from": {"kind": "DATASET", "id": merged_input.dataset_id},
+                "to": {"kind": "JOB", "id": merged_input.job_id},
+                "num_bytes": None,
+                "num_rows": None,
+                "num_files": None,
+                "schema": None,
+                "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            }
+            for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.job_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "JOB", "id": merged_output.job_id},
+                "to": {"kind": "DATASET", "id": merged_output.dataset_id},
+                "type": merged_output.type,
+                "num_bytes": None,
+                "num_rows": None,
+                "num_files": None,
+                "schema": None,
+                "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            }
+            for merged_output in sorted(merged_outputs, key=lambda x: (x.job_id, x.dataset_id))
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "type": job.type,
+                "location": {
+                    "id": job.location.id,
+                    "type": job.location.type,
+                    "name": job.location.name,
                     "addresses": [{"url": address.url} for address in job.location.addresses],
                     "external_id": job.location.external_id,
                 },

--- a/tests/test_server/test_lineage/test_operation_lineage.py
+++ b/tests/test_server/test_lineage/test_operation_lineage.py
@@ -1471,7 +1471,7 @@ async def test_get_operation_lineage_with_empty_io_stats_and_schema(
 ):
     lineage = simple_lineage
 
-    # clear input/output stats and schema.
+    # clear input/output stats
     for input in lineage.inputs:
         input.num_bytes = None
         input.num_rows = None

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -5,7 +5,8 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from data_rentgen.db.models import Job, Run
+from data_rentgen.db.models import Job, OutputType, Run
+from tests.test_server.fixtures.factories.schema import create_schema
 from tests.test_server.utils.enrich import enrich_datasets, enrich_jobs, enrich_runs
 from tests.test_server.utils.lineage_result import LineageResult
 from tests.test_server.utils.merge import merge_io_by_runs
@@ -206,7 +207,16 @@ async def test_get_run_lineage_simple(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -220,7 +230,16 @@ async def test_get_run_lineage_simple(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -494,7 +513,16 @@ async def test_get_run_lineage_with_direction_downstream(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -599,7 +627,16 @@ async def test_get_run_lineage_with_direction_upstream(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -715,7 +752,16 @@ async def test_get_run_lineage_with_until(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -729,7 +775,16 @@ async def test_get_run_lineage_with_until(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -875,7 +930,16 @@ async def test_get_run_lineage_with_depth(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -889,7 +953,16 @@ async def test_get_run_lineage_with_depth(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -1214,7 +1287,16 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -1228,7 +1310,16 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -1366,7 +1457,16 @@ async def test_get_run_lineage_with_depth_ignore_unrelated_datasets(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -1380,7 +1480,16 @@ async def test_get_run_lineage_with_depth_ignore_unrelated_datasets(
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
@@ -1509,7 +1618,16 @@ async def test_get_run_lineage_with_symlinks(
                 "num_bytes": merged_input.num_bytes,
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
-                "schema": None,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_input.schema.fields
+                    ],
+                },
                 "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             }
             for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
@@ -1520,6 +1638,156 @@ async def test_get_run_lineage_with_symlinks(
                 "from": {"kind": "RUN", "id": str(merged_output.run_id)},
                 "to": {"kind": "DATASET", "id": merged_output.dataset_id},
                 "type": merged_output.type,
+                "num_bytes": merged_output.num_bytes,
+                "num_rows": merged_output.num_rows,
+                "num_files": merged_output.num_files,
+                "schema": {
+                    "fields": [
+                        {
+                            "description": None,
+                            "fields": [],
+                            **field,
+                        }
+                        for field in merged_output.schema.fields
+                    ],
+                },
+                "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            }
+            for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "type": job.type,
+                "location": {
+                    "id": job.location.id,
+                    "name": job.location.name,
+                    "type": job.location.type,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                    "external_id": job.location.external_id,
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "id": dataset.location.id,
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                    "external_id": dataset.location.external_id,
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.name,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            },
+        ],
+    }
+
+
+async def test_get_run_lineage_unmergeable_inputs_and_outputs(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    duplicated_lineage: LineageResult,
+):
+    lineage = duplicated_lineage
+
+    # make every input and output a different schema -> grouping by Run returns None.
+    # make every output a different type -> grouping by Run returns None.
+    for raw_input in lineage.inputs:
+        schema = await create_schema(async_session)
+        raw_input.schema_id = schema.id
+        raw_input.schema = schema
+        await async_session.merge(raw_input)
+
+    output_types = list(OutputType)
+    for i, raw_output in enumerate(lineage.outputs):
+        schema = await create_schema(async_session)
+        raw_output.schema_id = schema.id
+        raw_output.schema = schema
+        raw_output.type = output_types[i % len(output_types)]
+        await async_session.merge(raw_output)
+
+    await async_session.commit()
+
+    run = lineage.runs[0]
+    job = next(job for job in lineage.jobs if job.id == run.job_id)
+
+    raw_inputs = [input for input in lineage.inputs if input.run_id == run.id]
+    merged_inputs = merge_io_by_runs(raw_inputs)
+    assert merged_inputs
+
+    raw_outputs = [output for output in lineage.outputs if output.run_id == run.id]
+    merged_outputs = merge_io_by_runs(raw_outputs)
+    assert merged_outputs
+
+    dataset_ids = {input.dataset_id for input in raw_inputs} | {output.dataset_id for output in raw_outputs}
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    [job] = await enrich_jobs([job], async_session)
+    [run] = await enrich_runs([run], async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+
+    response = await test_client.get(
+        "v1/runs/lineage",
+        params={
+            "since": run.created_at.isoformat(),
+            "start_node_id": str(run.id),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+            },
+        ]
+        + [
+            {
+                "kind": "INPUT",
+                "from": {"kind": "DATASET", "id": merged_input.dataset_id},
+                "to": {"kind": "RUN", "id": str(merged_input.run_id)},
+                "num_bytes": merged_input.num_bytes,
+                "num_rows": merged_input.num_rows,
+                "num_files": merged_input.num_files,
+                "schema": None,
+                "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            }
+            for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "RUN", "id": str(merged_output.run_id)},
+                "to": {"kind": "DATASET", "id": merged_output.dataset_id},
+                "type": None,
                 "num_bytes": merged_output.num_bytes,
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
@@ -1536,8 +1804,150 @@ async def test_get_run_lineage_with_symlinks(
                 "type": job.type,
                 "location": {
                     "id": job.location.id,
-                    "name": job.location.name,
                     "type": job.location.type,
+                    "name": job.location.name,
+                    "addresses": [{"url": address.url} for address in job.location.addresses],
+                    "external_id": job.location.external_id,
+                },
+            },
+        ]
+        + [
+            {
+                "kind": "DATASET",
+                "id": dataset.id,
+                "format": dataset.format,
+                "name": dataset.name,
+                "location": {
+                    "id": dataset.location.id,
+                    "name": dataset.location.name,
+                    "type": dataset.location.type,
+                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                    "external_id": dataset.location.external_id,
+                },
+            }
+            for dataset in sorted(datasets, key=lambda x: x.id)
+        ]
+        + [
+            {
+                "kind": "RUN",
+                "id": str(run.id),
+                "job_id": run.job_id,
+                "created_at": run.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "parent_run_id": str(run.parent_run_id),
+                "status": run.status.name,
+                "external_id": run.external_id,
+                "attempt": run.attempt,
+                "persistent_log_url": run.persistent_log_url,
+                "running_log_url": run.running_log_url,
+                "started_at": run.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "started_by_user": {"name": run.started_by_user.name},
+                "start_reason": run.start_reason.value,
+                "ended_at": run.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "end_reason": run.end_reason,
+            },
+        ],
+    }
+
+
+async def test_get_dataset_lineage_empty_io_stats_and_schema(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    duplicated_lineage: LineageResult,
+):
+    lineage = duplicated_lineage
+
+    # clear input/output stats and schema.
+    for raw_input in lineage.inputs:
+        raw_input.schema_id = None
+        raw_input.schema = None
+        raw_input.num_bytes = None
+        raw_input.num_rows = None
+        raw_input.num_files = None
+        await async_session.merge(raw_input)
+
+    for raw_output in lineage.outputs:
+        raw_output.schema_id = None
+        raw_output.schema = None
+        raw_output.num_bytes = None
+        raw_output.num_rows = None
+        raw_output.num_files = None
+        await async_session.merge(raw_output)
+
+    await async_session.commit()
+
+    run = lineage.runs[0]
+    job = next(job for job in lineage.jobs if job.id == run.job_id)
+
+    raw_inputs = [input for input in lineage.inputs if input.run_id == run.id]
+    merged_inputs = merge_io_by_runs(raw_inputs)
+    assert merged_inputs
+
+    raw_outputs = [output for output in lineage.outputs if output.run_id == run.id]
+    merged_outputs = merge_io_by_runs(raw_outputs)
+    assert merged_outputs
+
+    dataset_ids = {input.dataset_id for input in raw_inputs} | {output.dataset_id for output in raw_outputs}
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    [job] = await enrich_jobs([job], async_session)
+    [run] = await enrich_runs([run], async_session)
+    datasets = await enrich_datasets(datasets, async_session)
+
+    response = await test_client.get(
+        "v1/runs/lineage",
+        params={
+            "since": run.created_at.isoformat(),
+            "start_node_id": str(run.id),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": [
+            {
+                "kind": "PARENT",
+                "from": {"kind": "JOB", "id": run.job_id},
+                "to": {"kind": "RUN", "id": str(run.id)},
+            },
+        ]
+        + [
+            {
+                "kind": "INPUT",
+                "from": {"kind": "DATASET", "id": merged_input.dataset_id},
+                "to": {"kind": "RUN", "id": str(merged_input.run_id)},
+                "num_bytes": None,
+                "num_rows": None,
+                "num_files": None,
+                "schema": None,
+                "last_interaction_at": merged_input.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            }
+            for merged_input in sorted(merged_inputs, key=lambda x: (x.dataset_id, x.run_id))
+        ]
+        + [
+            {
+                "kind": "OUTPUT",
+                "from": {"kind": "RUN", "id": str(merged_output.run_id)},
+                "to": {"kind": "DATASET", "id": merged_output.dataset_id},
+                "type": merged_output.type,
+                "num_bytes": None,
+                "num_rows": None,
+                "num_files": None,
+                "schema": None,
+                "last_interaction_at": merged_output.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            }
+            for merged_output in sorted(merged_outputs, key=lambda x: (x.run_id, x.dataset_id))
+        ],
+        "nodes": [
+            {
+                "kind": "JOB",
+                "id": job.id,
+                "name": job.name,
+                "type": job.type,
+                "location": {
+                    "id": job.location.id,
+                    "type": job.location.type,
+                    "name": job.location.name,
                     "addresses": [{"url": address.url} for address in job.location.addresses],
                     "external_id": job.location.external_id,
                 },


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

* If all inputs/outputs within the Run or Job had the same `schema_id`, return this schema in API response with `granularity=RUN` or `JOB`. If any input/output has a different schema, return `None`, as we cannot properly merge them.
* Same for `Output.type`. Previously if different Outputs within the same Run or Job had different types, we returned multiple relations, each with different `type` value. Now we try to preserve original type, but if there are any Output with different type, replace it with `None`.
* For most tests use fixed `scheme_id` and `type=APPEND`, and check that schema and type are returned in API.
* Add tests for case then each input/output has a different schema/type.
* Also add tests with empty stats for Dataset, Job and Run lineage (previously it was implemented only for Operation).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
