### PR TITLE
[DOP-22578] Return statistics in GET /operations

### DIFF
--- a/data_rentgen/db/repositories/input.py
+++ b/data_rentgen/db/repositories/input.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from typing import Literal, Sequence
 from uuid import UUID
 
-from sqlalchemy import ColumnElement, Select, any_, func, literal_column, select
+from sqlalchemy import ColumnElement, Row, Select, any_, func, literal_column, select
 from sqlalchemy.dialects.postgresql import insert
 
 from data_rentgen.db.models import Input
@@ -162,7 +162,6 @@ class InputRepository(Repository[Input]):
         if granularity == "RUN":
             query = select(
                 func.max(Input.created_at).label("created_at"),
-                literal_column("NULL").label("id"),
                 literal_column("NULL").label("operation_id"),
                 Input.run_id,
                 Input.job_id,
@@ -180,7 +179,6 @@ class InputRepository(Repository[Input]):
         else:
             query = select(
                 func.max(Input.created_at).label("created_at"),
-                literal_column("NULL").label("id"),
                 literal_column("NULL").label("operation_id"),
                 literal_column("NULL").label("run_id"),
                 Input.job_id,
@@ -212,3 +210,32 @@ class InputRepository(Repository[Input]):
             )
             for row in query_result.all()
         ]
+
+    async def get_stats_by_operation_ids(self, operation_ids: Sequence[UUID]) -> dict[UUID, Row]:
+        if not operation_ids:
+            return {}
+
+        # Input created_at is always the same as operation's created_at
+        # do not use `tuple_(Input.created_at, Input.operation_id).in_(...),
+        # as this is too complex filter for Postgres to make an optimal query plan
+        min_created_at = extract_timestamp_from_uuid(min(operation_ids))
+        max_created_at = extract_timestamp_from_uuid(max(operation_ids))
+
+        query = (
+            select(
+                Input.operation_id.label("operation_id"),
+                func.count(Input.dataset_id.distinct()).label("total_datasets"),
+                func.sum(Input.num_bytes).label("total_bytes"),
+                func.sum(Input.num_rows).label("total_rows"),
+                func.sum(Input.num_files).label("total_files"),
+            )
+            .where(
+                Input.created_at >= min_created_at,
+                Input.created_at <= max_created_at,
+                Input.operation_id == any_(operation_ids),  # type: ignore[arg-type]
+            )
+            .group_by(Input.operation_id)
+        )
+
+        query_result = await self._session.execute(query)
+        return {row.operation_id: row for row in query_result.all()}

--- a/data_rentgen/server/api/v1/router/operation.py
+++ b/data_rentgen/server/api/v1/router/operation.py
@@ -9,13 +9,14 @@ from data_rentgen.server.errors import get_error_responses
 from data_rentgen.server.errors.schemas import InvalidRequestSchema
 from data_rentgen.server.schemas.v1 import (
     LineageResponseV1,
+    OperationDetailedResponseV1,
     OperationLineageQueryV1,
     OperationQueryV1,
-    OperationResponseV1,
     PageResponseV1,
 )
 from data_rentgen.server.services import get_user
 from data_rentgen.server.services.lineage import LineageService
+from data_rentgen.server.services.operation import OperationService
 from data_rentgen.server.utils.lineage_response import build_lineage_response
 from data_rentgen.services import UnitOfWork
 
