### PR TITLE
[DOP-22776] Strip partitions from dataset name

### DIFF
--- a/data_rentgen/consumer/extractors/dataset.py
+++ b/data_rentgen/consumer/extractors/dataset.py
@@ -29,7 +29,7 @@ OpenLineageDatasetLike = (
 METASTORE = DatasetSymlinkTypeDTO.METASTORE
 WAREHOUSE = DatasetSymlinkTypeDTO.WAREHOUSE
 
-PATTERN: re.Pattern = re.compile("^(.*?)/[^/=]+=")
+PARTITION_PATH_PATTERN: re.Pattern = re.compile("^(.*?)/[^/=]+=")
 
 
 def connect_dataset_with_symlinks(
@@ -59,8 +59,8 @@ def connect_dataset_with_symlinks(
 
 
 def extract_dataset(dataset: OpenLineageDatasetLike) -> DatasetDTO:
-    long_name = PATTERN.match(dataset.name)
-    name = long_name.group(1) if long_name else dataset.name
+    name_with_partitions = PARTITION_PATH_PATTERN.match(dataset.name)
+    name = name_with_partitions.group(1) if name_with_partitions else dataset.name
     return DatasetDTO(
         name=name,
         location=extract_dataset_location(dataset),

--- a/data_rentgen/consumer/extractors/dataset.py
+++ b/data_rentgen/consumer/extractors/dataset.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import re
 from urllib.parse import urlparse
 
 from data_rentgen.consumer.openlineage.dataset import OpenLineageDataset
@@ -56,8 +57,10 @@ def connect_dataset_with_symlinks(
 
 
 def extract_dataset(dataset: OpenLineageDatasetLike) -> DatasetDTO:
+    long_name = re.match("^(.*?)/[^/=]+=", dataset.name)
+    name = long_name.group(1) if long_name else dataset.name
     return DatasetDTO(
-        name=dataset.name,
+        name=name,
         location=extract_dataset_location(dataset),
         format=extract_dataset_format(dataset),
     )

--- a/data_rentgen/consumer/extractors/dataset.py
+++ b/data_rentgen/consumer/extractors/dataset.py
@@ -29,6 +29,8 @@ OpenLineageDatasetLike = (
 METASTORE = DatasetSymlinkTypeDTO.METASTORE
 WAREHOUSE = DatasetSymlinkTypeDTO.WAREHOUSE
 
+PATTERN: re.Pattern = re.compile("^(.*?)/[^/=]+=")
+
 
 def connect_dataset_with_symlinks(
     dataset: DatasetDTO,
@@ -57,7 +59,7 @@ def connect_dataset_with_symlinks(
 
 
 def extract_dataset(dataset: OpenLineageDatasetLike) -> DatasetDTO:
-    long_name = re.match("^(.*?)/[^/=]+=", dataset.name)
+    long_name = PATTERN.match(dataset.name)
     name = long_name.group(1) if long_name else dataset.name
     return DatasetDTO(
         name=name,

--- a/docs/changelog/next_release/175.improvement.rst
+++ b/docs/changelog/next_release/175.improvement.rst
@@ -1,0 +1,13 @@
+Add dataset name parsing for removing partition-like part from name.
+
+Before:
+
+Two different datasets
+``name="/app/warehouse/somedb.db/sometable/business_dt=2025-01-01/reg_id=99``
+``name="/app/warehouse/somedb.db/sometable/business_dt=2025-02-01/reg_id=99``
+
+Now:
+
+Two partitions union in one dataset
+``name="/app/warehouse/somedb.db/sometable``
+

--- a/docs/quickstart/setup_spark.rst
+++ b/docs/quickstart/setup_spark.rst
@@ -60,10 +60,6 @@ Setup
           )
           .config("spark.openlineage.transport.properties.compression.type", "zstd")
           # few other important options
-          .config(
-              "spark.openlineage.dataset.removePath.pattern",
-              r"(.*?)(?<remove>(?:\/[^\/=]+=[^\/=]+)+)",
-          )
           .config("spark.openlineage.jobName.appendDatasetName", "false")
           .config("spark.openlineage.columnLineage.datasetLineageEnabled", "true")
           .getOrCreate()

--- a/tests/test_consumer/test_extractors/test_extractors_batch_spark.py
+++ b/tests/test_consumer/test_extractors/test_extractors_batch_spark.py
@@ -613,3 +613,54 @@ def test_extractors_extract_batch_spark(
     assert extracted.schemas() == [extracted_dataset_schema]
     assert extracted.inputs() == [extracted_postgres_input]
     assert extracted.outputs() == [extracted_hive_output]
+
+
+def test_extract_batch_hdfs_strip_partitions(extracted_hdfs_dataset: DatasetDTO):
+    """
+    There is two datasets name in event. They should be union into one, excluding partition.
+    """
+    event_time = datetime(2024, 7, 5, 9, 7, 9, 849000, tzinfo=timezone.utc)
+    run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
+    operation_id = UUID("01908225-1fd7-746b-910c-70d24f2898b1")
+    event = OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.RUNNING,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="local://some.host.com",
+            name="mysession.execute_some_command",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    jobType=OpenLineageJobType.JOB,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration=OpenLineageJobIntegrationType.SPARK,
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=operation_id,
+            facets=OpenLineageRunFacets(
+                parent=OpenLineageParentRunFacet(
+                    job=OpenLineageParentJob(
+                        namespace="local://some.host.com",
+                        name="mysession",
+                    ),
+                    run=OpenLineageParentRun(
+                        runId=run_id,
+                    ),
+                ),
+            ),
+        ),
+        outputs=[
+            OpenLineageOutputDataset(
+                namespace="hdfs://test-hadoop:9820",
+                name="/user/hive/warehouse/mydb.db/mytable/business_dt=2025-01-01/reg_id=99/part_dt=2025-01-01",
+            ),
+            OpenLineageOutputDataset(
+                namespace="hdfs://test-hadoop:9820",
+                name="/user/hive/warehouse/mydb.db/mytable/business_dt=2025-02-01/reg_id=99/part_dt=2025-01-01",
+            ),
+        ],
+    )
+
+    extracted = extract_batch([event])
+    assert extracted.datasets() == [extracted_hdfs_dataset]

--- a/tests/test_consumer/test_extractors/test_extractors_dataset.py
+++ b/tests/test_consumer/test_extractors/test_extractors_dataset.py
@@ -38,6 +38,25 @@ def test_extractors_extract_dataset_hdfs():
     assert symlinks == []
 
 
+def test_extractors_extract_dataset_hdfs_with_patition():
+    dataset = OpenLineageDataset(
+        namespace="hdfs://test-hadoop:9820",
+        name="/user/hive/warehouse/mydb.db/mytable/business_dt=2025-01-01/reg_id=99/part_dt=2025-01-01",
+    )
+
+    dataset, symlinks = extract_dataset_and_symlinks(dataset)
+
+    assert dataset == DatasetDTO(
+        location=LocationDTO(
+            type="hdfs",
+            name="test-hadoop:9820",
+            addresses={"hdfs://test-hadoop:9820"},
+        ),
+        name="/user/hive/warehouse/mydb.db/mytable",
+    )
+    assert symlinks == []
+
+
 def test_extractors_extract_dataset_hdfs_with_table_symlink():
     dataset = OpenLineageDataset(
         namespace="hdfs://test-hadoop:9820",

--- a/tests/test_consumer/test_extractors/test_extractors_dataset.py
+++ b/tests/test_consumer/test_extractors/test_extractors_dataset.py
@@ -80,7 +80,7 @@ def test_extractors_extract_dataset_hdfs_with_patition():
     assert symlinks == []
 
 
-def test_extractors_extract_batch_dataset_hdfs():
+def test_extract_batch_hdfs_strip_partitions():
     """
     There is two datasets name in event. They should be union into one, excluding partition.
     """

--- a/tests/test_consumer/test_extractors/test_extractors_dataset.py
+++ b/tests/test_consumer/test_extractors/test_extractors_dataset.py
@@ -1,12 +1,8 @@
-from datetime import datetime, timezone
-
 import pytest
-from uuid6 import UUID
 
-from data_rentgen.consumer.extractors import extract_batch, extract_dataset_and_symlinks
+from data_rentgen.consumer.extractors import extract_dataset_and_symlinks
 from data_rentgen.consumer.openlineage.dataset import (
     OpenLineageDataset,
-    OpenLineageOutputDataset,
 )
 from data_rentgen.consumer.openlineage.dataset_facets import (
     OpenLineageDatasetFacets,
@@ -14,25 +10,6 @@ from data_rentgen.consumer.openlineage.dataset_facets import (
     OpenLineageSymlinkIdentifier,
     OpenLineageSymlinksDatasetFacet,
     OpenLineageSymlinkType,
-)
-from data_rentgen.consumer.openlineage.job import OpenLineageJob
-from data_rentgen.consumer.openlineage.job_facets import (
-    OpenLineageJobFacets,
-    OpenLineageJobIntegrationType,
-    OpenLineageJobProcessingType,
-    OpenLineageJobType,
-    OpenLineageJobTypeJobFacet,
-)
-from data_rentgen.consumer.openlineage.run import OpenLineageRun
-from data_rentgen.consumer.openlineage.run_event import (
-    OpenLineageRunEvent,
-    OpenLineageRunEventType,
-)
-from data_rentgen.consumer.openlineage.run_facets import (
-    OpenLineageParentJob,
-    OpenLineageParentRun,
-    OpenLineageParentRunFacet,
-    OpenLineageRunFacets,
 )
 from data_rentgen.dto import (
     DatasetDTO,
@@ -78,64 +55,6 @@ def test_extractors_extract_dataset_hdfs_with_patition():
         name="/user/hive/warehouse/mydb.db/mytable",
     )
     assert symlinks == []
-
-
-def test_extract_batch_hdfs_strip_partitions():
-    """
-    There is two datasets name in event. They should be union into one, excluding partition.
-    """
-    event_time = datetime(2024, 7, 5, 9, 7, 9, 849000, tzinfo=timezone.utc)
-    run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
-    operation_id = UUID("01908225-1fd7-746b-910c-70d24f2898b1")
-    event = OpenLineageRunEvent(
-        eventType=OpenLineageRunEventType.RUNNING,
-        eventTime=event_time,
-        job=OpenLineageJob(
-            namespace="local://some.host.com",
-            name="mysession.execute_some_command",
-            facets=OpenLineageJobFacets(
-                jobType=OpenLineageJobTypeJobFacet(
-                    jobType=OpenLineageJobType.JOB,
-                    processingType=OpenLineageJobProcessingType.BATCH,
-                    integration=OpenLineageJobIntegrationType.SPARK,
-                ),
-            ),
-        ),
-        run=OpenLineageRun(
-            runId=operation_id,
-            facets=OpenLineageRunFacets(
-                parent=OpenLineageParentRunFacet(
-                    job=OpenLineageParentJob(
-                        namespace="local://some.host.com",
-                        name="mysession",
-                    ),
-                    run=OpenLineageParentRun(
-                        runId=run_id,
-                    ),
-                ),
-            ),
-        ),
-        outputs=[
-            OpenLineageOutputDataset(
-                namespace="hdfs://test-hadoop:9820",
-                name="/user/hive/warehouse/mydb.db/mytable/business_dt=2025-01-01/reg_id=99/part_dt=2025-01-01",
-            ),
-            OpenLineageOutputDataset(
-                namespace="hdfs://test-hadoop:9820",
-                name="/user/hive/warehouse/mydb.db/mytable/business_dt=2025-02-01/reg_id=99/part_dt=2025-01-01",
-            ),
-        ],
-    )
-
-    extracted = extract_batch([event])
-    assert extracted.datasets() == [
-        DatasetDTO(
-            location=LocationDTO(type="hdfs", name="test-hadoop:9820", addresses={"hdfs://test-hadoop:9820"}, id=None),
-            name="/user/hive/warehouse/mydb.db/mytable",
-            format=None,
-            id=None,
-        ),
-    ]
 
 
 def test_extractors_extract_dataset_hdfs_with_table_symlink():


### PR DESCRIPTION
## Change Summary

Add regular expresion to remove partition like part of the name in file storages.

`name="/app/warehouse/somedb.db/sometable/business_dt=2025-01-01/reg_id=99"`
`name="/app/warehouse/somedb.db/sometable`

## Related issue number

[DOP-22776]

## Checklist

* [x] Commit message and PR title is comprehensive
* [ x Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [ ] My PR is ready to review.
