### PR TITLE
[DOP-24369] Make search_query param optional in GET /v1/runs

### DIFF
--- a/data_rentgen/db/repositories/operation.py
+++ b/data_rentgen/db/repositories/operation.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 from uuid import UUID
 
-from sqlalchemy import Row, any_, func, select
+from sqlalchemy import Row, UnaryExpression, any_, func, select
 from sqlalchemy.dialects.postgresql import insert
 
 from data_rentgen.db.models import Operation, OperationStatus, OperationType
@@ -87,7 +87,7 @@ class OperationRepository(Repository[Operation]):
             where.append(Operation.id == any_(operation_ids))  # type: ignore[arg-type]
 
         query = select(Operation).where(*where)
-        order_by = [Operation.run_id, Operation.id.desc()]
+        order_by: list[UnaryExpression] = [Operation.created_at.desc(), Operation.id.desc()]
         return await self._paginate_by_query(
             query=query,
             order_by=order_by,

--- a/data_rentgen/db/repositories/run.py
+++ b/data_rentgen/db/repositories/run.py
@@ -100,10 +100,10 @@ class RunRepository(Repository[Run]):
                 func.max(union_cte.c.search_rank).label("search_rank"),
             ).group_by(*run_columns)
             # place the most recent runs on top
-            order_by = [desc("search_rank"), desc("id")]
+            order_by = [desc("search_rank"), desc("created_at"), desc("id")]
         else:
             query = select(Run).where(*where)
-            order_by = [Run.id.desc()]
+            order_by = [Run.created_at.desc(), Run.id.desc()]
 
         options = [selectinload(Run.started_by_user)]
         return await self._paginate_by_query(

--- a/data_rentgen/server/schemas/v1/run.py
+++ b/data_rentgen/server/schemas/v1/run.py
@@ -171,8 +171,8 @@ class RunsQueryV1(PaginateQueryV1):
 
     @model_validator(mode="after")
     def _check_fields(self):
-        if not any([self.run_id, self.job_id, self.parent_run_id, self.search_query]):
-            msg = "input should contain either 'run_id', 'job_id', 'parent_run_id' or 'search_query' field"
+        if not any([self.since, self.run_id, self.job_id, self.parent_run_id, self.search_query]):
+            msg = "input should contain either 'since', 'run_id', 'job_id', 'parent_run_id' or 'search_query' field"
             raise ValueError(msg)
         if self.job_id and not self.since:
             msg = "'job_id' can be passed only with 'since'"

--- a/docs/changelog/next_release/184.feature.rst
+++ b/docs/changelog/next_release/184.feature.rst
@@ -1,0 +1,1 @@
+Allow fetching ``GET /v1/runs?since=...`` without ``search_query`` query param.

--- a/tests/test_server/test_operations/test_get_operations_by_id.py
+++ b/tests/test_server/test_operations/test_get_operations_by_id.py
@@ -132,7 +132,7 @@ async def test_get_operations_by_multiple_ids(
                     },
                 },
             }
-            for operation in sorted(selected_operations, key=lambda x: (x.run_id.int, -x.id.int))
+            for operation in sorted(selected_operations, key=lambda x: (x.created_at, x.id.int), reverse=True)
         ],
     }
 
@@ -209,6 +209,6 @@ async def test_get_operations_by_multiple_ids_with_stats(
                     "outputs": output_stats[operation.id],
                 },
             }
-            for operation in sorted(simple_lineage.operations, key=lambda x: (x.run_id.int, -x.id.int))
+            for operation in sorted(simple_lineage.operations, key=lambda x: (x.created_at, x.id.int), reverse=True)
         ],
     }

--- a/tests/test_server/test_operations/test_get_operations_by_run_id.py
+++ b/tests/test_server/test_operations/test_get_operations_by_run_id.py
@@ -132,7 +132,7 @@ async def test_get_operations_by_run_id(
                     },
                 },
             }
