### PR TITLE
[DOP-20054] Add swap  dataset and it's symlink(hive) for hdfs

### DIFF
--- a/data_rentgen/consumer/extractors/__init__.py
+++ b/data_rentgen/consumer/extractors/__init__.py
@@ -5,7 +5,7 @@ from data_rentgen.consumer.extractors.batch import BatchExtractionResult, extrac
 from data_rentgen.consumer.extractors.dataset import (
     connect_dataset_with_symlinks,
     extract_dataset,
-    extract_io_dataset,
+    extract_dataset_and_symlinks,
 )
 from data_rentgen.consumer.extractors.input import extract_input
 from data_rentgen.consumer.extractors.job import extract_job
@@ -15,7 +15,7 @@ from data_rentgen.consumer.extractors.run import extract_run, extract_run_minima
 from data_rentgen.consumer.extractors.schema import extract_schema
 
 __all__ = [
-    "extract_io_dataset",
+    "extract_dataset_and_symlinks",
     "extract_dataset",
     "connect_dataset_with_symlinks",
     "extract_job",

--- a/data_rentgen/consumer/extractors/__init__.py
+++ b/data_rentgen/consumer/extractors/__init__.py
@@ -3,9 +3,9 @@
 
 from data_rentgen.consumer.extractors.batch import BatchExtractionResult, extract_batch
 from data_rentgen.consumer.extractors.dataset import (
+    connect_dataset_with_symlinks,
     extract_dataset,
-    extract_dataset_aliases,
-    extract_dataset_symlinks,
+    extract_io_dataset,
 )
 from data_rentgen.consumer.extractors.input import extract_input
 from data_rentgen.consumer.extractors.job import extract_job
@@ -15,9 +15,9 @@ from data_rentgen.consumer.extractors.run import extract_run, extract_run_minima
 from data_rentgen.consumer.extractors.schema import extract_schema
 
 __all__ = [
+    "extract_io_dataset",
     "extract_dataset",
-    "extract_dataset_aliases",
-    "extract_dataset_symlinks",
+    "connect_dataset_with_symlinks",
     "extract_job",
     "extract_run",
     "extract_run_minimal",

--- a/data_rentgen/consumer/extractors/batch.py
+++ b/data_rentgen/consumer/extractors/batch.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TypeVar
 
-from data_rentgen.consumer.extractors.dataset import connect_dataset_with_symlinks
 from data_rentgen.consumer.extractors.input import extract_input
 from data_rentgen.consumer.extractors.operation import extract_operation
 from data_rentgen.consumer.extractors.output import extract_output
@@ -235,15 +234,17 @@ def extract_batch(events: list[OpenLineageRunEvent]) -> BatchExtractionResult:
             operation = extract_operation(event)
             result.add_operation(operation)
             for input_dataset in event.inputs:
-                result.add_input(extract_input(operation, input_dataset))
-
-            for output_dataset in event.outputs:
-                result.add_output(extract_output(operation, output_dataset))
-
-            for dataset in result.datasets():
-                symlinks = connect_dataset_with_symlinks(dataset, dataset.dataset_symlinks)
+                input, symlinks = extract_input(operation, input_dataset)
+                result.add_input(input)
                 for symlink in symlinks:
                     result.add_dataset_symlink(symlink)
+
+            for output_dataset in event.outputs:
+                output, symlinks = extract_output(operation, output_dataset)
+                result.add_output(output)
+                for symlink in symlinks:  # noqa: WPS440
+                    result.add_dataset_symlink(symlink)
+
         else:
             run = extract_run(event)
             result.add_run(run)

--- a/data_rentgen/consumer/extractors/batch.py
+++ b/data_rentgen/consumer/extractors/batch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TypeVar
 
-from data_rentgen.consumer.extractors.dataset import extract_dataset_symlinks
+from data_rentgen.consumer.extractors.dataset import connect_dataset_with_symlinks
 from data_rentgen.consumer.extractors.input import extract_input
 from data_rentgen.consumer.extractors.operation import extract_operation
 from data_rentgen.consumer.extractors.output import extract_output
@@ -234,17 +234,16 @@ def extract_batch(events: list[OpenLineageRunEvent]) -> BatchExtractionResult:
         if event.job.facets.jobType and event.job.facets.jobType.jobType == OpenLineageJobType.JOB:
             operation = extract_operation(event)
             result.add_operation(operation)
-
             for input_dataset in event.inputs:
                 result.add_input(extract_input(operation, input_dataset))
 
             for output_dataset in event.outputs:
                 result.add_output(extract_output(operation, output_dataset))
 
-            for dataset in event.inputs + event.outputs:
-                dataset_symlinks = extract_dataset_symlinks(dataset)
-                for dataset_symlink in dataset_symlinks:
-                    result.add_dataset_symlink(dataset_symlink)
+            for dataset in result.datasets():
+                symlinks = connect_dataset_with_symlinks(dataset, dataset.dataset_symlinks)
+                for symlink in symlinks:
+                    result.add_dataset_symlink(symlink)
         else:
             run = extract_run(event)
             result.add_run(run)

--- a/data_rentgen/consumer/extractors/dataset.py
+++ b/data_rentgen/consumer/extractors/dataset.py
@@ -65,10 +65,10 @@ def extract_dataset_and_symlinks(dataset: OpenLineageDataset) -> tuple[DatasetDT
             if identifier.type == OpenLineageSymlinkType.TABLE
         ]
         if table_symlinks:
-            # We are swap dataset with its TABLE symlink to make a more clean lineage.
-            # As example by swapping hdfs file with it's hive table.
-            # We have got that all operations interact with one table instead of many files(which can be different partitions).
-            # Discuss about this issue: https://github.com/OpenLineage/OpenLineage/issues/2718
+            # We are swapping the dataset with its TABLE symlink to create a cleaner lineage.
+            # For example, by replacing an HDFS file with its corresponding Hive table.
+            # This ensures that all operations interact with a single table instead of multiple files (which may represent different partitions).
+            # Discussion on this issue: https://github.com/OpenLineage/OpenLineage/issues/2718
 
             # TODO: add support for multiple TABLE symlinks
             if len(table_symlinks) > 1:

--- a/data_rentgen/consumer/extractors/dataset.py
+++ b/data_rentgen/consumer/extractors/dataset.py
@@ -78,19 +78,19 @@ def extract_dataset_and_symlinks(dataset: OpenLineageDataset) -> tuple[DatasetDT
                 "Dataset has more than one TABLE symlink. Only the first one will be used for replacement. Symlink name: %s",
                 table_symlinks[0].name,
             )
-            table_dataset = table_symlinks[0]
-            return (
-                DatasetDTO(
-                    name=table_dataset.name,
-                    location=extract_dataset_location(table_dataset),
-                    format=extract_dataset_format(table_dataset),
-                ),
-                connect_dataset_with_symlinks(
-                    extract_dataset(dataset),
-                    extract_dataset(table_dataset),
-                    OpenLineageSymlinkType.TABLE,
-                ),
-            )
+        table_dataset = table_symlinks[0]
+        return (
+            DatasetDTO(
+                name=table_dataset.name,
+                location=extract_dataset_location(table_dataset),
+                format=extract_dataset_format(table_dataset),
+            ),
+            connect_dataset_with_symlinks(
+                extract_dataset(dataset),
+                extract_dataset(table_dataset),
+                OpenLineageSymlinkType.TABLE,
+            ),
+        )
 
     symlinks = []
     for identifier in dataset.facets.symlinks.identifiers:

--- a/data_rentgen/consumer/extractors/input.py
+++ b/data_rentgen/consumer/extractors/input.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
-from data_rentgen.consumer.extractors.dataset import extract_dataset
+from data_rentgen.consumer.extractors.dataset import extract_io_dataset
 from data_rentgen.consumer.extractors.schema import extract_schema
 from data_rentgen.consumer.openlineage.dataset import OpenLineageInputDataset
 from data_rentgen.dto import InputDTO
@@ -14,7 +14,7 @@ def extract_input(
 ) -> InputDTO:
     result = InputDTO(
         operation=operation,
-        dataset=extract_dataset(dataset),
+        dataset=extract_io_dataset(dataset),
         schema=extract_schema(dataset),
     )
     if dataset.inputFacets.inputStatistics:

--- a/data_rentgen/consumer/extractors/input.py
+++ b/data_rentgen/consumer/extractors/input.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
-from data_rentgen.consumer.extractors.dataset import extract_io_dataset
+from data_rentgen.consumer.extractors.dataset import extract_dataset_and_symlinks
 from data_rentgen.consumer.extractors.schema import extract_schema
 from data_rentgen.consumer.openlineage.dataset import OpenLineageInputDataset
 from data_rentgen.dto import DatasetSymlinkDTO, InputDTO
@@ -12,7 +12,7 @@ def extract_input(
     operation: OperationDTO,
     dataset: OpenLineageInputDataset,
 ) -> tuple[InputDTO, list[DatasetSymlinkDTO]]:
-    dataset_dto, symlinks = extract_io_dataset(dataset)
+    dataset_dto, symlinks = extract_dataset_and_symlinks(dataset)
     result = InputDTO(
         operation=operation,
         dataset=dataset_dto,

--- a/data_rentgen/consumer/extractors/input.py
+++ b/data_rentgen/consumer/extractors/input.py
@@ -4,21 +4,22 @@
 from data_rentgen.consumer.extractors.dataset import extract_io_dataset
 from data_rentgen.consumer.extractors.schema import extract_schema
 from data_rentgen.consumer.openlineage.dataset import OpenLineageInputDataset
-from data_rentgen.dto import InputDTO
+from data_rentgen.dto import DatasetSymlinkDTO, InputDTO
 from data_rentgen.dto.operation import OperationDTO
 
 
 def extract_input(
     operation: OperationDTO,
     dataset: OpenLineageInputDataset,
-) -> InputDTO:
+) -> tuple[InputDTO, list[DatasetSymlinkDTO]]:
+    dataset_dto, symlinks = extract_io_dataset(dataset)
     result = InputDTO(
         operation=operation,
-        dataset=extract_io_dataset(dataset),
+        dataset=dataset_dto,
         schema=extract_schema(dataset),
     )
     if dataset.inputFacets.inputStatistics:
         result.num_rows = dataset.inputFacets.inputStatistics.rows
         result.num_bytes = dataset.inputFacets.inputStatistics.bytes
         result.num_files = dataset.inputFacets.inputStatistics.files
-    return result
+    return result, symlinks

--- a/data_rentgen/consumer/extractors/output.py
+++ b/data_rentgen/consumer/extractors/output.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
-from data_rentgen.consumer.extractors.dataset import extract_dataset
+from data_rentgen.consumer.extractors.dataset import extract_io_dataset
 from data_rentgen.consumer.extractors.schema import extract_schema
 from data_rentgen.consumer.openlineage.dataset import OpenLineageOutputDataset
 from data_rentgen.dto import OutputDTO, OutputTypeDTO
@@ -21,7 +21,7 @@ def extract_output(
     result = OutputDTO(
         type=output_type,
         operation=operation,
-        dataset=extract_dataset(dataset),
+        dataset=extract_io_dataset(dataset),
         schema=extract_schema(dataset),
     )
     if dataset.outputFacets.outputStatistics:

--- a/data_rentgen/consumer/extractors/output.py
+++ b/data_rentgen/consumer/extractors/output.py
@@ -17,7 +17,7 @@ def extract_output(
         output_type = OutputTypeDTO(lifecycle_change.lifecycleStateChange)
     else:
         output_type = OutputTypeDTO.APPEND
-    dataset_dto, symlink = extract_dataset_and_symlinks(dataset)
+    dataset_dto, symlinks = extract_dataset_and_symlinks(dataset)
     result = OutputDTO(
         type=output_type,
         operation=operation,
@@ -29,4 +29,4 @@ def extract_output(
         result.num_bytes = dataset.outputFacets.outputStatistics.bytes
         result.num_files = dataset.outputFacets.outputStatistics.files
 
-    return result, symlink
+    return result, symlinks

--- a/data_rentgen/consumer/extractors/output.py
+++ b/data_rentgen/consumer/extractors/output.py
@@ -4,24 +4,24 @@
 from data_rentgen.consumer.extractors.dataset import extract_io_dataset
 from data_rentgen.consumer.extractors.schema import extract_schema
 from data_rentgen.consumer.openlineage.dataset import OpenLineageOutputDataset
-from data_rentgen.dto import OutputDTO, OutputTypeDTO
+from data_rentgen.dto import DatasetSymlinkDTO, OutputDTO, OutputTypeDTO
 from data_rentgen.dto.operation import OperationDTO
 
 
 def extract_output(
     operation: OperationDTO,
     dataset: OpenLineageOutputDataset,
-) -> OutputDTO:
+) -> tuple[OutputDTO, list[DatasetSymlinkDTO]]:
     lifecycle_change = dataset.facets.lifecycleStateChange
     if lifecycle_change:
         output_type = OutputTypeDTO(lifecycle_change.lifecycleStateChange)
     else:
         output_type = OutputTypeDTO.APPEND
-
+    dataset_dto, symlink = extract_io_dataset(dataset)
     result = OutputDTO(
         type=output_type,
         operation=operation,
-        dataset=extract_io_dataset(dataset),
+        dataset=dataset_dto,
         schema=extract_schema(dataset),
     )
     if dataset.outputFacets.outputStatistics:
@@ -29,4 +29,4 @@ def extract_output(
         result.num_bytes = dataset.outputFacets.outputStatistics.bytes
         result.num_files = dataset.outputFacets.outputStatistics.files
 
-    return result
+    return result, symlink

--- a/data_rentgen/consumer/extractors/output.py
+++ b/data_rentgen/consumer/extractors/output.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
-from data_rentgen.consumer.extractors.dataset import extract_io_dataset
+from data_rentgen.consumer.extractors.dataset import extract_dataset_and_symlinks
 from data_rentgen.consumer.extractors.schema import extract_schema
 from data_rentgen.consumer.openlineage.dataset import OpenLineageOutputDataset
 from data_rentgen.dto import DatasetSymlinkDTO, OutputDTO, OutputTypeDTO
@@ -17,7 +17,7 @@ def extract_output(
         output_type = OutputTypeDTO(lifecycle_change.lifecycleStateChange)
     else:
         output_type = OutputTypeDTO.APPEND
-    dataset_dto, symlink = extract_io_dataset(dataset)
+    dataset_dto, symlink = extract_dataset_and_symlinks(dataset)
     result = OutputDTO(
         type=output_type,
         operation=operation,

--- a/data_rentgen/dto/dataset.py
+++ b/data_rentgen/dto/dataset.py
@@ -15,8 +15,6 @@ class DatasetDTO:
     name: str
     format: str | None = None
     id: int | None = field(default=None, compare=False)
-    symlink_type: str | None = field(default=None, compare=False)
-    dataset_symlinks: list[DatasetDTO] = field(default_factory=list)
 
     @cached_property
     def unique_key(self) -> tuple:

--- a/data_rentgen/dto/dataset.py
+++ b/data_rentgen/dto/dataset.py
@@ -15,6 +15,8 @@ class DatasetDTO:
     name: str
     format: str | None = None
     id: int | None = field(default=None, compare=False)
+    symlink_type: str | None = field(default=None, compare=False)
+    dataset_symlinks: list[DatasetDTO] = field(default_factory=list)
 
     @cached_property
     def unique_key(self) -> tuple:

--- a/tests/test_consumer/test_extractors/test_extractors_batch_spark.py
+++ b/tests/test_consumer/test_extractors/test_extractors_batch_spark.py
@@ -695,15 +695,16 @@ def extracted_postgres_input(
 
 
 @pytest.fixture
-def extracted_hdfs_output(
+def extracted_hive_output(
     extracted_spark_operation: OperationDTO,
     extracted_hdfs_dataset: DatasetDTO,
+    extracted_hive_dataset: DatasetDTO,
     extracted_dataset_schema: SchemaDTO,
 ) -> OutputDTO:
     return OutputDTO(
         type=OutputTypeDTO.CREATE,
         operation=extracted_spark_operation,
-        dataset=extracted_hdfs_dataset,
+        dataset=extracted_hive_dataset,
         schema=extracted_dataset_schema,
         num_rows=1_000_000,
         num_bytes=1000 * 1024 * 1024,
@@ -745,7 +746,7 @@ def test_extractors_extract_batch_spark(
     extracted_spark_app_run: RunDTO,
     extracted_spark_operation: OperationDTO,
     extracted_postgres_input: InputDTO,
-    extracted_hdfs_output: OutputDTO,
+    extracted_hive_output: OutputDTO,
     input_transformation,
 ):
     events = [
@@ -761,8 +762,8 @@ def test_extractors_extract_batch_spark(
     assert extracted.locations() == [
         extracted_spark_location,
         extracted_postgres_location,
-        extracted_hdfs_location,
         extracted_hive_location,
+        extracted_hdfs_location,
     ]
 
     assert extracted.jobs() == [extracted_spark_app_job]
@@ -772,8 +773,8 @@ def test_extractors_extract_batch_spark(
 
     assert extracted.datasets() == [
         extracted_postgres_dataset,
-        extracted_hdfs_dataset,
         extracted_hive_dataset,
+        extracted_hdfs_dataset,
     ]
 
     assert extracted.dataset_symlinks() == [
@@ -784,4 +785,4 @@ def test_extractors_extract_batch_spark(
     # Both input & output schemas are the same
     assert extracted.schemas() == [extracted_dataset_schema]
     assert extracted.inputs() == [extracted_postgres_input]
-    assert extracted.outputs() == [extracted_hdfs_output]
+    assert extracted.outputs() == [extracted_hive_output]

--- a/tests/test_consumer/test_extractors/test_extractors_dataset.py
+++ b/tests/test_consumer/test_extractors/test_extractors_dataset.py
@@ -61,8 +61,6 @@ def test_extractors_extract_dataset_hdfs_with_table_symlink():
             addresses={"hdfs://test-hadoop:9820"},
         ),
         name="/warehouse/mydb.db/mytable",
-        symlink_type=None,
-        dataset_symlinks=[],
     )
 
     hive_dataset = DatasetDTO(
@@ -72,13 +70,11 @@ def test_extractors_extract_dataset_hdfs_with_table_symlink():
             addresses={"hive://test-hadoop:9083"},
         ),
         name="mydb.mytable",
-        dataset_symlinks=[hdfs_dataset],
-        symlink_type=OpenLineageSymlinkType.TABLE,
     )
 
-    dataset = extract_io_dataset(dataset)
+    dataset, symlinks = extract_io_dataset(dataset)
     assert dataset == hive_dataset
-    assert connect_dataset_with_symlinks(dataset, dataset.dataset_symlinks) == [
+    assert symlinks == [
         DatasetSymlinkDTO(from_dataset=hdfs_dataset, to_dataset=hive_dataset, type=DatasetSymlinkTypeDTO.METASTORE),
         DatasetSymlinkDTO(from_dataset=hive_dataset, to_dataset=hdfs_dataset, type=DatasetSymlinkTypeDTO.WAREHOUSE),
     ]
@@ -196,13 +192,12 @@ def test_extractors_extract_dataset_hive_with_location_symlink():
             addresses={"hive://test-hadoop:9083"},
         ),
         name="mydb.mytable",
-        dataset_symlinks=[hdfs_dataset],
     )
 
-    dataset = extract_io_dataset(dataset)
+    dataset, symlinks = extract_io_dataset(dataset)
 
     assert dataset == hive_dataset
-    assert connect_dataset_with_symlinks(dataset, dataset.dataset_symlinks) == [
+    assert symlinks == [
         DatasetSymlinkDTO(from_dataset=hdfs_dataset, to_dataset=hive_dataset, type=DatasetSymlinkTypeDTO.METASTORE),
         DatasetSymlinkDTO(from_dataset=hive_dataset, to_dataset=hdfs_dataset, type=DatasetSymlinkTypeDTO.WAREHOUSE),
     ]

--- a/tests/test_consumer/test_extractors/test_extractors_dataset.py
+++ b/tests/test_consumer/test_extractors/test_extractors_dataset.py
@@ -3,7 +3,7 @@ import pytest
 from data_rentgen.consumer.extractors import (
     connect_dataset_with_symlinks,
     extract_dataset,
-    extract_io_dataset,
+    extract_dataset_and_symlinks,
 )
 from data_rentgen.consumer.openlineage.dataset import OpenLineageDataset
 from data_rentgen.consumer.openlineage.dataset_facets import (
@@ -27,7 +27,9 @@ def test_extractors_extract_dataset_hdfs():
         name="/user/hive/warehouse/mydb.db/mytable",
     )
 
-    assert extract_dataset(dataset) == DatasetDTO(
+    dataset, symlinks = extract_dataset_and_symlinks(dataset)
+
+    assert dataset == DatasetDTO(
         location=LocationDTO(
             type="hdfs",
             name="test-hadoop:9820",
@@ -35,6 +37,7 @@ def test_extractors_extract_dataset_hdfs():
         ),
         name="/user/hive/warehouse/mydb.db/mytable",
     )
+    assert symlinks == []
 
 
 def test_extractors_extract_dataset_hdfs_with_table_symlink():
@@ -72,7 +75,8 @@ def test_extractors_extract_dataset_hdfs_with_table_symlink():
         name="mydb.mytable",
     )
 
-    dataset, symlinks = extract_io_dataset(dataset)
+    dataset, symlinks = extract_dataset_and_symlinks(dataset)
+
     assert dataset == hive_dataset
     assert symlinks == [
         DatasetSymlinkDTO(from_dataset=hdfs_dataset, to_dataset=hive_dataset, type=DatasetSymlinkTypeDTO.METASTORE),
@@ -101,7 +105,9 @@ def test_extractors_extract_dataset_hdfs_with_format(storage_layer: str, file_fo
         ),
     )
 
-    assert extract_dataset(dataset) == DatasetDTO(
+    dataset, symlinks = extract_dataset_and_symlinks(dataset)
+
+    assert dataset == DatasetDTO(
         location=LocationDTO(
             type="hdfs",
             name="test-hadoop:9820",
@@ -110,6 +116,7 @@ def test_extractors_extract_dataset_hdfs_with_format(storage_layer: str, file_fo
         name="/user/hive/warehouse/mydb.db/mytable",
         format=expected_format,
     )
+    assert symlinks == []
 
 
 def test_extractors_extract_dataset_s3():
@@ -117,7 +124,10 @@ def test_extractors_extract_dataset_s3():
         namespace="s3://bucket",
         name="warehouse/mydb.db/mytable",
     )
-    assert extract_dataset(dataset) == DatasetDTO(
+
+    dataset, symlinks = extract_dataset_and_symlinks(dataset)
+
+    assert dataset == DatasetDTO(
         location=LocationDTO(
             type="s3",
             name="bucket",
@@ -125,6 +135,7 @@ def test_extractors_extract_dataset_s3():
         ),
         name="warehouse/mydb.db/mytable",
     )
+    assert symlinks == []
 
 
 def test_extractors_extract_dataset_file():
@@ -133,7 +144,9 @@ def test_extractors_extract_dataset_file():
         name="/warehouse/mydb.db/mytable",
     )
 
-    assert extract_dataset(dataset) == DatasetDTO(
+    dataset, symlinks = extract_dataset_and_symlinks(dataset)
+
+    assert dataset == DatasetDTO(
         location=LocationDTO(
             type="file",
             name="unknown",
@@ -141,6 +154,7 @@ def test_extractors_extract_dataset_file():
         ),
         name="/warehouse/mydb.db/mytable",
     )
+    assert symlinks == []
 
 
 def test_extractors_extract_dataset_hive():
@@ -149,7 +163,9 @@ def test_extractors_extract_dataset_hive():
         name="mydb.mytable",
     )
 
-    assert extract_dataset(dataset) == DatasetDTO(
+    dataset, symlinks = extract_dataset_and_symlinks(dataset)
+
+    assert dataset == DatasetDTO(
         location=LocationDTO(
             type="hive",
             name="test-hadoop:9083",
@@ -157,6 +173,7 @@ def test_extractors_extract_dataset_hive():
         ),
         name="mydb.mytable",
     )
+    assert symlinks == []
 
 
 def test_extractors_extract_dataset_hive_with_location_symlink():
@@ -194,7 +211,7 @@ def test_extractors_extract_dataset_hive_with_location_symlink():
         name="mydb.mytable",
     )
 
-    dataset, symlinks = extract_io_dataset(dataset)
+    dataset, symlinks = extract_dataset_and_symlinks(dataset)
 
     assert dataset == hive_dataset
     assert symlinks == [
@@ -209,7 +226,9 @@ def test_extractors_extract_dataset_postgres():
         name="mydb.myschema.mytable",
     )
 
-    assert extract_dataset(dataset) == DatasetDTO(
+    dataset, symlinks = extract_dataset_and_symlinks(dataset)
+
+    assert dataset == DatasetDTO(
         location=LocationDTO(
             type="postgres",
             name="192.168.1.1:5432",
@@ -217,6 +236,7 @@ def test_extractors_extract_dataset_postgres():
         ),
         name="mydb.myschema.mytable",
     )
+    assert symlinks == []
 
 
 def test_extractors_extract_dataset_kafka():
@@ -225,7 +245,9 @@ def test_extractors_extract_dataset_kafka():
         name="mytopic",
     )
 
-    assert extract_dataset(dataset) == DatasetDTO(
+    dataset, symlinks = extract_dataset_and_symlinks(dataset)
+
+    assert dataset == DatasetDTO(
         location=LocationDTO(
             type="kafka",
             name="192.168.1.1:9092",
@@ -233,6 +255,7 @@ def test_extractors_extract_dataset_kafka():
         ),
         name="mytopic",
     )
+    assert symlinks == []
 
 
 def test_extractors_extract_dataset_unknown():
@@ -241,7 +264,9 @@ def test_extractors_extract_dataset_unknown():
         name="some.name",
     )
 
-    assert extract_dataset(dataset) == DatasetDTO(
+    dataset, symlinks = extract_dataset_and_symlinks(dataset)
+
+    assert dataset == DatasetDTO(
         location=LocationDTO(
             type="unknown",
             name="some-namespace",
@@ -249,3 +274,4 @@ def test_extractors_extract_dataset_unknown():
         ),
         name="some.name",
     )
+    assert symlinks == []

--- a/tests/test_consumer/test_extractors/test_extractors_interaction.py
+++ b/tests/test_consumer/test_extractors/test_extractors_interaction.py
@@ -115,19 +115,22 @@ def test_extractors_extract_input(
     )
     operation_dto = Mock(spec=OperationDTO)
 
-    assert extract_input(operation_dto, input) == InputDTO(
-        operation=operation_dto,
-        dataset=DatasetDTO(
-            name="/user/hive/warehouse/mydb.db/mytable",
-            location=LocationDTO(
-                type="hdfs",
-                name="test-hadoop:9820",
-                addresses={"hdfs://test-hadoop:9820"},
+    assert extract_input(operation_dto, input) == (
+        InputDTO(
+            operation=operation_dto,
+            dataset=DatasetDTO(
+                name="/user/hive/warehouse/mydb.db/mytable",
+                location=LocationDTO(
+                    type="hdfs",
+                    name="test-hadoop:9820",
+                    addresses={"hdfs://test-hadoop:9820"},
+                ),
             ),
+            num_rows=row_count,
+            num_bytes=byte_count,
+            num_files=file_count,
         ),
-        num_rows=row_count,
-        num_bytes=byte_count,
-        num_files=file_count,
+        [],
     )
 
 
@@ -176,18 +179,21 @@ def test_extractors_extract_output(
     )
     operation_dto = Mock(spec=OperationDTO)
 
-    assert extract_output(operation_dto, output) == OutputDTO(
-        type=expected_type,
-        operation=operation_dto,
-        dataset=DatasetDTO(
-            name="/user/hive/warehouse/mydb.db/mytable",
-            location=LocationDTO(
-                type="hdfs",
-                name="test-hadoop:9820",
-                addresses={"hdfs://test-hadoop:9820"},
+    assert extract_output(operation_dto, output) == (
+        OutputDTO(
+            type=expected_type,
+            operation=operation_dto,
+            dataset=DatasetDTO(
+                name="/user/hive/warehouse/mydb.db/mytable",
+                location=LocationDTO(
+                    type="hdfs",
+                    name="test-hadoop:9820",
+                    addresses={"hdfs://test-hadoop:9820"},
+                ),
             ),
+            num_rows=row_count,
+            num_bytes=byte_count,
+            num_files=file_count,
         ),
-        num_rows=row_count,
-        num_bytes=byte_count,
-        num_files=file_count,
+        [],
     )

--- a/tests/test_consumer/test_handlers/test_runs_handler_spark.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_spark.py
@@ -65,7 +65,6 @@ async def test_runs_handler_spark(
     job_query = select(Job).order_by(Job.name).options(selectinload(Job.location).selectinload(Location.addresses))
     job_scalars = await async_session.scalars(job_query)
     jobs = job_scalars.all()
-
     assert len(jobs) == 1
     assert jobs[0].name == "spark_session"
     assert jobs[0].location.type == "local"
@@ -188,7 +187,7 @@ async def test_runs_handler_spark(
     assert hive_input.operation_id == job_operation.id
     assert hive_input.run_id == application_run.id
     assert hive_input.job_id == application_run.job_id
-    assert hive_input.dataset_id == hdfs_warehouse.id
+    assert hive_input.dataset_id == hive_table.id
     assert hive_input.schema_id == hive_schema.id
     assert hive_input.num_bytes is None
     assert hive_input.num_rows is None


### PR DESCRIPTION
## Change Summary

- All datasets now extrac in one method `extract_io_dataset`. It's return updated DatasetDTO, with new fields:
  - `dataset_symlinks: list[DatasetDTO]` - store all symlinks.
  - symlink_type: - store type type of connection. Used for `TABLE` type.
*MB It's better add new DTO for symlinks.`*
- Dataset connect with it symlinks via function `connect_dataset_with_symlinks() -> list[DatasetSymlinkDTO]`
- Remove `extract_dataset_aliases` - it is not used

## Related issue number

[DOP-20054]

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
