### PR TITLE
[DOP-21572] Add id field to IO schema

### DIFF
--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -122,6 +122,7 @@ class LineageOutputRelationSchemaFieldV1(BaseModel):
 
 
 class LineageOutputRelationSchemaV1(BaseModel):
+    id: int = Field(description="Schema id")
     fields: list[LineageOutputRelationSchemaFieldV1] = Field(description="Schema fields")
 
     model_config = ConfigDict(from_attributes=True)

--- a/tests/test_server/test_lineage/test_dataset_lineage.py
+++ b/tests/test_server/test_lineage/test_dataset_lineage.py
@@ -128,6 +128,7 @@ async def test_get_dataset_lineage_with_granularity_run(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -151,6 +152,7 @@ async def test_get_dataset_lineage_with_granularity_run(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -263,6 +265,7 @@ async def test_get_dataset_lineage_with_granularity_job(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -286,6 +289,7 @@ async def test_get_dataset_lineage_with_granularity_job(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -401,6 +405,7 @@ async def test_get_dataset_lineage_with_granularity_operation(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
+                    "id": input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -424,6 +429,7 @@ async def test_get_dataset_lineage_with_granularity_operation(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
+                    "id": output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -562,6 +568,7 @@ async def test_get_dataset_lineage_with_direction_downstream(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -684,6 +691,7 @@ async def test_get_dataset_lineage_with_direction_upstream(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -814,6 +822,7 @@ async def test_get_dataset_lineage_with_until(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -837,6 +846,7 @@ async def test_get_dataset_lineage_with_until(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -996,6 +1006,7 @@ async def test_get_dataset_lineage_with_depth(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1019,6 +1030,7 @@ async def test_get_dataset_lineage_with_depth(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1164,6 +1176,7 @@ async def test_get_dataset_lineage_with_depth_and_granularity_job(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1187,6 +1200,7 @@ async def test_get_dataset_lineage_with_depth_and_granularity_job(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1339,6 +1353,7 @@ async def test_get_dataset_lineage_with_depth_and_granularity_operation(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
+                    "id": input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1362,6 +1377,7 @@ async def test_get_dataset_lineage_with_depth_and_granularity_operation(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
+                    "id": output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1496,6 +1512,7 @@ async def test_get_dataset_lineage_with_depth_ignore_cycles(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1519,6 +1536,7 @@ async def test_get_dataset_lineage_with_depth_ignore_cycles(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1665,6 +1683,7 @@ async def test_get_dataset_lineage_with_depth_ignore_unrelated_datasets(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1688,6 +1707,7 @@ async def test_get_dataset_lineage_with_depth_ignore_unrelated_datasets(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1838,6 +1858,7 @@ async def test_get_dataset_lineage_with_symlink(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1861,6 +1882,7 @@ async def test_get_dataset_lineage_with_symlink(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,

--- a/tests/test_server/test_lineage/test_job_lineage.py
+++ b/tests/test_server/test_lineage/test_job_lineage.py
@@ -193,6 +193,7 @@ async def test_get_job_lineage_simple(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -216,6 +217,7 @@ async def test_get_job_lineage_simple(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -304,6 +306,7 @@ async def test_get_job_lineage_with_direction_downstream(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -391,6 +394,7 @@ async def test_get_job_lineage_with_direction_upstream(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -485,6 +489,7 @@ async def test_get_job_lineage_with_until(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -508,6 +513,7 @@ async def test_get_job_lineage_with_until(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -612,6 +618,7 @@ async def test_get_job_lineage_with_granularity_run(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -635,6 +642,7 @@ async def test_get_job_lineage_with_granularity_run(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -776,6 +784,7 @@ async def test_get_job_lineage_with_depth(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -799,6 +808,7 @@ async def test_get_job_lineage_with_depth(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -936,6 +946,7 @@ async def test_get_job_lineage_with_depth_and_granularity_run(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -959,6 +970,7 @@ async def test_get_job_lineage_with_depth_and_granularity_run(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1067,6 +1079,7 @@ async def test_get_job_lineage_with_depth_ignore_cycles(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1090,6 +1103,7 @@ async def test_get_job_lineage_with_depth_ignore_cycles(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1209,6 +1223,7 @@ async def test_get_job_lineage_with_depth_ignore_unrelated_datasets(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1232,6 +1247,7 @@ async def test_get_job_lineage_with_depth_ignore_unrelated_datasets(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1343,6 +1359,7 @@ async def test_get_job_lineage_with_symlinks(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1366,6 +1383,7 @@ async def test_get_job_lineage_with_symlinks(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,

--- a/tests/test_server/test_lineage/test_operation_lineage.py
+++ b/tests/test_server/test_lineage/test_operation_lineage.py
@@ -168,6 +168,7 @@ async def test_get_operation_lineage_simple(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
+                    "id": input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -191,6 +192,7 @@ async def test_get_operation_lineage_simple(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
+                    "id": output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -329,6 +331,7 @@ async def test_get_operation_lineage_with_direction_downstream(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
+                    "id": output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -466,6 +469,7 @@ async def test_get_operation_lineage_with_direction_upstream(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
+                    "id": input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -616,6 +620,7 @@ async def test_get_operation_lineage_with_until(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
+                    "id": input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -639,6 +644,7 @@ async def test_get_operation_lineage_with_until(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
+                    "id": output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -824,6 +830,7 @@ async def test_get_operation_lineage_with_depth(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
+                    "id": input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -847,6 +854,7 @@ async def test_get_operation_lineage_with_depth(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
+                    "id": output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -986,6 +994,7 @@ async def test_get_operation_lineage_with_depth_ignore_cycles(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
+                    "id": input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1009,6 +1018,7 @@ async def test_get_operation_lineage_with_depth_ignore_cycles(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
+                    "id": output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1179,6 +1189,7 @@ async def test_get_operation_lineage_with_depth_ignore_unrelated_datasets(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
+                    "id": input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1202,6 +1213,7 @@ async def test_get_operation_lineage_with_depth_ignore_unrelated_datasets(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
+                    "id": output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1361,6 +1373,7 @@ async def test_get_operation_lineage_with_symlinks(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
+                    "id": input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1384,6 +1397,7 @@ async def test_get_operation_lineage_with_symlinks(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
+                    "id": output.schema_id,
                     "fields": [
                         {
                             "description": None,

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -208,6 +208,7 @@ async def test_get_run_lineage_simple(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -231,6 +232,7 @@ async def test_get_run_lineage_simple(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -359,6 +361,7 @@ async def test_get_run_lineage_with_granularity_operation(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
+                    "id": input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -382,6 +385,7 @@ async def test_get_run_lineage_with_granularity_operation(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
+                    "id": output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -514,6 +518,7 @@ async def test_get_run_lineage_with_direction_downstream(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -628,6 +633,7 @@ async def test_get_run_lineage_with_direction_upstream(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -753,6 +759,7 @@ async def test_get_run_lineage_with_until(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -776,6 +783,7 @@ async def test_get_run_lineage_with_until(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -931,6 +939,7 @@ async def test_get_run_lineage_with_depth(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -954,6 +963,7 @@ async def test_get_run_lineage_with_depth(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1132,6 +1142,7 @@ async def test_get_run_lineage_with_depth_and_granularity_operation(
                 "num_rows": input.num_rows,
                 "num_files": input.num_files,
                 "schema": {
+                    "id": input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1155,6 +1166,7 @@ async def test_get_run_lineage_with_depth_and_granularity_operation(
                 "num_rows": output.num_rows,
                 "num_files": output.num_files,
                 "schema": {
+                    "id": output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1288,6 +1300,7 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1311,6 +1324,7 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1458,6 +1472,7 @@ async def test_get_run_lineage_with_depth_ignore_unrelated_datasets(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1481,6 +1496,7 @@ async def test_get_run_lineage_with_depth_ignore_unrelated_datasets(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1619,6 +1635,7 @@ async def test_get_run_lineage_with_symlinks(
                 "num_rows": merged_input.num_rows,
                 "num_files": merged_input.num_files,
                 "schema": {
+                    "id": merged_input.schema_id,
                     "fields": [
                         {
                             "description": None,
@@ -1642,6 +1659,7 @@ async def test_get_run_lineage_with_symlinks(
                 "num_rows": merged_output.num_rows,
                 "num_files": merged_output.num_files,
                 "schema": {
+                    "id": merged_output.schema_id,
                     "fields": [
                         {
                             "description": None,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Added `id` field to `schema` response. Although users cannot fetch schema by its id, this fields allows to check whether 2 schemas are equal without converting them to the same canonical format (e.g. json with sorted keys).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
