### PR TITLE
[DOP-23711] Change returning schema in lineage response

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,6 +116,7 @@ repos:
 
 ci:
   skip:
+    - rstcheck
     - mypy # checked with Github Actions
     - docker-compose-check # cannot run on pre-commit.ci
     - chmod # failing in pre-commit.ci

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,7 +116,6 @@ repos:
 
 ci:
   skip:
-    - rstcheck
     - mypy # checked with Github Actions
     - docker-compose-check # cannot run on pre-commit.ci
     - chmod # failing in pre-commit.ci

--- a/data_rentgen/server/api/v1/router/operation.py
+++ b/data_rentgen/server/api/v1/router/operation.py
@@ -27,6 +27,7 @@ router = APIRouter(
 )
 
 
+# TODO: Remove type ignore in DOP-24446
 @router.get("", summary="Paginated list of Operations")
 async def operations(
     query_args: Annotated[OperationQueryV1, Depends()],
@@ -39,8 +40,8 @@ async def operations(
         page_size=query_args.page_size,
         since=query_args.since,
         until=query_args.until,
-        operation_ids=query_args.operation_id,
-        run_id=query_args.run_id,
+        operation_ids=query_args.operation_id,  # type: ignore[arg-type]
+        run_id=query_args.run_id,  # type: ignore[arg-type]
     )
     return PageResponseV1[OperationDetailedResponseV1].from_pagination(pagination)
 

--- a/data_rentgen/server/api/v1/router/run.py
+++ b/data_rentgen/server/api/v1/router/run.py
@@ -31,9 +31,9 @@ async def runs(
         page_size=query_args.page_size,
         since=query_args.since,
         until=query_args.until,
-        run_ids=query_args.run_id,
+        run_ids=query_args.run_id,  # type: ignore[arg-type]
         job_id=query_args.job_id,
-        parent_run_id=query_args.parent_run_id,
+        parent_run_id=query_args.parent_run_id,  # type: ignore[arg-type]
         search_query=query_args.search_query,
     )
     return PageResponseV1[RunDetailedResponseV1].from_pagination(pagination)

--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -145,6 +145,10 @@ class LineageInputRelationV1(BaseModel):
         # pydantic models have reserved "schema" attribute, using alias
         serialization_alias="schema",
     )
+    schema_relevance_type: Literal["EXACT_MATCH", "LATEST_KNOWN"] | None = Field(
+        description="Relevance of schema",
+        default=None,
+    )
 
 
 class LineageOutputRelationV1(BaseModel):
@@ -160,6 +164,10 @@ class LineageOutputRelationV1(BaseModel):
         default=None,
         # pydantic models have reserved "schema" attribute, using alias
         serialization_alias="schema",
+    )
+    schema_relevance_type: Literal["EXACT_MATCH", "LATEST_KNOWN"] | None = Field(
+        description="Relevance of schema",
+        default=None,
     )
 
 

--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -128,7 +128,7 @@ class LineageIORelationSchemaFieldV1(BaseModel):
 class LineageIORelationSchemaV1(BaseModel):
     id: str = Field(description="Schema id", coerce_numbers_to_str=True)
     fields: list[LineageIORelationSchemaFieldV1] = Field(description="Schema fields")
-    schema_relevance_type: Literal["EXACT_MATCH", "LATEST_KNOWN"] | None = Field(
+    relevance_type: Literal["EXACT_MATCH", "LATEST_KNOWN"] | None = Field(
         description="Relevance of schema",
         default="LATEST_KNOWN",
     )

--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -128,7 +128,10 @@ class LineageIORelationSchemaFieldV1(BaseModel):
 class LineageIORelationSchemaV1(BaseModel):
     id: str = Field(description="Schema id", coerce_numbers_to_str=True)
     fields: list[LineageIORelationSchemaFieldV1] = Field(description="Schema fields")
-
+    schema_relevance_type: Literal["EXACT_MATCH", "LATEST_KNOWN"] | None = Field(
+        description="Relevance of schema",
+        default="LATEST_KNOWN",
+    )
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -145,10 +148,6 @@ class LineageInputRelationV1(BaseModel):
         # pydantic models have reserved "schema" attribute, using alias
         serialization_alias="schema",
     )
-    schema_relevance_type: Literal["EXACT_MATCH", "LATEST_KNOWN"] | None = Field(
-        description="Relevance of schema",
-        default=None,
-    )
 
 
 class LineageOutputRelationV1(BaseModel):
