### PR TITLE
[DOP-22578] Change response schema of GET /datasets

### DIFF
--- a/data_rentgen/server/api/v1/router/dataset.py
+++ b/data_rentgen/server/api/v1/router/dataset.py
@@ -8,15 +8,14 @@ from data_rentgen.db.models import User
 from data_rentgen.server.errors import get_error_responses
 from data_rentgen.server.errors.schemas import InvalidRequestSchema
 from data_rentgen.server.schemas.v1 import (
+    DatasetDetailedResponseV1,
     DatasetLineageQueryV1,
     DatasetPaginateQueryV1,
-    DatasetResponseV1,
     LineageResponseV1,
     PageResponseV1,
 )
-from data_rentgen.server.services import LineageService, get_user
+from data_rentgen.server.services import DatasetService, LineageService, get_user
 from data_rentgen.server.utils.lineage_response import build_lineage_response
-from data_rentgen.services import UnitOfWork
 
 router = APIRouter(prefix="/datasets", tags=["Datasets"], responses=get_error_responses(include={InvalidRequestSchema}))
 
@@ -24,16 +23,16 @@ router = APIRouter(prefix="/datasets", tags=["Datasets"], responses=get_error_re
 @router.get("", summary="Paginated list of Datasets")
 async def paginate_datasets(
     query_args: Annotated[DatasetPaginateQueryV1, Depends()],
-    unit_of_work: Annotated[UnitOfWork, Depends()],
+    dataset_service: Annotated[DatasetService, Depends()],
     current_user: User = Depends(get_user()),
-) -> PageResponseV1[DatasetResponseV1]:
-    pagination = await unit_of_work.dataset.paginate(
+) -> PageResponseV1[DatasetDetailedResponseV1]:
+    pagination = await dataset_service.paginate(
         page=query_args.page,
         page_size=query_args.page_size,
         dataset_ids=query_args.dataset_id,
         search_query=query_args.search_query,
     )
-    return PageResponseV1[DatasetResponseV1].from_pagination(pagination)
+    return PageResponseV1[DatasetDetailedResponseV1].from_pagination(pagination)
 
 
 @router.get("/lineage", summary="Get Dataset lineage graph")

--- a/data_rentgen/server/schemas/v1/__init__.py
+++ b/data_rentgen/server/schemas/v1/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from data_rentgen.server.schemas.v1.address import AddressResponseV1
 from data_rentgen.server.schemas.v1.dataset import (
+    DatasetDetailedResponseV1,
     DatasetPaginateQueryV1,
     DatasetResponseV1,
 )
@@ -58,9 +59,10 @@ __all__ = [
     "RunsQueryV1",
     "RunStatisticsReponseV1",
     "UserResponseV1",
+    "DatasetDetailedResponseV1",
+    "DatasetLineageQueryV1",
     "DatasetPaginateQueryV1",
     "DatasetResponseV1",
-    "DatasetLineageQueryV1",
     "LineageDirectionV1",
     "LineageEntityV1",
     "LineageEntityKindV1",

--- a/data_rentgen/server/schemas/v1/dataset.py
+++ b/data_rentgen/server/schemas/v1/dataset.py
@@ -21,6 +21,12 @@ class DatasetResponseV1(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class DatasetDetailedResponseV1(BaseModel):
+    data: DatasetResponseV1 = Field(description="Dataset data")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class DatasetPaginateQueryV1(PaginateQueryV1):
     """Query params for Dataset paginate request."""
 

--- a/data_rentgen/server/services/__init__.py
+++ b/data_rentgen/server/services/__init__.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024-2025 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
+from data_rentgen.server.services.dataset import DatasetService
 from data_rentgen.server.services.get_user import get_user
 from data_rentgen.server.services.lineage import LineageService
 from data_rentgen.server.services.location import LocationService
@@ -7,6 +8,7 @@ from data_rentgen.server.services.operation import OperationService
 from data_rentgen.server.services.run import RunService
 
 __all__ = [
+    "DatasetService",
     "get_user",
     "LineageService",
     "LocationService",

--- a/data_rentgen/server/services/dataset.py
+++ b/data_rentgen/server/services/dataset.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2024-2025 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+from typing import Annotated
+
+from fastapi import Depends
+
+from data_rentgen.db.models.dataset import Dataset
+from data_rentgen.dto.pagination import PaginationDTO
+from data_rentgen.services.uow import UnitOfWork
+
+
+@dataclass
+class DatasetServiceResult:
+    data: Dataset
+
+
+class DatasetServicePaginatedResult(PaginationDTO[DatasetServiceResult]):
+    pass
+
+
+class DatasetService:
+    def __init__(self, uow: Annotated[UnitOfWork, Depends()]):
+        self._uow = uow
+
+    async def paginate(
+        self,
+        page: int,
+        page_size: int,
+        dataset_ids: list[int],
+        search_query: str | None,
+    ) -> DatasetServicePaginatedResult:
+        pagination = await self._uow.dataset.paginate(
+            page=page,
+            page_size=page_size,
+            dataset_ids=dataset_ids,
+            search_query=search_query,
+        )
+
+        return DatasetServicePaginatedResult(
+            page=pagination.page,
+            page_size=pagination.page_size,
+            total_count=pagination.total_count,
+            items=[DatasetServiceResult(data=dataset) for dataset in pagination.items],
+        )

--- a/docs/changelog/next_release/161.breaking.rst
+++ b/docs/changelog/next_release/161.breaking.rst
@@ -1,0 +1,34 @@
+Change response schema of ``GET /datasets`` from:
+
+.. code:: python
+
+    {
+        "meta": {...},
+        "items": [
+            {
+                "kind": "DATASET",
+                "id": ...,
+                # ...
+            }
+        ],
+    }
+
+to:
+
+.. code:: python
+
+    {
+        "meta": {...},
+        "items": [
+            {
+                "data": {
+                    "kind": "DATASET",
+                    "id": ...,
+                    # ...
+                },
+            }
+        ],
+    }
+
+
+This makes API response more consistent with others (e.g. ``GET /runs``, ``GET /operations``).

--- a/tests/test_server/test_datasets/test_get_datasets.py
+++ b/tests/test_server/test_datasets/test_get_datasets.py
@@ -37,16 +37,18 @@ async def test_get_datasets_no_filters(
         },
         "items": [
             {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
+                "data": {
+                    "kind": "DATASET",
+                    "id": dataset.id,
+                    "format": dataset.format,
+                    "name": dataset.name,
+                    "location": {
+                        "id": dataset.location.id,
+                        "name": dataset.location.name,
+                        "type": dataset.location.type,
+                        "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                        "external_id": dataset.location.external_id,
+                    },
                 },
             }
             for dataset in sorted(datasets, key=lambda x: x.name)

--- a/tests/test_server/test_datasets/test_get_datasets_by_id.py
+++ b/tests/test_server/test_datasets/test_get_datasets_by_id.py
@@ -67,16 +67,18 @@ async def test_get_datasets_by_one_id(
         },
         "items": [
             {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
+                "data": {
+                    "kind": "DATASET",
+                    "id": dataset.id,
+                    "format": dataset.format,
+                    "name": dataset.name,
+                    "location": {
+                        "id": dataset.location.id,
+                        "name": dataset.location.name,
+                        "type": dataset.location.type,
+                        "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                        "external_id": dataset.location.external_id,
+                    },
                 },
             },
         ],
@@ -112,16 +114,18 @@ async def test_get_datasets_by_multiple_ids(
         },
         "items": [
             {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
+                "data": {
+                    "kind": "DATASET",
+                    "id": dataset.id,
+                    "format": dataset.format,
+                    "name": dataset.name,
+                    "location": {
+                        "id": dataset.location.id,
+                        "name": dataset.location.name,
+                        "type": dataset.location.type,
+                        "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                        "external_id": dataset.location.external_id,
+                    },
                 },
             }
             for dataset in sorted(selected_datasets, key=lambda x: x.name)

--- a/tests/test_server/test_datasets/test_search_datasets.py
+++ b/tests/test_server/test_datasets/test_search_datasets.py
@@ -42,16 +42,18 @@ async def test_search_datasets_by_address_url(
         },
         "items": [
             {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
+                "data": {
+                    "kind": "DATASET",
+                    "id": dataset.id,
+                    "format": dataset.format,
+                    "name": dataset.name,
+                    "location": {
+                        "id": dataset.location.id,
+                        "name": dataset.location.name,
+                        "type": dataset.location.type,
+                        "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                        "external_id": dataset.location.external_id,
+                    },
                 },
             }
             for dataset in datasets
@@ -100,16 +102,18 @@ async def test_search_datasets_by_location_name(
         },
         "items": [
             {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
+                "data": {
+                    "kind": "DATASET",
+                    "id": dataset.id,
+                    "format": dataset.format,
+                    "name": dataset.name,
+                    "location": {
+                        "id": dataset.location.id,
+                        "name": dataset.location.name,
+                        "type": dataset.location.type,
+                        "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                        "external_id": dataset.location.external_id,
+                    },
                 },
             }
             for dataset in datasets
@@ -147,16 +151,18 @@ async def test_search_datasets_by_dataset_name(
         },
         "items": [
             {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
+                "data": {
+                    "kind": "DATASET",
+                    "id": dataset.id,
+                    "format": dataset.format,
+                    "name": dataset.name,
+                    "location": {
+                        "id": dataset.location.id,
+                        "name": dataset.location.name,
+                        "type": dataset.location.type,
+                        "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                        "external_id": dataset.location.external_id,
+                    },
                 },
             }
             for dataset in datasets
@@ -201,16 +207,18 @@ async def test_search_datasets_by_location_name_and_address_url(
         },
         "items": [
             {
-                "kind": "DATASET",
-                "id": dataset.id,
-                "format": dataset.format,
-                "name": dataset.name,
-                "location": {
-                    "id": dataset.location.id,
-                    "name": dataset.location.name,
-                    "type": dataset.location.type,
-                    "addresses": [{"url": address.url} for address in dataset.location.addresses],
-                    "external_id": dataset.location.external_id,
+                "data": {
+                    "kind": "DATASET",
+                    "id": dataset.id,
+                    "format": dataset.format,
+                    "name": dataset.name,
+                    "location": {
+                        "id": dataset.location.id,
+                        "name": dataset.location.name,
+                        "type": dataset.location.type,
+                        "addresses": [{"url": address.url} for address in dataset.location.addresses],
+                        "external_id": dataset.location.external_id,
+                    },
                 },
             }
             for dataset in datasets


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Changed the response schema of `GET /datasets` to match other endpoints (#158, #159, #160, #162). For now there is no statistics for dataset, but it can be added later (e.g. inputs/outputs stats within last day/week/month) without breaking backward compatibility.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