-            for operation in sorted(selected_operations, key=lambda x: x.id, reverse=True)
+            for operation in sorted(selected_operations, key=lambda x: (x.created_at, x.id), reverse=True)
         ],
     }
 
@@ -190,6 +190,6 @@ async def test_get_operations_by_run_id_with_until(
                     },
                 },
             }
-            for operation in sorted(selected_operations, key=lambda x: x.id, reverse=True)
+            for operation in sorted(selected_operations, key=lambda x: (x.created_at, x.id), reverse=True)
         ],
     }

--- a/tests/test_server/test_runs/test_get_runs.py
+++ b/tests/test_server/test_runs/test_get_runs.py
@@ -3,10 +3,14 @@ from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 from uuid6 import uuid7
 
+from data_rentgen.db.models.run import Run
 from data_rentgen.db.utils.uuid import generate_new_uuid
 from tests.fixtures.mocks import MockedUser
+from tests.test_server.utils.convert_to_json import run_to_json
+from tests.test_server.utils.enrich import enrich_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
@@ -29,7 +33,7 @@ async def test_get_runs_missing_fields(
                 {
                     "location": [],
                     "code": "value_error",
-                    "message": "Value error, input should contain either 'run_id', 'job_id', 'parent_run_id' or 'search_query' field",
+                    "message": "Value error, input should contain either 'since', 'run_id', 'job_id', 'parent_run_id' or 'search_query' field",
                     "context": {},
                     "input": {
                         "page": 1,
@@ -78,6 +82,122 @@ async def test_get_runs_by_run_id_until_less_than_since(
                 },
             ],
         },
+    }
+
+
+async def test_get_runs_with_since(
+    test_client: AsyncClient,
+    runs: list[Run],
+    async_session: AsyncSession,
+    mocked_user: MockedUser,
+):
+    since = min(run.created_at for run in runs)
+    runs = await enrich_runs(runs, async_session)
+
+    response = await test_client.get(
+        "v1/runs",
+        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
+        params={
+            "since": since.isoformat(),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "meta": {
+            "page": 1,
+            "page_size": 20,
+            "total_count": len(runs),
+            "pages_count": 1,
+            "has_next": False,
+            "has_previous": False,
+            "next_page": None,
+            "previous_page": None,
+        },
+        "items": [
+            {
+                "id": str(run.id),
+                "data": run_to_json(run),
+                "statistics": {
+                    "inputs": {
+                        "total_datasets": 0,
+                        "total_bytes": 0,
+                        "total_rows": 0,
+                        "total_files": 0,
+                    },
+                    "outputs": {
+                        "total_datasets": 0,
+                        "total_bytes": 0,
+                        "total_rows": 0,
+                        "total_files": 0,
+                    },
+                    "operations": {
+                        "total_operations": 0,
+                    },
+                },
+            }
+            for run in sorted(runs, key=lambda x: (x.created_at, x.id), reverse=True)
+        ],
+    }
+
+
+async def test_get_runs_with_until(
+    test_client: AsyncClient,
+    runs: list[Run],
+    async_session: AsyncSession,
+    mocked_user: MockedUser,
+):
+    since = min(run.created_at for run in runs)
+    until = since + timedelta(seconds=1)
+
+    selected_runs = [run for run in runs if since <= run.created_at <= until]
+    selected_runs = await enrich_runs(selected_runs, async_session)
+
+    response = await test_client.get(
+        "v1/runs",
+        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
+        params={
+            "since": since.isoformat(),
+            "until": until.isoformat(),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "meta": {
+            "page": 1,
+            "page_size": 20,
+            "total_count": len(selected_runs),
+            "pages_count": 1,
+            "has_next": False,
+            "has_previous": False,
+            "next_page": None,
+            "previous_page": None,
+        },
+        "items": [
+            {
+                "id": str(run.id),
+                "data": run_to_json(run),
+                "statistics": {
+                    "inputs": {
+                        "total_datasets": 0,
+                        "total_bytes": 0,
+                        "total_rows": 0,
+                        "total_files": 0,
+                    },
+                    "outputs": {
+                        "total_datasets": 0,
+                        "total_bytes": 0,
+                        "total_rows": 0,
+                        "total_files": 0,
+                    },
+                    "operations": {
+                        "total_operations": 0,
+                    },
+                },
+            }
+            for run in sorted(selected_runs, key=lambda x: (x.created_at, x.id), reverse=True)
+        ],
     }
 
 

--- a/tests/test_server/test_runs/test_get_runs_by_id.py
+++ b/tests/test_server/test_runs/test_get_runs_by_id.py
@@ -142,7 +142,7 @@ async def test_get_runs_by_multiple_ids(
                     },
                 },
             }