@@ -164,10 +163,6 @@ class LineageOutputRelationV1(BaseModel):
         default=None,
         # pydantic models have reserved "schema" attribute, using alias
         serialization_alias="schema",
-    )
-    schema_relevance_type: Literal["EXACT_MATCH", "LATEST_KNOWN"] | None = Field(
-        description="Relevance of schema",
-        default=None,
     )
 
 

--- a/data_rentgen/server/services/operation.py
+++ b/data_rentgen/server/services/operation.py
@@ -3,10 +3,10 @@
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Annotated
-from uuid import UUID
 
 from fastapi import Depends
 from sqlalchemy import Row
+from uuid6 import UUID
 
 from data_rentgen.db.models.operation import Operation
 from data_rentgen.dto.pagination import PaginationDTO

--- a/data_rentgen/server/services/run.py
+++ b/data_rentgen/server/services/run.py
@@ -3,10 +3,10 @@
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Annotated
-from uuid import UUID
 
 from fastapi import Depends
 from sqlalchemy import Row
+from uuid6 import UUID
 
 from data_rentgen.db.models.run import Run
 from data_rentgen.dto.pagination import PaginationDTO

--- a/data_rentgen/server/utils/lineage_response.py
+++ b/data_rentgen/server/utils/lineage_response.py
@@ -116,8 +116,9 @@ def _get_input_relations(inputs: dict[Any, InputRow]) -> list[LineageInputRelati
             num_rows=input_.num_rows,
             num_files=input_.num_files,
             i_schema=LineageIORelationSchemaV1.model_validate(input_.schema) if input_.schema else None,
-            schema_relevance_type=input_.schema_relevance_type,
         )
+        if relation.i_schema:
+            relation.i_schema.schema_relevance_type = input_.schema_relevance_type
         relations.append(relation)
 
     return sorted(relations, key=lambda x: (x.to.kind, str(x.from_.id), str(x.to.id)))
@@ -142,8 +143,9 @@ def _get_output_relations(outputs: dict[Any, OutputRow]) -> list[LineageOutputRe
             num_rows=output.num_rows,
             num_files=output.num_files,
             o_schema=LineageIORelationSchemaV1.model_validate(output.schema) if output.schema else None,
-            schema_relevance_type=output.schema_relevance_type,
         )
+        if relation.o_schema:
+            relation.o_schema.schema_relevance_type = output.schema_relevance_type
         relations.append(relation)
 
     return sorted(relations, key=lambda x: (x.from_.kind, str(x.from_.id), str(x.to.id), x.type))

--- a/data_rentgen/server/utils/lineage_response.py
+++ b/data_rentgen/server/utils/lineage_response.py
@@ -7,11 +7,11 @@ from typing import Any
 from uuid6 import UUID
 
 from data_rentgen.db.models.dataset_symlink import DatasetSymlink
-from data_rentgen.db.models.input import Input
 from data_rentgen.db.models.operation import Operation
-from data_rentgen.db.models.output import Output
 from data_rentgen.db.models.run import Run
 from data_rentgen.db.repositories.column_lineage import ColumnLineageRow
