### PR TITLE
[DOP-23921] Include sum inputs & outputs to lineage response

### DIFF
--- a/data_rentgen/db/repositories/input.py
+++ b/data_rentgen/db/repositories/input.py
@@ -70,6 +70,7 @@ class InputRepository(Repository[Input]):
     async def list_by_operation_ids(
         self,
         operation_ids: Sequence[UUID],
+        granularity: Literal["JOB", "RUN", "OPERATION"],
     ) -> list[Input]:
         if not operation_ids:
             return []
@@ -85,14 +86,14 @@ class InputRepository(Repository[Input]):
             Input.operation_id == any_(operation_ids),  # type: ignore[arg-type]
         ]
 
-        return await self._get_inputs(where, "OPERATION")
+        return await self._get_inputs(where, granularity)
 
     async def list_by_run_ids(
         self,
         run_ids: Sequence[UUID],
         since: datetime,
         until: datetime | None,
-        granularity: Literal["RUN", "OPERATION"],
+        granularity: Literal["JOB", "RUN", "OPERATION"],
     ) -> list[Input]:
         if not run_ids:
             return []

--- a/data_rentgen/db/repositories/output.py
+++ b/data_rentgen/db/repositories/output.py
@@ -71,6 +71,7 @@ class OutputRepository(Repository[Output]):
     async def list_by_operation_ids(
         self,
         operation_ids: Sequence[UUID],
+        granularity: Literal["JOB", "RUN", "OPERATION"],
     ) -> list[Output]:
         if not operation_ids:
             return []
@@ -86,14 +87,14 @@ class OutputRepository(Repository[Output]):
             Output.operation_id == any_(operation_ids),  # type: ignore[arg-type]
         ]
 
-        return await self._get_outputs(where, "OPERATION")
+        return await self._get_outputs(where, granularity)
 
     async def list_by_run_ids(
         self,
         run_ids: Sequence[UUID],
         since: datetime,
         until: datetime | None,
-        granularity: Literal["RUN", "OPERATION"],
+        granularity: Literal["JOB", "RUN", "OPERATION"],
     ) -> list[Output]:
         if not run_ids:
             return []

--- a/data_rentgen/server/utils/lineage_response.py
+++ b/data_rentgen/server/utils/lineage_response.py
@@ -119,7 +119,7 @@ def _get_input_relations(inputs: dict[Any, Input]) -> list[LineageInputRelationV
         )
         relations.append(relation)
 
-    return sorted(relations, key=lambda x: (str(x.from_.id), str(x.to.id)))
+    return sorted(relations, key=lambda x: (x.to.kind, str(x.from_.id), str(x.to.id)))
 
 
 def _get_output_relations(outputs: dict[Any, Output]) -> list[LineageOutputRelationV1]:
@@ -144,7 +144,7 @@ def _get_output_relations(outputs: dict[Any, Output]) -> list[LineageOutputRelat
         )
         relations.append(relation)
 
-    return sorted(relations, key=lambda x: (str(x.from_.id), str(x.to.id), x.type))
+    return sorted(relations, key=lambda x: (x.from_.kind, str(x.from_.id), str(x.to.id), x.type))
 
 
 def _get_direct_column_lineage(column_lineage_by_source_target_id: dict[tuple, list[ColumnLineageRow]]):

--- a/docs/changelog/next_release/171.feature.rst
+++ b/docs/changelog/next_release/171.feature.rst
@@ -1,0 +1,3 @@
+Include sum inputs & outputs to lineage responses.
+For example, if user asked for lineage with ``granularity=OPERATION``, include inputs & outputs with detalization to ``RUN`` (sum of all included operations by ``run_id``) and ``JOB`` (sum of all included operations by ``job_id``).
+This allows to show that specific operation is some specific percent of all operations within this run or job.

