### PR TITLE
[DOP-23708] Improve caching inside BatchExtractionResult

### DIFF
--- a/data_rentgen/consumer/extractors/batch.py
+++ b/data_rentgen/consumer/extractors/batch.py
@@ -90,71 +90,73 @@ class BatchExtractionResult:
         )
 
     @staticmethod
-    def _add(context: dict[tuple, T], new_item: T) -> dict[tuple, T]:
+    def _add(context: dict[tuple, T], new_item: T) -> T:
         key = new_item.unique_key
         if key in context:
             old_item = context[key]
             if old_item is new_item:
-                return context
+                return old_item
 
-            context[key] = old_item.merge(new_item)
-        else:
-            context[key] = new_item
-        return context
+            merged_item = old_item.merge(new_item)
+            context[key] = merged_item
+            return merged_item
+
+        context[key] = new_item
+        return new_item
 
     def add_location(self, location: LocationDTO):
-        self._add(self._locations, location)
+        return self._add(self._locations, location)
 
     def add_dataset(self, dataset: DatasetDTO):
-        self._add(self._datasets, dataset)
-        self.add_location(dataset.location)
+        dataset.location = self.add_location(dataset.location)
+        return self._add(self._datasets, dataset)
 
     def add_dataset_symlink(self, dataset_symlink: DatasetSymlinkDTO):
-        self._add(self._dataset_symlinks, dataset_symlink)
-        self.add_dataset(dataset_symlink.from_dataset)
-        self.add_dataset(dataset_symlink.to_dataset)
+        dataset_symlink.from_dataset = self.add_dataset(dataset_symlink.from_dataset)
+        dataset_symlink.to_dataset = self.add_dataset(dataset_symlink.to_dataset)
+        return self._add(self._dataset_symlinks, dataset_symlink)
 
     def add_job(self, job: JobDTO):
-        self._add(self._jobs, job)
-        self.add_location(job.location)
+        job.location = self.add_location(job.location)
+        return self._add(self._jobs, job)
 
     def add_run(self, run: RunDTO):
-        self._add(self._runs, run)
-        self.add_job(run.job)
+        run.job = self.add_job(run.job)
         if run.parent_run:
-            self.add_run(run.parent_run)
+            run.parent_run = self.add_run(run.parent_run)
         if run.user:
-            self.add_user(run.user)
+            run.user = self.add_user(run.user)
+        return self._add(self._runs, run)
 
     def add_operation(self, operation: OperationDTO):
-        self._add(self._operations, operation)
-        self.add_run(operation.run)
+        operation.run = self.add_run(operation.run)
+        return self._add(self._operations, operation)
 
     def add_input(self, input_: InputDTO):
-        self._add(self._inputs, input_)
-        self.add_operation(input_.operation)
-        self.add_dataset(input_.dataset)
+        input_.operation = self.add_operation(input_.operation)
+        input_.dataset = self.add_dataset(input_.dataset)
         if input_.schema:
-            self.add_schema(input_.schema)
+            input_.schema = self.add_schema(input_.schema)
+        return self._add(self._inputs, input_)
 
     def add_output(self, output: OutputDTO):
-        self._add(self._outputs, output)
-        self.add_operation(output.operation)
-        self.add_dataset(output.dataset)
+        output.operation = self.add_operation(output.operation)
+        output.dataset = self.add_dataset(output.dataset)
         if output.schema:
-            self.add_schema(output.schema)
+            output.schema = self.add_schema(output.schema)
+        return self._add(self._outputs, output)
 
     def add_column_lineage(self, lineage: ColumnLineageDTO):
-        self._add(self._column_lineage, lineage)
-        self.add_dataset(lineage.source_dataset)
-        self.add_dataset(lineage.target_dataset)
-        self.add_operation(lineage.operation)
+        lineage.source_dataset = self.add_dataset(lineage.source_dataset)
+        lineage.target_dataset = self.add_dataset(lineage.target_dataset)
+        lineage.operation = self.add_operation(lineage.operation)
+        return self._add(self._column_lineage, lineage)
 
     def add_schema(self, schema: SchemaDTO):
-        self._add(self._schemas, schema)
+        return self._add(self._schemas, schema)
 
     def add_user(self, user: UserDTO):
-        self._add(self._users, user)
+        return self._add(self._users, user)
 
     def _get_location(self, location_key: tuple) -> LocationDTO:
         return self._locations[location_key]

--- a/data_rentgen/dto/column_lineage.py
+++ b/data_rentgen/dto/column_lineage.py
@@ -31,7 +31,7 @@ class ColumnLineageDTO:
     def __post_init__(self, dataset_column_relations: list[DatasetColumnRelationDTO]):
         self._dataset_column_relations = merge_dataset_column_relations(dataset_column_relations)
 
-    @cached_property
+    @property
     def unique_key(self) -> tuple:
         return (self.operation.unique_key, self.source_dataset.unique_key, self.target_dataset.unique_key)
 

