### PR TITLE
[DOP-23708] Do not use RETURNING if result is ignored

### DIFF
--- a/data_rentgen/db/repositories/dataset_column_relation.py
+++ b/data_rentgen/db/repositories/dataset_column_relation.py
@@ -17,7 +17,7 @@ from data_rentgen.dto import ColumnLineageDTO
 
 
 class DatasetColumnRelationRepository(Repository[ColumnLineage]):
-    async def create_bulk_for_column_lineage(self, items: list[ColumnLineageDTO]):
+    async def create_bulk_for_column_lineage(self, items: list[ColumnLineageDTO]) -> None:
         if not items:
             return
 

--- a/data_rentgen/db/repositories/input.py
+++ b/data_rentgen/db/repositories/input.py
@@ -33,21 +33,22 @@ class InputRepository(Repository[Input]):
         ]
         return generate_incremental_uuid(created_at, ".".join(id_components))
 
-    async def create_or_update_bulk(self, inputs: list[InputDTO]) -> list[Input]:
+    async def create_or_update_bulk(self, inputs: list[InputDTO]) -> None:
         if not inputs:
-            return []
+            return
 
         insert_statement = insert(Input)
+        new_row = insert_statement.excluded
         statement = insert_statement.on_conflict_do_update(
             index_elements=[Input.created_at, Input.id],
             set_={
-                "num_bytes": func.greatest(insert_statement.excluded.num_bytes, Input.num_bytes),
-                "num_rows": func.greatest(insert_statement.excluded.num_rows, Input.num_rows),
-                "num_files": func.greatest(insert_statement.excluded.num_files, Input.num_files),
+                "num_bytes": func.greatest(new_row.num_bytes, Input.num_bytes),
+                "num_rows": func.greatest(new_row.num_rows, Input.num_rows),
+                "num_files": func.greatest(new_row.num_files, Input.num_files),
             },
-        ).returning(Input)
+        )
 
-        result = await self._session.execute(
+        await self._session.execute(
             statement,
             [
                 {
@@ -65,7 +66,6 @@ class InputRepository(Repository[Input]):
                 for input_ in inputs
             ],
         )
-        return list(result.scalars().all())
 
     async def list_by_operation_ids(
         self,

--- a/data_rentgen/db/repositories/operation.py
+++ b/data_rentgen/db/repositories/operation.py
@@ -15,9 +15,9 @@ from data_rentgen.dto import OperationDTO, PaginationDTO
 
 
 class OperationRepository(Repository[Operation]):
-    async def create_or_update_bulk(self, operations: list[OperationDTO]) -> list[Operation]:
+    async def create_or_update_bulk(self, operations: list[OperationDTO]) -> None:
         if not operations:
-            return []
+            return
 
         insert_statement = insert(Operation)
         statement = insert_statement.on_conflict_do_update(
@@ -32,9 +32,9 @@ class OperationRepository(Repository[Operation]):
                 "group": func.coalesce(insert_statement.excluded.group, Operation.group),
                 "position": func.coalesce(insert_statement.excluded.position, Operation.position),
             },
-        ).returning(Operation)
+        )
 
-        result = await self._session.execute(
+        await self._session.execute(
             statement,
             [
                 {
@@ -53,7 +53,6 @@ class OperationRepository(Repository[Operation]):
                 for operation in operations
             ],
         )
-        return list(result.scalars().all())
 
     async def paginate(
         self,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Operations, inputs and outputs are created with predefined `id` field, so we don't actually need `RETURNING ...` in insert queries. This optimization reduces the amount of data read from DB, but not very much - for 1.6 mil events read IO reduced from 475MB to 455MB.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