--- a/tests/test_server/test_lineage/test_column_lineage.py
+++ b/tests/test_server/test_lineage/test_column_lineage.py
@@ -57,7 +57,7 @@ async def test_dataset_lineage_with_empty_column_lineage(
         "v1/datasets/lineage",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since,
+            "since": since.isoformat(),
             "start_node_id": dataset.id,
             "include_column_lineage": True,
         },
@@ -68,8 +68,14 @@ async def test_dataset_lineage_with_empty_column_lineage(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -121,8 +127,16 @@ async def test_operation_lineage_include_columns_with_combined_transformations(
         "relations": {
             "parents": run_parents_to_json([run]) + operation_parents_to_json([operation]),
             "symlinks": [],
-            "inputs": inputs_to_json(inputs, granularity="OPERATION"),
-            "outputs": outputs_to_json(outputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(inputs, granularity="OPERATION"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(outputs, granularity="OPERATION"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [
                 {
                     "from": {"id": str(datasets[0].id), "kind": "DATASET"},
@@ -206,8 +220,14 @@ async def test_run_lineage_include_columns_with_combined_transformations(
         "relations": {
             "parents": run_parents_to_json([run]),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [
                 {
                     "from": {"id": str(datasets[0].id), "kind": "DATASET"},
@@ -416,8 +436,14 @@ async def test_dataset_lineage_include_columns_with_depth(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [
                 {
                     "from": {"id": str(lineage.datasets[0].id), "kind": "DATASET"},
@@ -661,8 +687,16 @@ async def test_get_dataset_lineage_include_columns_with_depth_and_granularity_op
         "relations": {
             "parents": run_parents_to_json(runs) + operation_parents_to_json(operations),
             "symlinks": [],
-            "inputs": inputs_to_json(inputs, granularity="OPERATION"),
-            "outputs": outputs_to_json(outputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(inputs, granularity="OPERATION"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(outputs, granularity="OPERATION"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [
                 {
                     "from": {"id": str(lineage.datasets[0].id), "kind": "DATASET"},
@@ -791,8 +825,16 @@ async def test_operation_lineage_include_columns_with_depth(
         "relations": {
             "parents": run_parents_to_json(runs) + operation_parents_to_json(operations),
             "symlinks": [],
-            "inputs": inputs_to_json(inputs, granularity="OPERATION"),
-            "outputs": outputs_to_json(outputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(inputs, granularity="OPERATION"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(outputs, granularity="OPERATION"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [
                 {
                     "from": {"id": str(lineage.datasets[0].id), "kind": "DATASET"},
@@ -937,8 +979,14 @@ async def test_run_lineage_include_columns_with_depth(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [
                 {
                     "from": {"id": str(lineage.datasets[0].id), "kind": "DATASET"},

--- a/tests/test_server/test_lineage/test_dataset_lineage.py
+++ b/tests/test_server/test_lineage/test_dataset_lineage.py
@@ -117,8 +117,14 @@ async def test_get_dataset_lineage_with_granularity_run(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -232,8 +238,16 @@ async def test_get_dataset_lineage_with_granularity_operation(
         "relations": {
             "parents": run_parents_to_json(runs) + operation_parents_to_json(operations),
             "symlinks": [],
-            "inputs": inputs_to_json(inputs, granularity="OPERATION"),
-            "outputs": outputs_to_json(outputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(inputs, granularity="OPERATION"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(outputs, granularity="OPERATION"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -286,7 +300,10 @@ async def test_get_dataset_lineage_with_direction_downstream(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
             "outputs": [],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
@@ -342,7 +359,10 @@ async def test_get_dataset_lineage_with_direction_upstream(
             "parents": run_parents_to_json(runs),
             "symlinks": [],
             "inputs": [],
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -404,8 +424,14 @@ async def test_get_dataset_lineage_with_until(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -496,8 +522,14 @@ async def test_get_dataset_lineage_with_depth(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -679,8 +711,16 @@ async def test_get_dataset_lineage_with_depth_and_granularity_operation(
         "relations": {
             "parents": run_parents_to_json(runs) + operation_parents_to_json(operations),
             "symlinks": [],
-            "inputs": inputs_to_json(inputs, granularity="OPERATION"),
-            "outputs": outputs_to_json(outputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(inputs, granularity="OPERATION"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(outputs, granularity="OPERATION"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -727,8 +767,14 @@ async def test_get_dataset_lineage_with_depth_ignore_cycles(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(lineage.inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(lineage.outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(lineage.inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(lineage.inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(lineage.outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(lineage.outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -805,8 +851,14 @@ async def test_get_dataset_lineage_with_depth_ignore_unrelated_datasets(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -878,8 +930,14 @@ async def test_get_dataset_lineage_with_symlink(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": symlinks_to_json(dataset_symlinks),
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -953,8 +1011,14 @@ async def test_get_dataset_lineage_unmergeable_schema_and_output_type(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -1026,14 +1090,26 @@ async def test_get_dataset_lineage_empty_io_stats_and_schema(
 
     # merge_io_by_runs sums empty bytes, rows and files, producing 0 instead of None.
     # override that
-    merged_inputs = merge_io_by_runs(inputs)
-    for input in merged_inputs:
+    merged_run_inputs = merge_io_by_runs(inputs)
+    for input in merged_run_inputs:
         input.num_bytes = None
         input.num_rows = None
         input.num_files = None
 
-    merged_outputs = merge_io_by_runs(outputs)
-    for output in merged_outputs:
+    merged_run_outputs = merge_io_by_runs(outputs)
+    for output in merged_run_outputs:
+        output.num_bytes = None
+        output.num_rows = None
+        output.num_files = None
+
+    merged_job_inputs = merge_io_by_jobs(inputs)
+    for input in merged_job_inputs:
+        input.num_bytes = None
+        input.num_rows = None
+        input.num_files = None
+
+    merged_job_outputs = merge_io_by_jobs(outputs)
+    for output in merged_job_outputs:
         output.num_bytes = None
         output.num_rows = None
         output.num_files = None
@@ -1043,8 +1119,14 @@ async def test_get_dataset_lineage_empty_io_stats_and_schema(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merged_inputs, granularity="RUN"),
-            "outputs": outputs_to_json(merged_outputs, granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merged_job_inputs, granularity="JOB"),
+                *inputs_to_json(merged_run_inputs, granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merged_job_outputs, granularity="JOB"),
+                *outputs_to_json(merged_run_outputs, granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },

--- a/tests/test_server/test_lineage/test_job_lineage.py
+++ b/tests/test_server/test_lineage/test_job_lineage.py
@@ -394,8 +394,14 @@ async def test_get_job_lineage_with_granularity_run(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -569,8 +575,14 @@ async def test_get_job_lineage_with_depth_and_granularity_run(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },

--- a/tests/test_server/test_lineage/test_operation_lineage.py
+++ b/tests/test_server/test_lineage/test_operation_lineage.py
@@ -20,6 +20,7 @@ from tests.test_server.utils.convert_to_json import (
 )
 from tests.test_server.utils.enrich import enrich_datasets, enrich_jobs, enrich_runs
 from tests.test_server.utils.lineage_result import LineageResult
+from tests.test_server.utils.merge import merge_io_by_jobs, merge_io_by_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio, pytest.mark.lineage]
 
@@ -112,8 +113,16 @@ async def test_get_operation_lineage_simple(
         "relations": {
             "parents": run_parents_to_json([run]) + operation_parents_to_json([operation]),
             "symlinks": [],
-            "inputs": inputs_to_json(inputs, granularity="OPERATION"),
-            "outputs": outputs_to_json(outputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(inputs, granularity="OPERATION"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(outputs, granularity="OPERATION"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -164,7 +173,11 @@ async def test_get_operation_lineage_with_direction_downstream(
             "parents": run_parents_to_json([run]) + operation_parents_to_json([operation]),
             "symlinks": [],
             "inputs": [],
-            "outputs": outputs_to_json(outputs, granularity="OPERATION"),
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(outputs, granularity="OPERATION"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -214,7 +227,11 @@ async def test_get_operation_lineage_with_direction_upstream(
         "relations": {
             "parents": run_parents_to_json([run]) + operation_parents_to_json([operation]),
             "symlinks": [],
-            "inputs": inputs_to_json(inputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(inputs, granularity="OPERATION"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
             "outputs": [],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
@@ -280,8 +297,16 @@ async def test_get_operation_lineage_with_until(
         "relations": {
             "parents": run_parents_to_json([run]) + operation_parents_to_json([operation]),
             "symlinks": [],
-            "inputs": inputs_to_json(inputs, granularity="OPERATION"),
-            "outputs": outputs_to_json(outputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(inputs, granularity="OPERATION"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(outputs, granularity="OPERATION"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -379,8 +404,16 @@ async def test_get_operation_lineage_with_depth(
         "relations": {
             "parents": run_parents_to_json(runs) + operation_parents_to_json(operations),
             "symlinks": [],
-            "inputs": inputs_to_json(inputs, granularity="OPERATION"),
-            "outputs": outputs_to_json(outputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(inputs, granularity="OPERATION"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(outputs, granularity="OPERATION"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -427,8 +460,16 @@ async def test_get_operation_lineage_with_depth_ignore_cycles(
         "relations": {
             "parents": run_parents_to_json(runs) + operation_parents_to_json(lineage.operations),
             "symlinks": [],
-            "inputs": inputs_to_json(lineage.inputs, granularity="OPERATION"),
-            "outputs": outputs_to_json(lineage.outputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(lineage.inputs), granularity="JOB"),
+                *inputs_to_json(lineage.inputs, granularity="OPERATION"),
+                *inputs_to_json(merge_io_by_runs(lineage.inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(lineage.outputs), granularity="JOB"),
+                *outputs_to_json(lineage.outputs, granularity="OPERATION"),
+                *outputs_to_json(merge_io_by_runs(lineage.outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -506,8 +547,16 @@ async def test_get_operation_lineage_with_depth_ignore_unrelated_datasets(
         "relations": {
             "parents": run_parents_to_json(runs) + operation_parents_to_json(lineage.operations),
             "symlinks": [],
-            "inputs": inputs_to_json(inputs, granularity="OPERATION"),
-            "outputs": outputs_to_json(outputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(inputs, granularity="OPERATION"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(outputs, granularity="OPERATION"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -569,8 +618,16 @@ async def test_get_operation_lineage_with_symlinks(
         "relations": {
             "parents": run_parents_to_json([run]) + operation_parents_to_json([operation]),
             "symlinks": symlinks_to_json(dataset_symlinks),
-            "inputs": inputs_to_json(inputs, granularity="OPERATION"),
-            "outputs": outputs_to_json(outputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(inputs, granularity="OPERATION"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(outputs, granularity="OPERATION"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -638,13 +695,47 @@ async def test_get_operation_lineage_with_empty_io_stats_and_schema(
         },
     )
 
+    # merge_io_by_runs sums empty bytes, rows and files, producing 0 instead of None.
+    # override that
+    merged_run_inputs = merge_io_by_runs(inputs)
+    for input in merged_run_inputs:
+        input.num_bytes = None
+        input.num_rows = None
+        input.num_files = None
+
+    merged_run_outputs = merge_io_by_runs(outputs)
+    for output in merged_run_outputs:
+        output.num_bytes = None
+        output.num_rows = None
+        output.num_files = None
+
+    merged_job_inputs = merge_io_by_jobs(inputs)
+    for input in merged_job_inputs:
+        input.num_bytes = None
+        input.num_rows = None
+        input.num_files = None
+
+    merged_job_outputs = merge_io_by_jobs(outputs)
+    for output in merged_job_outputs:
+        output.num_bytes = None
+        output.num_rows = None
+        output.num_files = None
+
     assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "relations": {
             "parents": run_parents_to_json([run]) + operation_parents_to_json([operation]),
             "symlinks": [],
-            "inputs": inputs_to_json(inputs, granularity="OPERATION"),
-            "outputs": outputs_to_json(outputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merged_job_inputs, granularity="JOB"),
+                *inputs_to_json(inputs, granularity="OPERATION"),
+                *inputs_to_json(merged_run_inputs, granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merged_job_outputs, granularity="JOB"),
+                *outputs_to_json(outputs, granularity="OPERATION"),
+                *outputs_to_json(merged_run_outputs, granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -21,7 +21,7 @@ from tests.test_server.utils.convert_to_json import (
 )
 from tests.test_server.utils.enrich import enrich_datasets, enrich_jobs, enrich_runs
 from tests.test_server.utils.lineage_result import LineageResult
-from tests.test_server.utils.merge import merge_io_by_runs
+from tests.test_server.utils.merge import merge_io_by_jobs, merge_io_by_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio, pytest.mark.lineage]
 
@@ -152,8 +152,14 @@ async def test_get_run_lineage_simple(
         "relations": {
             "parents": run_parents_to_json([run]),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -209,8 +215,16 @@ async def test_get_run_lineage_with_granularity_operation(
         "relations": {
             "parents": run_parents_to_json([run]) + operation_parents_to_json(operations),
             "symlinks": [],
-            "inputs": inputs_to_json(inputs, granularity="OPERATION"),
-            "outputs": outputs_to_json(outputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(inputs, granularity="OPERATION"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(outputs, granularity="OPERATION"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -260,7 +274,10 @@ async def test_get_run_lineage_with_direction_downstream(
             "parents": run_parents_to_json([run]),
             "symlinks": [],
             "inputs": [],
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -309,7 +326,10 @@ async def test_get_run_lineage_with_direction_upstream(
         "relations": {
             "parents": run_parents_to_json([run]),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
             "outputs": [],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
@@ -367,8 +387,14 @@ async def test_get_run_lineage_with_until(
         "relations": {
             "parents": run_parents_to_json([run]),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -458,8 +484,14 @@ async def test_get_run_lineage_with_depth(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -562,8 +594,16 @@ async def test_get_run_lineage_with_depth_and_granularity_operation(
         "relations": {
             "parents": run_parents_to_json(runs) + operation_parents_to_json(operations),
             "symlinks": [],
-            "inputs": inputs_to_json(inputs, granularity="OPERATION"),
-            "outputs": outputs_to_json(outputs, granularity="OPERATION"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(inputs, granularity="OPERATION"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(outputs, granularity="OPERATION"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -609,8 +649,14 @@ async def test_get_run_lineage_with_depth_ignore_cycles(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(lineage.inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(lineage.outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(lineage.inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(lineage.inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(lineage.outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(lineage.outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -688,8 +734,14 @@ async def test_get_run_lineage_with_depth_ignore_unrelated_datasets(
         "relations": {
             "parents": run_parents_to_json(runs),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -750,8 +802,14 @@ async def test_get_run_lineage_with_symlinks(
         "relations": {
             "parents": run_parents_to_json([run]),
             "symlinks": symlinks_to_json(dataset_symlinks),
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -821,8 +879,14 @@ async def test_get_run_lineage_unmergeable_inputs_and_outputs(
         "relations": {
             "parents": run_parents_to_json([run]),
             "symlinks": [],
-            "inputs": inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
-            "outputs": outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
@@ -890,14 +954,26 @@ async def test_get_run_lineage_empty_io_stats_and_schema(
 
     # merge_io_by_runs sums empty bytes, rows and files, producing 0 instead of None.
     # override that
-    merged_inputs = merge_io_by_runs(inputs)
-    for input in merged_inputs:
+    merged_run_inputs = merge_io_by_runs(inputs)
+    for input in merged_run_inputs:
         input.num_bytes = None
         input.num_rows = None
         input.num_files = None
 
-    merged_outputs = merge_io_by_runs(outputs)
-    for output in merged_outputs:
+    merged_run_outputs = merge_io_by_runs(outputs)
+    for output in merged_run_outputs:
+        output.num_bytes = None
+        output.num_rows = None
+        output.num_files = None
+
+    merged_job_inputs = merge_io_by_jobs(inputs)
+    for input in merged_job_inputs:
+        input.num_bytes = None
+        input.num_rows = None
+        input.num_files = None
+
+    merged_job_outputs = merge_io_by_jobs(outputs)
+    for output in merged_job_outputs:
         output.num_bytes = None
         output.num_rows = None
         output.num_files = None
@@ -907,8 +983,14 @@ async def test_get_run_lineage_empty_io_stats_and_schema(
         "relations": {
             "parents": run_parents_to_json([run]),
             "symlinks": [],
-            "inputs": inputs_to_json(merged_inputs, granularity="RUN"),
-            "outputs": outputs_to_json(merged_outputs, granularity="RUN"),
+            "inputs": [
+                *inputs_to_json(merged_job_inputs, granularity="JOB"),
+                *inputs_to_json(merged_run_inputs, granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merged_job_outputs, granularity="JOB"),
+                *outputs_to_json(merged_run_outputs, granularity="RUN"),
+            ],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },

--- a/tests/test_server/utils/convert_to_json.py
+++ b/tests/test_server/utils/convert_to_json.py
@@ -94,13 +94,11 @@ def input_to_json(input: Input, granularity: Literal["OPERATION", "RUN", "JOB"])
 
 
 def inputs_to_json(inputs: list[Input], granularity: Literal["OPERATION", "RUN", "JOB"]):
-    return [
-        input_to_json(input, granularity)
-        for input in sorted(
-            inputs,
-            key=lambda x: (str(x.dataset_id), str(x.operation_id or x.run_id or x.job_id)),
-        )
-    ]
+    results = [input_to_json(input_, granularity) for input_ in inputs]
+    return sorted(
+        results,
+        key=lambda x: (x["from"]["id"], x["to"]["id"]),
+    )
 
 
 def output_to_json(output: Output, granularity: Literal["OPERATION", "RUN", "JOB"]):
@@ -124,13 +122,11 @@ def output_to_json(output: Output, granularity: Literal["OPERATION", "RUN", "JOB
 
 
 def outputs_to_json(outputs: list[Output], granularity: Literal["OPERATION", "RUN", "JOB"]):
-    return [
-        output_to_json(output, granularity)
-        for output in sorted(
-            outputs,
-            key=lambda x: (str(x.operation_id or x.run_id or x.job_id), str(x.dataset_id), x.type),
-        )
-    ]
+    results = [output_to_json(output, granularity) for output in outputs]
+    return sorted(
+        results,
+        key=lambda x: (x["from"]["id"], x["to"]["id"], x["type"]),
+    )
 
 
 def address_to_json(address: Address):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

This is required to show sum of operations within run, and sum of runs within job in the lineage graph:
![изображение](https://github.com/user-attachments/assets/a3de04f0-6680-4a87-9e24-f1f091216ed6)

Instead of calling `list_by_run_ids(granularity="RUN") + list_by_JOB_ids(granularity="JOB")`, call `list_by_run_ids(granularity="RUN") + list_by_RUN_ids(granularity="JOB")`. Otherwise lineage graph may include inputs & outputs of job with other datasets, not actually used by selected `run_id` or `operation_id`.

This logic can be implemented on UI side, but the code is quite ugly, so I've decided that it's better to move it to backend.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
