### PR TITLE
[DOP-22578] Change response schema of GET /jobs

### DIFF
--- a/data_rentgen/server/api/v1/router/job.py
+++ b/data_rentgen/server/api/v1/router/job.py
@@ -8,15 +8,14 @@ from data_rentgen.db.models import User
 from data_rentgen.server.errors import get_error_responses
 from data_rentgen.server.errors.schemas import InvalidRequestSchema
 from data_rentgen.server.schemas.v1 import (
+    JobDetailedResponseV1,
     JobLineageQueryV1,
     JobPaginateQueryV1,
-    JobResponseV1,
     LineageResponseV1,
     PageResponseV1,
 )
-from data_rentgen.server.services import LineageService, get_user
+from data_rentgen.server.services import JobService, LineageService, get_user
 from data_rentgen.server.utils.lineage_response import build_lineage_response
-from data_rentgen.services import UnitOfWork
 
 router = APIRouter(prefix="/jobs", tags=["Jobs"], responses=get_error_responses(include={InvalidRequestSchema}))
 
@@ -24,16 +23,16 @@ router = APIRouter(prefix="/jobs", tags=["Jobs"], responses=get_error_responses(
 @router.get("", summary="Paginated list of Jobs")
 async def paginate_jobs(
     query_args: Annotated[JobPaginateQueryV1, Depends()],
-    unit_of_work: Annotated[UnitOfWork, Depends()],
+    job_service: Annotated[JobService, Depends()],
     current_user: User = Depends(get_user()),
-) -> PageResponseV1[JobResponseV1]:
-    pagination = await unit_of_work.job.paginate(
+) -> PageResponseV1[JobDetailedResponseV1]:
+    pagination = await job_service.paginate(
         page=query_args.page,
         page_size=query_args.page_size,
         job_ids=query_args.job_id,
         search_query=query_args.search_query,
     )
-    return PageResponseV1[JobResponseV1].from_pagination(pagination)
+    return PageResponseV1[JobDetailedResponseV1].from_pagination(pagination)
 
 
 @router.get("/lineage", summary="Get Job lineage graph")

--- a/data_rentgen/server/schemas/v1/__init__.py
+++ b/data_rentgen/server/schemas/v1/__init__.py
@@ -5,7 +5,11 @@ from data_rentgen.server.schemas.v1.dataset import (
     DatasetPaginateQueryV1,
     DatasetResponseV1,
 )
-from data_rentgen.server.schemas.v1.job import JobPaginateQueryV1, JobResponseV1
+from data_rentgen.server.schemas.v1.job import (
+    JobDetailedResponseV1,
+    JobPaginateQueryV1,
+    JobResponseV1,
+)
 from data_rentgen.server.schemas.v1.lineage import (
     DatasetLineageQueryV1,
     JobLineageQueryV1,
@@ -81,8 +85,9 @@ __all__ = [
     "OperationQueryV1",
     "OperationResponseV1",
     "OperationStatisticsReponseV1",
-    "JobResponseV1",
-    "JobPaginateQueryV1",
+    "JobDetailedResponseV1",
     "JobLineageQueryV1",
+    "JobPaginateQueryV1",
+    "JobResponseV1",
     "PaginateQueryV1",
 ]

--- a/data_rentgen/server/schemas/v1/job.py
+++ b/data_rentgen/server/schemas/v1/job.py
@@ -21,6 +21,12 @@ class JobResponseV1(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class JobDetailedResponseV1(BaseModel):
+    data: JobResponseV1 = Field(description="Job data")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class JobPaginateQueryV1(PaginateQueryV1):
     """Query params for Jobs paginate request."""
 

--- a/data_rentgen/server/services/__init__.py
+++ b/data_rentgen/server/services/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024-2025 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 from data_rentgen.server.services.get_user import get_user
+from data_rentgen.server.services.job import JobService
 from data_rentgen.server.services.lineage import LineageService
 from data_rentgen.server.services.location import LocationService
 from data_rentgen.server.services.operation import OperationService
@@ -8,6 +9,7 @@ from data_rentgen.server.services.run import RunService
 
 __all__ = [
     "get_user",
+    "JobService",
     "LineageService",
     "LocationService",
     "OperationService",

--- a/data_rentgen/server/services/job.py
+++ b/data_rentgen/server/services/job.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2024-2025 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+from typing import Annotated
+
+from fastapi import Depends
+
+from data_rentgen.db.models.job import Job
+from data_rentgen.dto.pagination import PaginationDTO
+from data_rentgen.services.uow import UnitOfWork
+
+
+@dataclass
+class JobServiceResult:
+    data: Job
+
+
+class JobServicePaginatedResult(PaginationDTO[JobServiceResult]):
+    pass
+
+
+class JobService:
+    def __init__(self, uow: Annotated[UnitOfWork, Depends()]):
+        self._uow = uow
+
+    async def paginate(
+        self,
+        page: int,
+        page_size: int,
+        job_ids: list[int],
+        search_query: str | None,
+    ) -> JobServicePaginatedResult:
+        pagination = await self._uow.job.paginate(
+            page=page,
+            page_size=page_size,
+            job_ids=job_ids,
+            search_query=search_query,
+        )
+
+        return JobServicePaginatedResult(
+            page=pagination.page,
+            page_size=pagination.page_size,
+            total_count=pagination.total_count,
+            items=[JobServiceResult(data=job) for job in pagination.items],
+        )

--- a/docs/changelog/next_release/162.breaking.rst
+++ b/docs/changelog/next_release/162.breaking.rst
@@ -1,0 +1,34 @@
+Change response schema of ``GET /jobs`` from:
+
+.. code:: python
+
+    {
+        "meta": {...},
+        "items": [
+            {
+                "kind": "JOB",
+                "id": ...,
+                # ...
+            }
+        ],
+    }
+
+to:
+
+.. code:: python
+
+    {
+        "meta": {...},
+        "items": [
+            {
+                "data": {
+                    "kind": "JOB",
+                    "id": ...,
+                    # ...
+                },
+            }
+        ],
+    }
+
+
+This makes API response more consistent with others (e.g. ``GET /runs``, ``GET /operations``).

--- a/tests/test_server/test_jobs/test_get_jobs.py
+++ b/tests/test_server/test_jobs/test_get_jobs.py
@@ -37,16 +37,18 @@ async def test_get_jobs_no_filters(
         },
         "items": [
             {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "type": job.location.type,
-                    "name": job.location.name,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
+                "data": {
+                    "kind": "JOB",
+                    "id": job.id,
+                    "name": job.name,
+                    "type": job.type,
+                    "location": {
+                        "id": job.location.id,
+                        "type": job.location.type,
+                        "name": job.location.name,
+                        "addresses": [{"url": address.url} for address in job.location.addresses],
+                        "external_id": job.location.external_id,
+                    },
                 },
             }
             for job in sorted(jobs, key=lambda x: x.name)

--- a/tests/test_server/test_jobs/test_get_jobs_by_id.py
+++ b/tests/test_server/test_jobs/test_get_jobs_by_id.py
@@ -67,16 +67,18 @@ async def test_get_jobs_by_one_id(
         },
         "items": [
             {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "type": job.location.type,
-                    "name": job.location.name,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
+                "data": {
+                    "kind": "JOB",
+                    "id": job.id,
+                    "name": job.name,
+                    "type": job.type,
+                    "location": {
+                        "id": job.location.id,
+                        "type": job.location.type,
+                        "name": job.location.name,
+                        "addresses": [{"url": address.url} for address in job.location.addresses],
+                        "external_id": job.location.external_id,
+                    },
                 },
             },
         ],
@@ -112,16 +114,18 @@ async def test_get_jobs_by_multiple_ids(
         },
         "items": [
             {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "type": job.location.type,
-                    "name": job.location.name,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
+                "data": {
+                    "kind": "JOB",
+                    "id": job.id,
+                    "name": job.name,
+                    "type": job.type,
+                    "location": {
+                        "id": job.location.id,
+                        "type": job.location.type,
+                        "name": job.location.name,
+                        "addresses": [{"url": address.url} for address in job.location.addresses],
+                        "external_id": job.location.external_id,
+                    },
                 },
             }
             for job in sorted(selected_jobs, key=lambda x: x.name)

--- a/tests/test_server/test_jobs/test_search_jobs.py
+++ b/tests/test_server/test_jobs/test_search_jobs.py
@@ -41,16 +41,18 @@ async def test_search_jobs_by_address_url(
         },
         "items": [
             {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "name": job.location.name,
-                    "type": job.location.type,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
+                "data": {
+                    "kind": "JOB",
+                    "id": job.id,
+                    "name": job.name,
+                    "type": job.type,
+                    "location": {
+                        "id": job.location.id,
+                        "type": job.location.type,
+                        "name": job.location.name,
+                        "addresses": [{"url": address.url} for address in job.location.addresses],
+                        "external_id": job.location.external_id,
+                    },
                 },
             }
             for job in jobs
@@ -88,16 +90,18 @@ async def test_search_jobs_by_location_name(
         },
         "items": [
             {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "name": job.location.name,
-                    "type": job.location.type,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
+                "data": {
+                    "kind": "JOB",
+                    "id": job.id,
+                    "name": job.name,
+                    "type": job.type,
+                    "location": {
+                        "id": job.location.id,
+                        "type": job.location.type,
+                        "name": job.location.name,
+                        "addresses": [{"url": address.url} for address in job.location.addresses],
+                        "external_id": job.location.external_id,
+                    },
                 },
             }
             for job in jobs
@@ -146,16 +150,18 @@ async def test_search_jobs_by_job_name(
         },
         "items": [
             {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "name": job.location.name,
-                    "type": job.location.type,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
+                "data": {
+                    "kind": "JOB",
+                    "id": job.id,
+                    "name": job.name,
+                    "type": job.type,
+                    "location": {
+                        "id": job.location.id,
+                        "type": job.location.type,
+                        "name": job.location.name,
+                        "addresses": [{"url": address.url} for address in job.location.addresses],
+                        "external_id": job.location.external_id,
+                    },
                 },
             }
             for job in jobs
@@ -194,16 +200,18 @@ async def test_search_jobs_by_location_name_and_address_url(
         },
         "items": [
             {
-                "kind": "JOB",
-                "id": job.id,
-                "name": job.name,
-                "type": job.type,
-                "location": {
-                    "id": job.location.id,
-                    "name": job.location.name,
-                    "type": job.location.type,
-                    "addresses": [{"url": address.url} for address in job.location.addresses],
-                    "external_id": job.location.external_id,
+                "data": {
+                    "kind": "JOB",
+                    "id": job.id,
+                    "name": job.name,
+                    "type": job.type,
+                    "location": {
+                        "id": job.location.id,
+                        "type": job.location.type,
+                        "name": job.location.name,
+                        "addresses": [{"url": address.url} for address in job.location.addresses],
+                        "external_id": job.location.external_id,
+                    },
                 },
             }
             for job in jobs


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Changed the response schema of `GET /jobs` to match other endpoints (#158, #159, #160, #161). For now there is no statistics for job, but it can be added later (e.g. number of runs since last day, week, month) without breaking backward compatibility.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