-            for run in sorted(selected_runs, key=lambda x: x.id, reverse=True)
+            for run in sorted(selected_runs, key=lambda x: (x.created_at, x.id), reverse=True)
         ],
     }
 
@@ -228,6 +228,6 @@ async def test_get_runs_by_multiple_ids_with_stats(
                     "operations": operation_stats[run.id],
                 },
             }
-            for run in sorted(runs, key=lambda x: x.id, reverse=True)
+            for run in sorted(runs, key=lambda x: (x.created_at, x.id), reverse=True)
         ],
     }

--- a/tests/test_server/test_runs/test_get_runs_by_job_id.py
+++ b/tests/test_server/test_runs/test_get_runs_by_job_id.py
@@ -143,7 +143,7 @@ async def test_get_runs_by_job_id(
                     },
                 },
             }
-            for run in sorted(selected_runs, key=lambda x: x.id, reverse=True)
+            for run in sorted(selected_runs, key=lambda x: (x.created_at, x.id), reverse=True)
         ],
     }
 
@@ -158,13 +158,13 @@ async def test_get_runs_by_job_id_with_until(
     until = since + timedelta(seconds=1)
 
     selected_runs = [run for run in runs_with_same_job if since <= run.created_at <= until]
-    runs = await enrich_runs(selected_runs, async_session)
+    selected_runs = await enrich_runs(selected_runs, async_session)
 
     response = await test_client.get(
         "v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "job_id": runs[0].job_id,
+            "job_id": selected_runs[0].job_id,
             "since": since.isoformat(),
             "until": until.isoformat(),
         },
@@ -175,7 +175,7 @@ async def test_get_runs_by_job_id_with_until(
         "meta": {
             "page": 1,
             "page_size": 20,
-            "total_count": 2,
+            "total_count": len(selected_runs),
             "pages_count": 1,
             "has_next": False,
             "has_previous": False,
@@ -204,6 +204,6 @@ async def test_get_runs_by_job_id_with_until(
                     },
                 },
             }
-            for run in sorted(runs, key=lambda x: x.id, reverse=True)
+            for run in sorted(selected_runs, key=lambda x: (x.created_at, x.id), reverse=True)
         ],
     }

--- a/tests/test_server/test_runs/test_get_runs_by_parent_run_id.py
+++ b/tests/test_server/test_runs/test_get_runs_by_parent_run_id.py
@@ -137,7 +137,7 @@ async def test_get_runs_by_parent_run_id(
                     },
                 },
             }
-            for run in sorted(runs, key=lambda x: x.id, reverse=True)
+            for run in sorted(runs, key=lambda x: (x.created_at, x.id), reverse=True)
         ],
     }
 
@@ -198,6 +198,6 @@ async def test_get_runs_by_parent_run_id_with_until(
                     },
                 },
             }
-            for run in sorted(runs, key=lambda x: x.id, reverse=True)
+            for run in sorted(runs, key=lambda x: (x.created_at, x.id), reverse=True)
         ],
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

`ORDER BY {primary key columns} (ASC|DESC) LIMIT N` is quite effective operation, so we don't have to filter runs by something else. Same for `COUNT`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