+from data_rentgen.db.repositories.input import InputRow
+from data_rentgen.db.repositories.output import OutputRow
 from data_rentgen.server.schemas.v1 import (
     ColumnLineageInteractionTypeV1,
     DatasetResponseV1,
@@ -98,7 +98,7 @@ def _get_symlink_relations(dataset_symlinks: dict[Any, DatasetSymlink]) -> list[
     return symlinks
 
 
-def _get_input_relations(inputs: dict[Any, Input]) -> list[LineageInputRelationV1]:
+def _get_input_relations(inputs: dict[Any, InputRow]) -> list[LineageInputRelationV1]:
     relations = []
     for input_ in inputs.values():
         if input_.operation_id is not None:
@@ -116,13 +116,14 @@ def _get_input_relations(inputs: dict[Any, Input]) -> list[LineageInputRelationV
             num_rows=input_.num_rows,
             num_files=input_.num_files,
             i_schema=LineageIORelationSchemaV1.model_validate(input_.schema) if input_.schema else None,
+            schema_relevance_type=input_.schema_relevance_type,
         )
         relations.append(relation)
 
     return sorted(relations, key=lambda x: (x.to.kind, str(x.from_.id), str(x.to.id)))
 
 
-def _get_output_relations(outputs: dict[Any, Output]) -> list[LineageOutputRelationV1]:
+def _get_output_relations(outputs: dict[Any, OutputRow]) -> list[LineageOutputRelationV1]:
     relations = []
     for output in outputs.values():
         if output.operation_id is not None:
@@ -141,6 +142,7 @@ def _get_output_relations(outputs: dict[Any, Output]) -> list[LineageOutputRelat
             num_rows=output.num_rows,
             num_files=output.num_files,
             o_schema=LineageIORelationSchemaV1.model_validate(output.schema) if output.schema else None,
+            schema_relevance_type=output.schema_relevance_type,
         )
         relations.append(relation)
 

--- a/data_rentgen/server/utils/lineage_response.py
+++ b/data_rentgen/server/utils/lineage_response.py
@@ -118,7 +118,7 @@ def _get_input_relations(inputs: dict[Any, InputRow]) -> list[LineageInputRelati
             i_schema=LineageIORelationSchemaV1.model_validate(input_.schema) if input_.schema else None,
         )
         if relation.i_schema:
-            relation.i_schema.schema_relevance_type = input_.schema_relevance_type
+            relation.i_schema.relevance_type = input_.schema_relevance_type
         relations.append(relation)
 
     return sorted(relations, key=lambda x: (x.to.kind, str(x.from_.id), str(x.to.id)))
@@ -145,7 +145,7 @@ def _get_output_relations(outputs: dict[Any, OutputRow]) -> list[LineageOutputRe
             o_schema=LineageIORelationSchemaV1.model_validate(output.schema) if output.schema else None,
         )
         if relation.o_schema:
-            relation.o_schema.schema_relevance_type = output.schema_relevance_type
+            relation.o_schema.relevance_type = output.schema_relevance_type
         relations.append(relation)
 
     return sorted(relations, key=lambda x: (x.from_.kind, str(x.from_.id), str(x.to.id), x.type))

--- a/docs/changelog/next_release/185.improvement.rst
+++ b/docs/changelog/next_release/185.improvement.rst
@@ -1,0 +1,132 @@
+Change logic for output/input dataset schema in lineage response.
+Add types of schema in response 'EXACT_MATCH' and 'LATEST_KNOWN'.
+
+'EXACT_MATCH' - when last and first(order by created_at ascending) schema_ids are the same.
+'LATEST_KNOWN' - when last and first are not the same, in this case last schema_id will return.
+
+
+from:
+
+.. code:: json
+"relations": {
+  "direct_column_lineage": [],
+  "indirect_column_lineage": [],
+  "inputs": [
+    {
+      "from": { "id": "2697", "kind": "DATASET" },
+      "last_interaction_at": "2025-03-14T15:22:30.572000Z",
+      "num_bytes": 13166146,
+      "num_files": 240,
+      "num_rows": 22793,
+      "schema": {
+        "fields": [
+          {
+            "description": null,
+            "fields": [],
+            "name": "dt",
+            "type": "timestamp"
+          },
+          {
+            "description": null,
+            "fields": [],
+            "name": "customer_id",
+            "type": "decimal(20,0)"
+          },
+          {
+            "description": null,
+            "fields": [],
+            "name": "total_spent",
+            "type": "float"
+          }
+        ],
+        "id": "1418"
+      },
+      "to": { "id": "1260", "kind": "JOB" }
+    },
+    {
+      "from": { "id": "3300", "kind": "DATASET" },
+      "last_interaction_at": "2025-03-17T08:45:58.439000Z",
+      "num_bytes": 13060345,
+      "num_files": 112,
+      "num_rows": 13723,
+      "schema": null,
+      "to": { "id": "0195a347-fa5f-7a72-aa14-bc510fadfd3a", "kind": "RUN" }
+    }
+  ]
+}
+
+
+
+to:
+
+.. code:: json
+"relations": {
+  "direct_column_lineage": [],
+  "indirect_column_lineage": [],
+  "inputs": [
+    {
+      "from": { "id": "2697", "kind": "DATASET" },
+      "last_interaction_at": "2025-03-14T15:22:30.572000Z",
+      "num_bytes": 13166146,
+      "num_files": 240,
+      "num_rows": 22793,
+      "schema": {
+        "fields": [
+          {
+            "description": null,
+            "fields": [],
+            "name": "dt",
+            "type": "timestamp"
+          },
+          {
+            "description": null,
+            "fields": [],
+            "name": "customer_id",
+            "type": "decimal(20,0)"
+          },
+          {
+            "description": null,
+            "fields": [],
+            "name": "total_spent",
+            "type": "float"
+          }
+        ],
+        "id": "1418"
+      },
+      "schema_relevance_type": "EXACT_MATCH",
+      "to": { "id": "1260", "kind": "JOB" }
+    },
+    {
+      "from": { "id": "3300", "kind": "DATASET" },
+      "last_interaction_at": "2025-03-17T08:45:58.439000Z",
+      "num_bytes": 13060345,
+      "num_files": 112,
+      "num_rows": 13723,
+      "schema": {
+        "fields": [
+          {
+            "description": null,
+            "fields": [],
+            "name": "dt",
+            "type": "timestamp"
+          },
+          {
+            "description": null,
+            "fields": [],
+            "name": "customer_id",
+            "type": "decimal(20,0)"
+          },
+          {
+            "description": null,
+            "fields": [],
+            "name": "total_spent",
+            "type": "float"
+          }
+        ],
+        "id": "1657"
+      },
+      "schema_relevance_type": "LATEST_KNOWN",
+      "to": { "id": "0195a347-fa5f-7a72-aa14-bc510fadfd3a", "kind": "RUN" }
+    }
+  ]
+}

--- a/docs/changelog/next_release/185.improvement.rst
+++ b/docs/changelog/next_release/185.improvement.rst
@@ -92,8 +92,8 @@ to:
           }
         ],
         "id": "1418"