--- a/data_rentgen/dto/dataset.py
+++ b/data_rentgen/dto/dataset.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from functools import cached_property
 
 from data_rentgen.dto.location import LocationDTO
 
@@ -16,11 +15,15 @@ class DatasetDTO:
     format: str | None = None
     id: int | None = field(default=None, compare=False)
 
-    @cached_property
+    @property
     def unique_key(self) -> tuple:
         return (self.location.unique_key, self.name)
 
     def merge(self, new: DatasetDTO) -> DatasetDTO:
+        if self.location is new.location and new.id is None and new.format == self.format:
+            # datasets aren't changed that much, reuse them if possible
+            return self
+
         return DatasetDTO(
             location=self.location.merge(new.location),
             name=self.name,

--- a/data_rentgen/dto/dataset_column_relation.py
+++ b/data_rentgen/dto/dataset_column_relation.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import IntFlag
-from functools import cached_property
 
 from uuid6 import UUID
 
@@ -40,7 +39,7 @@ class DatasetColumnRelationDTO:
     fingerprint: UUID | None = None
     # description is always "", see io.openlineage.spark.agent.lifecycle.plan.column.TransformationInfo
 
-    @cached_property
+    @property
     def unique_key(self) -> tuple:
         return (
             self.source_column,

--- a/data_rentgen/dto/dataset_symlink.py
+++ b/data_rentgen/dto/dataset_symlink.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from functools import cached_property
 
 from data_rentgen.dto.dataset import DatasetDTO
 
@@ -25,7 +24,7 @@ class DatasetSymlinkDTO:
     type: DatasetSymlinkTypeDTO
     id: int | None = field(default=None, compare=False)
 
-    @cached_property
+    @property
     def unique_key(self) -> tuple:
         return (self.from_dataset.unique_key, self.to_dataset.unique_key, self.type)
 

--- a/data_rentgen/dto/input.py
+++ b/data_rentgen/dto/input.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import cached_property
 
 from uuid6 import UUID
 
@@ -24,7 +23,7 @@ class InputDTO:
     # id is generated using other ids combination
     id: UUID | None = None
 
-    @cached_property
+    @property
     def unique_key(self) -> tuple:
         return (
             self.operation.unique_key,

--- a/data_rentgen/dto/job.py
+++ b/data_rentgen/dto/job.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from functools import cached_property
 
 from data_rentgen.dto.location import LocationDTO
 
@@ -26,11 +25,15 @@ class JobDTO:
     type: JobTypeDTO | None = None
     id: int | None = field(default=None, compare=False)
 
-    @cached_property
+    @property
     def unique_key(self) -> tuple:
         return (self.location.unique_key, self.name)
 
     def merge(self, new: JobDTO) -> JobDTO:
+        if new.id is None and self.type == new.type:
+            # jobs aren't changed that much, reuse them if possible
+            return self
+
         return JobDTO(
             location=self.location.merge(new.location),
             name=self.name,

--- a/data_rentgen/dto/location.py
+++ b/data_rentgen/dto/location.py
@@ -17,6 +17,10 @@ class LocationDTO:
         return (self.type, self.name)
 
     def merge(self, new: LocationDTO) -> LocationDTO:
+        if new.id is None and self.addresses == new.addresses:
+            # locations aren't changed that much, reuse them if possible
+            return self
+
         return LocationDTO(
             type=self.type,
             name=self.name,

--- a/data_rentgen/dto/output.py
+++ b/data_rentgen/dto/output.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from functools import cached_property
 
 from uuid6 import UUID
 
@@ -41,7 +40,7 @@ class OutputDTO:
     # id is generated using other ids combination
     id: UUID | None = None
 
-    @cached_property
+    @property
     def unique_key(self) -> tuple:
         return (
             self.operation.unique_key,

--- a/data_rentgen/dto/schema.py
+++ b/data_rentgen/dto/schema.py
@@ -15,9 +15,13 @@ class SchemaDTO:
 
     @cached_property
     def unique_key(self) -> tuple:
+        # expensive operation, calculate it only once
         return (json.dumps(self.fields, sort_keys=True),)
 
     def merge(self, new: SchemaDTO) -> SchemaDTO:
+        if new.id is None:
+            return self
+
         return SchemaDTO(
             fields=self.fields,
             id=new.id or self.id,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Currently `BatchExtractionResult._add` already can handle case then existing batch item is exactly the same as new item (using `var1 is var2`). But this optimization is not applied if objects are different with exactly the same fields value, which is quite common for `extract_*` functions.

Add 2 small optimizations here:
* If location, dataset, job, schema DTO method `.merge(old, new)` received object with exactly the same field values, return existing object instead of constructing new one.
* For nested DTOs reuse existing items from batch result.

This reduced amount of time spent in `add_input` from 3% to 1.3%, not very much:
![profile_no_column_lineage_cache](https://github.com/user-attachments/assets/6ee5375e-897c-43b3-93cc-64f6afb88818)
![profile_only_batch_cache](https://github.com/user-attachments/assets/1efa60a2-e810-49de-88e6-f9f29eefd031)

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