@@ -30,9 +31,10 @@ router = APIRouter(
 async def operations(
     query_args: Annotated[OperationQueryV1, Depends()],
     unit_of_work: Annotated[UnitOfWork, Depends()],
+    operation_service: Annotated[OperationService, Depends()],
     current_user: User = Depends(get_user()),
-) -> PageResponseV1[OperationResponseV1]:
-    pagination = await unit_of_work.operation.paginate(
+) -> PageResponseV1[OperationDetailedResponseV1]:
+    pagination = await operation_service.paginate(
         page=query_args.page,
         page_size=query_args.page_size,
         since=query_args.since,
@@ -40,7 +42,7 @@ async def operations(
         operation_ids=query_args.operation_id,
         run_id=query_args.run_id,
     )
-    return PageResponseV1[OperationResponseV1].from_pagination(pagination)
+    return PageResponseV1[OperationDetailedResponseV1].from_pagination(pagination)
 
 
 @router.get("/lineage", summary="Get Operation lineage graph")

--- a/data_rentgen/server/schemas/v1/__init__.py
+++ b/data_rentgen/server/schemas/v1/__init__.py
@@ -26,8 +26,11 @@ from data_rentgen.server.schemas.v1.location import (
     UpdateLocationRequestV1,
 )
 from data_rentgen.server.schemas.v1.operation import (
+    OperationDetailedResponseV1,
+    OperationIOStatisticsReponseV1,
     OperationQueryV1,
     OperationResponseV1,
+    OperationStatisticsReponseV1,
 )
 from data_rentgen.server.schemas.v1.pagination import (
     PageMetaResponseV1,
@@ -59,9 +62,12 @@ __all__ = [
     "UpdateLocationRequestV1",
     "PageMetaResponseV1",
     "PageResponseV1",
+    "OperationDetailedResponseV1",
+    "OperationIOStatisticsReponseV1",
+    "OperationLineageQueryV1",
     "OperationQueryV1",
     "OperationResponseV1",
-    "OperationLineageQueryV1",
+    "OperationStatisticsReponseV1",
     "JobResponseV1",
     "JobPaginateQueryV1",
     "JobLineageQueryV1",

--- a/data_rentgen/server/schemas/v1/operation.py
+++ b/data_rentgen/server/schemas/v1/operation.py
@@ -64,6 +64,37 @@ class OperationResponseV1(BaseModel):
         return str(value)
 
 
+class OperationIOStatisticsReponseV1(BaseModel):
+    """Operation IO statistics response."""
+
+    total_datasets: int = Field(default=0, description="Total number of datasets")
+    total_bytes: int = Field(default=0, description="Total number of bytes")
+    total_rows: int = Field(default=0, description="Total number of rows")
+    total_files: int = Field(default=0, description="Total number of files")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OperationStatisticsReponseV1(BaseModel):
+    """Operation statistics response."""
+
+    outputs: OperationIOStatisticsReponseV1 = Field(description="Output statistics")
+    inputs: OperationIOStatisticsReponseV1 = Field(description="Input statistics")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OperationDetailedResponseV1(BaseModel):
+    """Operation response."""
+
+    data: OperationResponseV1 = Field(description="Operation data")
+    statistics: OperationStatisticsReponseV1 = Field(
+        description="Operation statistics",
+    )
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class OperationQueryV1(PaginateQueryV1):
     """Query params for Operations paginate request."""
 

--- a/data_rentgen/server/services/__init__.py
+++ b/data_rentgen/server/services/__init__.py
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from data_rentgen.server.services.get_user import get_user
 from data_rentgen.server.services.lineage import LineageService
+from data_rentgen.server.services.operation import OperationService
 
-__all__ = ["LineageService", "get_user"]
+__all__ = ["get_user", "LineageService", "OperationService"]

--- a/data_rentgen/server/services/operation.py
+++ b/data_rentgen/server/services/operation.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2024-2025 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import Depends
+from sqlalchemy import Row
+
+from data_rentgen.db.models.operation import Operation
+from data_rentgen.dto.pagination import PaginationDTO
+from data_rentgen.services.uow import UnitOfWork
+
+
+@dataclass
+class OperationServiceIOStatistics:
+    total_datasets: int = 0
+    total_bytes: int = 0
+    total_rows: int = 0
+    total_files: int = 0
+
+    @classmethod
+    def from_row(cls, row: Row | None):
+        if not row:
+            return cls()
+
+        return cls(
+            total_datasets=row.total_datasets,
+            total_bytes=row.total_bytes,
+            total_rows=row.total_rows,
+            total_files=row.total_files,
+        )
+
+
+@dataclass
+class OperationServiceStatistics:
+    inputs: OperationServiceIOStatistics
+    outputs: OperationServiceIOStatistics
+
+
+@dataclass
+class OperationServicePageItem:
+    data: Operation
+    statistics: OperationServiceStatistics
+
+
+class OperationServicePaginatedResult(PaginationDTO[OperationServicePageItem]):
+    pass
+
+
+class OperationService:
+    def __init__(self, uow: Annotated[UnitOfWork, Depends()]):
+        self._uow = uow
+
+    async def paginate(
+        self,
+        page: int,
+        page_size: int,
+        since: datetime | None,
+        until: datetime | None,
+        operation_ids: list[UUID],
+        run_id: UUID | None,
+    ) -> OperationServicePaginatedResult:
+        pagination = await self._uow.operation.paginate(
+            page=page,
+            page_size=page_size,
+            since=since,
+            until=until,
+            operation_ids=operation_ids,
+            run_id=run_id,
+        )
+        operation_ids = [item.id for item in pagination.items]
+        input_stats = await self._uow.input.get_stats_by_operation_ids(operation_ids)
+        output_stats = await self._uow.output.get_stats_by_operation_ids(operation_ids)
+
+        return OperationServicePaginatedResult(
+            page=pagination.page,
+            page_size=pagination.page_size,
+            total_count=pagination.total_count,
+            items=[
+                OperationServicePageItem(
+                    data=operation,
+                    statistics=OperationServiceStatistics(
+                        inputs=OperationServiceIOStatistics.from_row(input_stats.get(operation.id)),
+                        outputs=OperationServiceIOStatistics.from_row(output_stats.get(operation.id)),
+                    ),
+                )
+                for operation in pagination.items
+            ],
+        )

--- a/docs/changelog/next_release/158.breaking.rst
+++ b/docs/changelog/next_release/158.breaking.rst
@@ -1,0 +1,47 @@
+Change response schema of ``GET /operations`` from:
+
+.. code:: python
+
+    {
+        "meta": {...},
+        "items": [
+            {
+                "kind": "OPERATION",
+                "id": ...,
+                # ...
+            }
+        ],
+    }
+
+to:
+
+.. code:: python
+
+    {
+        "meta": {...},
+        "items": [
+            {
+                "data": {
+                    "kind": "OPERATION",
+                    "id": ...,
+                    # ...
+                },
+                "statistics": {
+                    "inputs": {
+                        "total_datasets": 2,
+                        "total_bytes": 123456,
+                        "total_rows": 100,
+                        "total_files": 0,
+                    },
+                    "outputs": {
+                        "total_datasets": 2,
+                        "total_bytes": 123456,
+                        "total_rows": 100,
+                        "total_files": 0,
+                    },
+                },
+            }
+        ],
+    }
+
+This allows to show operation statistics in UI without building up lineage graph.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -438,6 +438,8 @@ ignore = [
   "B008",
 # Found `__init__.py` module with logic
   "WPS412",
+# Found incorrect order of methods in a class
+  "WPS338",
 ]
 
 per-file-ignores = [

--- a/tests/test_server/test_operations/test_get_operations_by_run_id.py
+++ b/tests/test_server/test_operations/test_get_operations_by_run_id.py
@@ -114,18 +114,34 @@ async def test_get_operations_by_run_id(
         },
         "items": [
             {
-                "kind": "OPERATION",
-                "id": str(operation.id),
-                "created_at": operation.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "run_id": str(operation.run_id),
-                "name": operation.name,
-                "status": operation.status.name,
-                "type": operation.type.value,
-                "position": operation.position,
-                "group": operation.group,
-                "description": operation.description,
-                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "data": {
+                    "kind": "OPERATION",
+                    "id": str(operation.id),
+                    "created_at": operation.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                    "run_id": str(operation.run_id),
+                    "name": operation.name,
+                    "status": operation.status.name,
+                    "type": operation.type.value,
+                    "position": operation.position,
+                    "group": operation.group,
+                    "description": operation.description,
+                    "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                "statistics": {
+                    "inputs": {
+                        "total_datasets": 0,
+                        "total_bytes": 0,
+                        "total_rows": 0,
+                        "total_files": 0,
+                    },
+                    "outputs": {
+                        "total_datasets": 0,
+                        "total_bytes": 0,
+                        "total_rows": 0,
+                        "total_files": 0,
+                    },
+                },
             }
             for operation in sorted(selected_operations, key=lambda x: x.id, reverse=True)
         ],
@@ -168,18 +184,34 @@ async def test_get_operations_by_run_id_with_until(
         },
         "items": [
             {
-                "kind": "OPERATION",
-                "id": str(operation.id),
-                "created_at": operation.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "run_id": str(operation.run_id),
-                "name": operation.name,
-                "status": operation.status.name,
-                "type": operation.type.value,
-                "position": operation.position,
-                "group": operation.group,
-                "description": operation.description,
-                "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "data": {
+                    "kind": "OPERATION",
+                    "id": str(operation.id),
+                    "created_at": operation.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                    "run_id": str(operation.run_id),
+                    "name": operation.name,
+                    "status": operation.status.name,
+                    "type": operation.type.value,
+                    "position": operation.position,
+                    "group": operation.group,
+                    "description": operation.description,
+                    "started_at": operation.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "ended_at": operation.ended_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                "statistics": {
+                    "inputs": {
+                        "total_datasets": 0,
+                        "total_bytes": 0,
+                        "total_rows": 0,
+                        "total_files": 0,
+                    },
+                    "outputs": {
+                        "total_datasets": 0,
+                        "total_bytes": 0,
+                        "total_rows": 0,
+                        "total_files": 0,
+                    },
+                },
             }
             for operation in sorted(selected_operations, key=lambda x: x.id, reverse=True)
         ],


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Changed the response schema of `GET /operations` to include inputs & outputs statistics. This is useful to show in list of operations within run.
Don't change response for lineage, as it includes inputs & outputs are distinct relations.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