+        "relevance_type": "EXACT_MATCH",
       },
-      "schema_relevance_type": "EXACT_MATCH",
       "to": { "id": "1260", "kind": "JOB" }
     },
     {
@@ -124,8 +124,8 @@ to:
           }
         ],
         "id": "1657"
+        "relevance_type": "LATEST_KNOWN",
       },
-      "schema_relevance_type": "LATEST_KNOWN",
       "to": { "id": "0195a347-fa5f-7a72-aa14-bc510fadfd3a", "kind": "RUN" }
     }
   ]

--- a/tests/test_server/utils/convert_to_json.py
+++ b/tests/test_server/utils/convert_to_json.py
@@ -65,7 +65,7 @@ def symlinks_to_json(symlinks: list[DatasetSymlink]):
     return [symlink_to_json(run) for run in sorted(symlinks, key=lambda x: x.id)]
 
 
-def schema_to_json(schema: Schema):
+def schema_to_json(schema: Schema, schema_relevance_type: str):
     return {
         "id": str(schema.id),
         "fields": [
@@ -76,6 +76,7 @@ def schema_to_json(schema: Schema):
             }
             for field in schema.fields
         ],
+        "schema_relevance_type": schema_relevance_type,
     }
 
 
@@ -97,9 +98,8 @@ def input_to_json(input: InputRow | Input, granularity: Literal["OPERATION", "RU
         "num_bytes": input.num_bytes,
         "num_rows": input.num_rows,
         "num_files": input.num_files,
-        "schema": schema_to_json(input.schema) if input.schema else None,
+        "schema": schema_to_json(input.schema, schema_relevance_type) if input.schema else None,
         "last_interaction_at": format_datetime(input.created_at),
-        "schema_relevance_type": schema_relevance_type,
     }
 
 
@@ -130,9 +130,8 @@ def output_to_json(output: OutputRow | Output, granularity: Literal["OPERATION",
         "num_bytes": output.num_bytes,
         "num_rows": output.num_rows,
         "num_files": output.num_files,
-        "schema": schema_to_json(output.schema) if output.schema else None,
+        "schema": schema_to_json(output.schema, schema_relevance_type) if output.schema else None,
         "last_interaction_at": format_datetime(output.created_at),
-        "schema_relevance_type": schema_relevance_type,
     }
 
 

--- a/tests/test_server/utils/convert_to_json.py
+++ b/tests/test_server/utils/convert_to_json.py
@@ -76,7 +76,7 @@ def schema_to_json(schema: Schema, schema_relevance_type: str):
             }
             for field in schema.fields
         ],
-        "schema_relevance_type": schema_relevance_type,
+        "relevance_type": schema_relevance_type,
     }
 
 


### PR DESCRIPTION
## Change Summary

Change logic for output/input dataset schema in lineage response.
Add types of schema in reponse 'EXACT_MATCH' and 'LATEST_KNOWN'.

'EXACT_MATCH' - when last and first(order by `created_at` ascending) schema_ids are the same.
'LATEST_KNOWN' - when last and first are not the same, in this case last schema_id will return.

## Related issue number

[DOP-23711]

## Checklist

* [ ] Commit message and PR title is comprehensive
* [ ] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [ ] My PR is ready to review.
