### PR TITLE
[DOP-24570] Exclude dataset symlinks with no inputs/outputs

### DIFF
--- a/docs/changelog/next_release/189.improvement.rst
+++ b/docs/changelog/next_release/189.improvement.rst
@@ -1,0 +1,1 @@
+Remove datasets and symlinks from lineage response which have no inputs or outputs.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Before - dataset symlinks are always included into lineage graph:
![Снимок экрана_20250318_142049-1](https://github.com/user-attachments/assets/0ebf9ab9-7b46-48b7-b20e-9c7ab58ed107)

After - dataset symlinks are included only of they have some input or output:
![Снимок экрана_20250318_141958-1](https://github.com/user-attachments/assets/a40afe21-3308-4978-93e2-98e9745b743b)

This reduces visual noise.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
