### PR TITLE
[DOP-25498] Do not restrict values of Job.type

### DIFF
--- a/data_rentgen/consumer/extractors/batch_extraction_result.py
+++ b/data_rentgen/consumer/extractors/batch_extraction_result.py
@@ -10,6 +10,7 @@ from data_rentgen.dto import (
     DatasetSymlinkDTO,
     InputDTO,
     JobDTO,
+    JobTypeDTO,
     LocationDTO,
     OperationDTO,
     OutputDTO,
@@ -25,6 +26,7 @@ T = TypeVar(
     ColumnLineageDTO,
     DatasetSymlinkDTO,
     JobDTO,
+    JobTypeDTO,
     RunDTO,
     OperationDTO,
     InputDTO,
@@ -56,6 +58,7 @@ class BatchExtractionResult:
         self._locations: dict[tuple, LocationDTO] = {}
         self._datasets: dict[tuple, DatasetDTO] = {}
         self._dataset_symlinks: dict[tuple, DatasetSymlinkDTO] = {}
+        self._job_types: dict[tuple, JobTypeDTO] = {}
         self._jobs: dict[tuple, JobDTO] = {}
         self._runs: dict[tuple, RunDTO] = {}
         self._operations: dict[tuple, OperationDTO] = {}
@@ -71,6 +74,7 @@ class BatchExtractionResult:
             f"locations={len(self._locations)}, "
             f"datasets={len(self._datasets)}, "
             f"dataset_symlinks={len(self._dataset_symlinks)}, "
+            f"job_types={len(self._job_types)}, "
             f"jobs={len(self._jobs)}, "
             f"runs={len(self._runs)}, "
             f"operations={len(self._operations)}, "
@@ -109,8 +113,13 @@ class BatchExtractionResult:
         dataset_symlink.to_dataset = self.add_dataset(dataset_symlink.to_dataset)
         return self._add(self._dataset_symlinks, dataset_symlink)
 
+    def add_job_type(self, job_type: JobTypeDTO):
+        return self._add(self._job_types, job_type)
+
     def add_job(self, job: JobDTO):
         job.location = self.add_location(job.location)
+        if job.type:
+            job.type = self.add_job_type(job.type)
         return self._add(self._jobs, job)
 
     def add_run(self, run: RunDTO):
@@ -171,9 +180,14 @@ class BatchExtractionResult:
         dataset_symlink.to_dataset = self.get_dataset(dataset_symlink.to_dataset.unique_key)
         return dataset_symlink
 
+    def get_job_type(self, job_type_key: tuple) -> JobTypeDTO:
+        return self._job_types[job_type_key]
+
     def get_job(self, job_key: tuple) -> JobDTO:
         job = self._jobs[job_key]
         job.location = self.get_location(job.location.unique_key)
+        if job.type:
+            job.type = self.get_job_type(job.type.unique_key)
         return job
 
     def get_run(self, run_key: tuple) -> RunDTO:
@@ -221,6 +235,9 @@ class BatchExtractionResult:
 
     def dataset_symlinks(self) -> list[DatasetSymlinkDTO]:
         return list(map(self.get_dataset_symlink, self._dataset_symlinks))
+
+    def job_types(self) -> list[JobTypeDTO]:
+        return list(map(self.get_job_type, self._job_types))
 
     def jobs(self) -> list[JobDTO]:
         return list(map(self.get_job, self._jobs))

--- a/data_rentgen/consumer/extractors/job.py
+++ b/data_rentgen/consumer/extractors/job.py
@@ -36,8 +36,9 @@ def extract_job_location(job: OpenLineageJob | OpenLineageParentJob) -> Location
 
 def extract_job_type(job: OpenLineageJob) -> JobTypeDTO | None:
     if job.facets.jobType:
-        job_type = job.facets.jobType.jobType
         integration_type = job.facets.jobType.integration
-        return JobTypeDTO(f"{integration_type}_{job_type}")
+        job_type = job.facets.jobType.jobType
+        type_ = f"{integration_type}_{job_type}" if job_type else integration_type
+        return JobTypeDTO(type=type_.upper())
 
     return None

--- a/data_rentgen/consumer/extractors/operation.py
+++ b/data_rentgen/consumer/extractors/operation.py
@@ -20,11 +20,15 @@ def extract_operation(event: OpenLineageRunEvent) -> OperationDTO:
         prefix = len(run.job.name) + 1
         operation_name = operation_name[prefix:]
 
+    type_: OperationTypeDTO = OperationTypeDTO.BATCH
+    if event.job.facets.jobType and event.job.facets.jobType.processingType:
+        type_ = OperationTypeDTO(event.job.facets.jobType.processingType)
+
     operation = OperationDTO(
         id=event.run.runId,  # type: ignore [arg-type]
         run=run,
         name=operation_name,
-        type=OperationTypeDTO(event.job.facets.jobType.processingType) if event.job.facets.jobType else None,
+        type=type_,
     )
     enrich_operation_status(operation, event)
     enrich_operation_description(operation, event)

--- a/data_rentgen/consumer/openlineage/job_facets/__init__.py
+++ b/data_rentgen/consumer/openlineage/job_facets/__init__.py
@@ -7,9 +7,7 @@ from data_rentgen.consumer.openlineage.job_facets.documentation import (
     OpenLineageDocumentationJobFacet,
 )
 from data_rentgen.consumer.openlineage.job_facets.job_type import (
-    OpenLineageJobIntegrationType,
     OpenLineageJobProcessingType,
-    OpenLineageJobType,
     OpenLineageJobTypeJobFacet,
 )
 
@@ -17,9 +15,7 @@ __all__ = [
     "OpenLineageDocumentationJobFacet",
     "OpenLineageJobFacet",
     "OpenLineageJobFacets",
-    "OpenLineageJobIntegrationType",
     "OpenLineageJobProcessingType",
-    "OpenLineageJobType",
     "OpenLineageJobTypeJobFacet",
 ]
 

--- a/data_rentgen/consumer/openlineage/job_facets/job_type.py
+++ b/data_rentgen/consumer/openlineage/job_facets/job_type.py
@@ -3,41 +3,7 @@
 
 from enum import Enum
 
-from pydantic import field_validator
-
 from data_rentgen.consumer.openlineage.job_facets.base import OpenLineageJobFacet
-
-
-class OpenLineageJobIntegrationType(str, Enum):
-    """Integration where job is running.
-    See [JobTypeJobFacet](https://github.com/OpenLineage/OpenLineage/blob/main/spec/facets/JobTypeJobFacet.json).
-    """
-
-    SPARK = "SPARK"
-    AIRFLOW = "AIRFLOW"
-
-    def __str__(self) -> str:
-        return self.value
-
-
-class OpenLineageJobType(str, Enum):
-    """Job type.
-    See [JobTypeJobFacet](https://github.com/OpenLineage/OpenLineage/blob/main/spec/facets/JobTypeJobFacet.json).
-    """
-
-    APPLICATION = "APPLICATION"
-    JOB = "JOB"
-    DAG = "DAG"
-    TASK = "TASK"
-
-    def __str__(self) -> str:
-        return self.value
-
-    @classmethod
-    def _missing_(cls, value):
-        if value in {"SQL_JOB", "RDD_JOB"}:
-            return cls.JOB
-        return None
 
 
 class OpenLineageJobProcessingType(str, Enum):
@@ -47,6 +13,7 @@ class OpenLineageJobProcessingType(str, Enum):
 
     BATCH = "BATCH"
     STREAMING = "STREAMING"
+    NONE = "NONE"
 
 
 class OpenLineageJobTypeJobFacet(OpenLineageJobFacet):
@@ -54,13 +21,6 @@ class OpenLineageJobTypeJobFacet(OpenLineageJobFacet):
     See [JobTypeJobFacet](https://github.com/OpenLineage/OpenLineage/blob/main/spec/facets/JobTypeJobFacet.json).
     """
 
-    integration: OpenLineageJobIntegrationType
-    jobType: OpenLineageJobType
-    processingType: OpenLineageJobProcessingType | None = None
-
-    @field_validator("processingType", mode="before")
-    @classmethod
-    def _validate_processing_type(cls, processing_type: str):
-        if processing_type == "NONE":
-            return None
-        return processing_type
+    processingType: OpenLineageJobProcessingType
+    integration: str
+    jobType: str | None = None

--- a/data_rentgen/consumer/subscribers.py
+++ b/data_rentgen/consumer/subscribers.py
@@ -65,7 +65,7 @@ async def extract_events(
             event = OpenLineageRunEventAdapter.validate_json(message.value)
             extractor.add_events([event])
         except (ValueError, TypeError):
-            logger.error(  # noqa: TRY400
+            logger.exception(
                 "Failed to parse message: ConsumerRecord(topic=%r, partition=%d, offset=%d)",
                 message.topic,
                 message.partition,
@@ -108,6 +108,12 @@ async def save_to_db(
         async with unit_of_work:
             dataset_symlink = await unit_of_work.dataset_symlink.create_or_update(dataset_symlink_dto)
             dataset_symlink_dto.id = dataset_symlink.id
+
+    logger.debug("Creating job types")
+    for job_type_dto in data.job_types():
+        async with unit_of_work:
+            job_type = await unit_of_work.job_type.get_or_create(job_type_dto)
+            job_type_dto.id = job_type.id
 
     logger.debug("Creating jobs")
     for job_dto in data.jobs():

--- a/data_rentgen/db/migrations/versions/2025-04-25_2d2fe3f2f348_add_job_type.py
+++ b/data_rentgen/db/migrations/versions/2025-04-25_2d2fe3f2f348_add_job_type.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2024-2025 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+"""Add job_type
+
+Revision ID: 2d2fe3f2f348
+Revises: 976168ee4f16
+Create Date: 2025-04-25 15:09:17.556969
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2d2fe3f2f348"
+down_revision = "976168ee4f16"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "job_type",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("type", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__job_type")),
+        sa.UniqueConstraint("type", name=op.f("uq__job_type__type")),
+    )
+    op.create_index(op.f("ix__job_type__type"), "job_type", ["type"], unique=False)
+
+    op.execute(
+        sa.text(
+            """
+        INSERT INTO
+            job_type (id, type)
+        VALUES
+            (0, 'UNKNOWN'),
+            (1, 'SPARK_APPLICATION'),
+            (2, 'AIRFLOW_DAG'),
+            (3, 'AIRFLOW_TASK');
+        """,
+        ),
+    )
+    op.execute(sa.text("ALTER SEQUENCE job_type_id_seq RESTART WITH 4;"))
+
+    op.execute(sa.text("LOCK TABLE job IN ACCESS EXCLUSIVE MODE;"))
+    op.drop_index("ix__job__type", table_name="job")
+    op.alter_column(
+        "job",
+        "type",
+        new_column_name="type_id",
+        existing_type=sa.String(length=32),
+        type_=sa.BigInteger(),
+        nullable=False,
+        postgresql_using="""
+            CASE
+                WHEN type = 'SPARK_APPLICATION'
+                    THEN 1
+                WHEN type = 'AIRFLOW_DAG'
+                    THEN 2
+                WHEN type = 'AIRFLOW_TASK'
+                    THEN 3
+                ELSE 0
+            END
+        """,
+    )
+    op.create_index(op.f("ix__job__type_id"), "job", ["type_id"], unique=False)
+    op.create_foreign_key(
+        op.f("fk__job__type_id__job_type"),
+        "job",
+        "job_type",
+        ["type_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("LOCK TABLE job IN ACCESS EXCLUSIVE MODE;"))
+    op.drop_constraint(op.f("fk__job__type_id__job_type"), "job", type_="foreignkey")
+    op.drop_index(op.f("ix__job__type_id"), table_name="job")
+    op.alter_column(
+        "job",
+        "type_id",
+        new_column_name="type",
+        existing_type=sa.BigInteger(),
+        type_=sa.String(length=32),
+        nullable=False,
+    )
+    op.execute(
+        sa.text(
+            """
+        UPDATE job
+        SET type = (SELECT job_type.type FROM job_type WHERE job_type.id = job.type);
+        """,
+        ),
+    )
+    op.create_index("ix__job__type", "job", ["type"], unique=False)
+
+    op.drop_index(op.f("ix__job_type__type"), table_name="job_type")
+    op.drop_table("job_type")

--- a/data_rentgen/db/models/__init__.py
+++ b/data_rentgen/db/models/__init__.py
@@ -13,7 +13,8 @@ from data_rentgen.db.models.dataset_column_relation import (
 )
 from data_rentgen.db.models.dataset_symlink import DatasetSymlink, DatasetSymlinkType
 from data_rentgen.db.models.input import Input
-from data_rentgen.db.models.job import Job, JobType
+from data_rentgen.db.models.job import Job
+from data_rentgen.db.models.job_type import JobType
 from data_rentgen.db.models.location import Location
 from data_rentgen.db.models.operation import Operation, OperationStatus, OperationType
 from data_rentgen.db.models.output import Output, OutputType

--- a/data_rentgen/db/models/job_type.py
+++ b/data_rentgen/db/models/job_type.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2024-2025 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from sqlalchemy import BigInteger, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from data_rentgen.db.models.base import Base
+
+
+class JobType(Base):
+    __tablename__ = "job_type"
+    __table_args__ = (UniqueConstraint("type"),)
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+
+    type: Mapped[str] = mapped_column(
+        String,
+        index=True,
+        nullable=False,
+        doc="Job type, e.g. SPARK_APPLICATION, AIRFLOW_DAG",
+    )

--- a/data_rentgen/db/repositories/job_type.py
+++ b/data_rentgen/db/repositories/job_type.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2024-2025 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+
+from sqlalchemy import (
+    select,
+)
+
+from data_rentgen.db.models import JobType
+from data_rentgen.db.repositories.base import Repository
+from data_rentgen.dto.job_type import JobTypeDTO
+
+
+class JobTypeRepository(Repository[JobType]):
+    async def get_or_create(self, job_type_dto: JobTypeDTO) -> JobType:
+        query = select(JobType).where(JobType.type == job_type_dto.type)
+        result = await self._session.scalar(query)
+        if not result:
+            # try one more time, but with lock acquired.
+            # if another worker already created the same row, just use it. if not - create with holding the lock.
+            await self._lock("job_type", job_type_dto.type)
+            result = await self._session.scalar(query)
+
+        if not result:
+            result = JobType(type=job_type_dto.type)
+            self._session.add(result)
+            await self._session.flush([result])
+        return result

--- a/data_rentgen/dto/__init__.py
+++ b/data_rentgen/dto/__init__.py
@@ -9,7 +9,8 @@ from data_rentgen.dto.dataset_column_relation import (
 )
 from data_rentgen.dto.dataset_symlink import DatasetSymlinkDTO, DatasetSymlinkTypeDTO
 from data_rentgen.dto.input import InputDTO
-from data_rentgen.dto.job import JobDTO, JobTypeDTO
+from data_rentgen.dto.job import JobDTO
+from data_rentgen.dto.job_type import JobTypeDTO
 from data_rentgen.dto.location import LocationDTO
 from data_rentgen.dto.operation import (
     OperationDTO,

--- a/data_rentgen/dto/job.py
+++ b/data_rentgen/dto/job.py
@@ -4,18 +4,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
 
+from data_rentgen.dto.job_type import JobTypeDTO
 from data_rentgen.dto.location import LocationDTO
-
-
-class JobTypeDTO(str, Enum):
-    AIRFLOW_DAG = "AIRFLOW_DAG"
-    AIRFLOW_TASK = "AIRFLOW_TASK"
-    SPARK_APPLICATION = "SPARK_APPLICATION"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 @dataclass
@@ -30,13 +21,19 @@ class JobDTO:
         return (self.location.unique_key, self.name)
 
     def merge(self, new: JobDTO) -> JobDTO:
-        if new.id is None and self.type == new.type:
+        if new.id is None:
             # jobs aren't changed that much, reuse them if possible
             return self
+
+        type_: JobTypeDTO | None
+        if new.type and self.type:  # noqa: SIM108
+            type_ = self.type.merge(new.type)
+        else:
+            type_ = new.type or self.type
 
         return JobDTO(
             location=self.location.merge(new.location),
             name=self.name,
-            type=new.type or self.type,
+            type=type_,
             id=new.id or self.id,
         )

--- a/data_rentgen/dto/job_type.py
+++ b/data_rentgen/dto/job_type.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2024-2025 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class JobTypeDTO:
+    type: str
+    id: int | None = field(default=None, compare=False)
+
+    @property
+    def unique_key(self) -> tuple:
+        return (self.type,)
+
+    def merge(self, new: JobTypeDTO) -> JobTypeDTO:
+        if new.id is None and self.type == new.type:
+            # job types aren't changed that much, reuse them if possible
+            return self
+
+        return JobTypeDTO(
+            type=new.type,
+            id=new.id or self.id,
+        )

--- a/data_rentgen/dto/operation.py
+++ b/data_rentgen/dto/operation.py
@@ -18,6 +18,12 @@ class OperationTypeDTO(str, Enum):
     def __str__(self) -> str:
         return str(self.value)
 
+    @classmethod
+    def _missing_(cls, value: object) -> OperationTypeDTO:
+        if value == "NONE":
+            return OperationTypeDTO.BATCH
+        return super()._missing_(value)
+
 
 class OperationStatusDTO(IntEnum):
     UNKNOWN = -1
@@ -32,7 +38,7 @@ class OperationDTO:
     id: UUID
     run: RunDTO
     name: str
-    type: OperationTypeDTO | None = None
+    type: OperationTypeDTO = OperationTypeDTO.BATCH
     position: int | None = None
     group: str | None = None
     description: str | None = None
@@ -49,7 +55,7 @@ class OperationDTO:
             id=self.id,
             run=self.run.merge(new.run),
             name=new.name or self.name,
-            type=new.type or self.type,
+            type=new.type,
             group=new.group or self.group,
             description=new.description or self.description,
             status=max(new.status, self.status),

--- a/data_rentgen/services/uow.py
+++ b/data_rentgen/services/uow.py
@@ -14,6 +14,7 @@ from data_rentgen.db.repositories.dataset_column_relation import (
 from data_rentgen.db.repositories.dataset_symlink import DatasetSymlinkRepository
 from data_rentgen.db.repositories.input import InputRepository
 from data_rentgen.db.repositories.job import JobRepository
+from data_rentgen.db.repositories.job_type import JobTypeRepository
 from data_rentgen.db.repositories.location import LocationRepository
 from data_rentgen.db.repositories.operation import OperationRepository
 from data_rentgen.db.repositories.output import OutputRepository
@@ -30,6 +31,7 @@ class UnitOfWork:
     ):
         self._session = session
         self.location = LocationRepository(session)
+        self.job_type = JobTypeRepository(session)
         self.job = JobRepository(session)
         self.run = RunRepository(session)
         self.operation = OperationRepository(session)

--- a/tests/test_consumer/test_extractors/fixtures/column_lineage_facets.py
+++ b/tests/test_consumer/test_extractors/fixtures/column_lineage_facets.py
@@ -17,9 +17,7 @@ from data_rentgen.consumer.openlineage.dataset_facets import (
 from data_rentgen.consumer.openlineage.job import OpenLineageJob
 from data_rentgen.consumer.openlineage.job_facets import (
     OpenLineageJobFacets,
-    OpenLineageJobIntegrationType,
     OpenLineageJobProcessingType,
-    OpenLineageJobType,
     OpenLineageJobTypeJobFacet,
 )
 from data_rentgen.consumer.openlineage.run import OpenLineageRun
@@ -241,9 +239,9 @@ def get_run_event_with_column_lineage(
             name="mysession.execute_some_command",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    jobType=OpenLineageJobType.JOB,
                     processingType=OpenLineageJobProcessingType.BATCH,
-                    integration=OpenLineageJobIntegrationType.SPARK,
+                    integration="SPARK",
+                    jobType="SQL_JOB",
                 ),
             ),
         ),

--- a/tests/test_consumer/test_extractors/fixtures/extracted_dto.py
+++ b/tests/test_consumer/test_extractors/fixtures/extracted_dto.py
@@ -178,7 +178,7 @@ def extracted_spark_app_job(
     return JobDTO(
         name="mysession",
         location=extracted_spark_location,
-        type=JobTypeDTO.SPARK_APPLICATION,
+        type=JobTypeDTO(type="SPARK_APPLICATION"),
     )
 
 
@@ -230,7 +230,6 @@ def extracted_postgres_input(
 @pytest.fixture
 def extracted_hive_output(
     extracted_spark_operation: OperationDTO,
-    extracted_hdfs_dataset: DatasetDTO,
     extracted_hive_dataset: DatasetDTO,
     extracted_dataset_schema: SchemaDTO,
 ) -> OutputDTO:

--- a/tests/test_consumer/test_extractors/test_extractors_batch_airflow.py
+++ b/tests/test_consumer/test_extractors/test_extractors_batch_airflow.py
@@ -8,8 +8,7 @@ from data_rentgen.consumer.extractors import BatchExtractor
 from data_rentgen.consumer.openlineage.job import OpenLineageJob
 from data_rentgen.consumer.openlineage.job_facets import (
     OpenLineageJobFacets,
-    OpenLineageJobIntegrationType,
-    OpenLineageJobType,
+    OpenLineageJobProcessingType,
     OpenLineageJobTypeJobFacet,
 )
 from data_rentgen.consumer.openlineage.run import OpenLineageRun
@@ -52,9 +51,9 @@ def airflow_dag_run_event_start() -> OpenLineageRunEvent:
             name="mydag",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.DAG,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="AIRFLOW",
+                    jobType="DAG",
                 ),
             ),
         ),
@@ -92,9 +91,9 @@ def airflow_dag_run_event_stop() -> OpenLineageRunEvent:
             name="mydag",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.DAG,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="AIRFLOW",
+                    jobType="DAG",
                 ),
             ),
         ),
@@ -123,9 +122,9 @@ def airflow_task_run_event_start() -> OpenLineageRunEvent:
             name="mydag.mytask",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.TASK,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="AIRFLOW",
+                    jobType="TASK",
                 ),
             ),
         ),
@@ -172,9 +171,9 @@ def airflow_task_run_event_stop() -> OpenLineageRunEvent:
             name="mydag.mytask",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.TASK,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="AIRFLOW",
+                    jobType="TASK",
                 ),
             ),
         ),
@@ -207,7 +206,7 @@ def extracted_airflow_dag_job(
     return JobDTO(
         name="mydag",
         location=extracted_airflow_location,
-        type=JobTypeDTO.AIRFLOW_DAG,
+        type=JobTypeDTO(type="AIRFLOW_DAG"),
     )
 
 
@@ -218,7 +217,7 @@ def extracted_airflow_task_job(
     return JobDTO(
         name="mydag.mytask",
         location=extracted_airflow_location,
-        type=JobTypeDTO.AIRFLOW_TASK,
+        type=JobTypeDTO(type="AIRFLOW_TASK"),
     )
 
 

--- a/tests/test_consumer/test_extractors/test_extractors_batch_spark.py
+++ b/tests/test_consumer/test_extractors/test_extractors_batch_spark.py
@@ -23,9 +23,7 @@ from data_rentgen.consumer.openlineage.dataset_facets import (
 from data_rentgen.consumer.openlineage.job import OpenLineageJob
 from data_rentgen.consumer.openlineage.job_facets import (
     OpenLineageJobFacets,
-    OpenLineageJobIntegrationType,
     OpenLineageJobProcessingType,
-    OpenLineageJobType,
     OpenLineageJobTypeJobFacet,
 )
 from data_rentgen.consumer.openlineage.run import OpenLineageRun
@@ -67,9 +65,9 @@ def spark_app_run_event_start() -> OpenLineageRunEvent:
             name="mysession",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.SPARK,
-                    jobType=OpenLineageJobType.APPLICATION,
+                    processingType=OpenLineageJobProcessingType.NONE,
+                    integration="SPARK",
+                    jobType="APPLICATION",
                 ),
             ),
         ),
@@ -102,9 +100,9 @@ def spark_app_run_event_stop() -> OpenLineageRunEvent:
             name="mysession",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.SPARK,
-                    jobType=OpenLineageJobType.APPLICATION,
+                    processingType=OpenLineageJobProcessingType.NONE,
+                    integration="SPARK",
+                    jobType="APPLICATION",
                 ),
             ),
         ),
@@ -125,9 +123,9 @@ def spark_operation_run_event_start() -> OpenLineageRunEvent:
             name="mysession.execute_some_command",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    jobType=OpenLineageJobType.JOB,
                     processingType=OpenLineageJobProcessingType.BATCH,
-                    integration=OpenLineageJobIntegrationType.SPARK,
+                    integration="SPARK",
+                    jobType="SQL_JOB",
                 ),
             ),
         ),
@@ -263,9 +261,9 @@ def spark_operation_run_event_running() -> OpenLineageRunEvent:
             name="mysession.execute_some_command",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    jobType=OpenLineageJobType.JOB,
                     processingType=OpenLineageJobProcessingType.BATCH,
-                    integration=OpenLineageJobIntegrationType.SPARK,
+                    integration="SPARK",
+                    jobType="SQL_JOB",
                 ),
             ),
         ),
@@ -407,9 +405,9 @@ def spark_operation_run_event_stop() -> OpenLineageRunEvent:
             name="mysession.execute_some_command",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    jobType=OpenLineageJobType.JOB,
                     processingType=OpenLineageJobProcessingType.BATCH,
-                    integration=OpenLineageJobIntegrationType.SPARK,
+                    integration="SPARK",
+                    jobType="SQL_JOB",
                 ),
             ),
         ),
@@ -630,9 +628,9 @@ def test_extractors_extract_batch_spark_strip_hdfs_partitions(extracted_hdfs_dat
             name="mysession.execute_some_command",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    jobType=OpenLineageJobType.JOB,
                     processingType=OpenLineageJobProcessingType.BATCH,
-                    integration=OpenLineageJobIntegrationType.SPARK,
+                    integration="SPARK",
+                    jobType="SQL_JOB",
                 ),
             ),
         ),

--- a/tests/test_consumer/test_extractors/test_extractors_operation.py
+++ b/tests/test_consumer/test_extractors/test_extractors_operation.py
@@ -9,9 +9,7 @@ from data_rentgen.consumer.extractors import extract_operation
 from data_rentgen.consumer.openlineage.job import OpenLineageJob
 from data_rentgen.consumer.openlineage.job_facets import (
     OpenLineageJobFacets,
-    OpenLineageJobIntegrationType,
     OpenLineageJobProcessingType,
-    OpenLineageJobType,
     OpenLineageJobTypeJobFacet,
 )
 from data_rentgen.consumer.openlineage.run import OpenLineageRun
@@ -46,9 +44,9 @@ def test_extractors_extract_operation_spark_job_no_details():
             name="mysession.execute_some_command",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    jobType=OpenLineageJobType.JOB,
                     processingType=OpenLineageJobProcessingType.BATCH,
-                    integration=OpenLineageJobIntegrationType.SPARK,
+                    integration="SPARK",
+                    jobType="SQL_JOB",
                 ),
             ),
         ),
@@ -125,9 +123,9 @@ def test_extractors_extract_operation_spark_job_with_details(
             name="mysession.execute_some_command",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    jobType=OpenLineageJobType.JOB,
                     processingType=OpenLineageJobProcessingType.STREAMING,
-                    integration=OpenLineageJobIntegrationType.SPARK,
+                    integration="SPARK",
+                    jobType="SQL_JOB",
                 ),
             ),
         ),
@@ -191,9 +189,9 @@ def test_extractors_extract_operation_spark_job_name_contains_newlines():
             """,
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    jobType=OpenLineageJobType.JOB,
                     processingType=OpenLineageJobProcessingType.BATCH,
-                    integration=OpenLineageJobIntegrationType.SPARK,
+                    integration="SPARK",
+                    jobType="SQL_JOB",
                 ),
             ),
         ),
@@ -255,7 +253,17 @@ def test_extractors_extract_operation_spark_job_finished(
     operation = OpenLineageRunEvent(
         eventType=event_type,
         eventTime=now,
-        job=OpenLineageJob(namespace="anything", name="mysession.execute_some_command"),
+        job=OpenLineageJob(
+            namespace="anything",
+            name="mysession.execute_some_command",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="SPARK",
+                    jobType="SQL_JOB",
+                ),
+            ),
+        ),
         run=OpenLineageRun(
             runId=operation_id,
             facets=OpenLineageRunFacets(
@@ -287,7 +295,7 @@ def test_extractors_extract_operation_spark_job_finished(
             ),
         ),
         name="execute_some_command",
-        type=None,
+        type=OperationTypeDTO.BATCH,
         position=None,
         description=None,
         status=expected_status,

--- a/tests/test_consumer/test_extractors/test_extractors_run.py
+++ b/tests/test_consumer/test_extractors/test_extractors_run.py
@@ -8,8 +8,7 @@ from data_rentgen.consumer.extractors import extract_run
 from data_rentgen.consumer.openlineage.job import OpenLineageJob
 from data_rentgen.consumer.openlineage.job_facets import (
     OpenLineageJobFacets,
-    OpenLineageJobIntegrationType,
-    OpenLineageJobType,
+    OpenLineageJobProcessingType,
     OpenLineageJobTypeJobFacet,
 )
 from data_rentgen.consumer.openlineage.run import OpenLineageRun
@@ -55,9 +54,9 @@ def test_extractors_extract_run_spark_app_yarn():
             name="myjob",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.SPARK,
-                    jobType=OpenLineageJobType.APPLICATION,
+                    processingType=OpenLineageJobProcessingType.NONE,
+                    integration="SPARK",
+                    jobType="APPLICATION",
                 ),
             ),
         ),
@@ -83,7 +82,7 @@ def test_extractors_extract_run_spark_app_yarn():
         job=JobDTO(
             name="myjob",
             location=LocationDTO(type="yarn", name="cluster", addresses={"yarn://cluster"}),
-            type=JobTypeDTO.SPARK_APPLICATION,
+            type=JobTypeDTO(type="SPARK_APPLICATION"),
         ),
         status=RunStatusDTO.STARTED,
         started_at=now,
@@ -108,9 +107,9 @@ def test_extractors_extract_run_spark_app_local():
             name="myjob",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.SPARK,
-                    jobType=OpenLineageJobType.APPLICATION,
+                    processingType=OpenLineageJobProcessingType.NONE,
+                    integration="SPARK",
+                    jobType="APPLICATION",
                 ),
             ),
         ),
@@ -135,7 +134,7 @@ def test_extractors_extract_run_spark_app_local():
         job=JobDTO(
             name="myjob",
             location=LocationDTO(type="host", name="some.host.com", addresses={"host://some.host.com"}),
-            type=JobTypeDTO.SPARK_APPLICATION,
+            type=JobTypeDTO(type="SPARK_APPLICATION"),
         ),
         status=RunStatusDTO.STARTED,
         started_at=None,
@@ -159,9 +158,9 @@ def test_extractors_extract_run_airflow_dag_2_3_plus():
             name="mydag",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.DAG,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="AIRFLOW",
+                    jobType="DAG",
                 ),
             ),
         ),
@@ -195,7 +194,7 @@ def test_extractors_extract_run_airflow_dag_2_3_plus():
                 name="airflow-host:8081",
                 addresses={"http://airflow-host:8081"},
             ),
-            type=JobTypeDTO.AIRFLOW_DAG,
+            type=JobTypeDTO(type="AIRFLOW_DAG"),
         ),
         status=RunStatusDTO.SUCCEEDED,
         started_at=None,
@@ -222,9 +221,9 @@ def test_extractors_extract_run_airflow_dag_2_x():
             name="mydag",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.DAG,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="AIRFLOW",
+                    jobType="DAG",
                 ),
             ),
         ),
@@ -258,7 +257,7 @@ def test_extractors_extract_run_airflow_dag_2_x():
                 name="airflow-host:8081",
                 addresses={"http://airflow-host:8081"},
             ),
-            type=JobTypeDTO.AIRFLOW_DAG,
+            type=JobTypeDTO(type="AIRFLOW_DAG"),
         ),
         status=RunStatusDTO.SUCCEEDED,
         started_at=None,
@@ -285,9 +284,9 @@ def test_extractors_extract_run_airflow_task_with_ti_persistent_log_url():
             name="mydag.mytask",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.TASK,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="AIRFLOW",
+                    jobType="TASK",
                 ),
             ),
         ),
@@ -330,7 +329,7 @@ def test_extractors_extract_run_airflow_task_with_ti_persistent_log_url():
                 name="airflow-host:8081",
                 addresses={"http://airflow-host:8081"},
             ),
-            type=JobTypeDTO.AIRFLOW_TASK,
+            type=JobTypeDTO(type="AIRFLOW_TASK"),
         ),
         status=RunStatusDTO.SUCCEEDED,
         started_at=None,
@@ -357,9 +356,9 @@ def test_extractors_extract_run_airflow_task_2_9_plus():
             name="mydag.mytask",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.TASK,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="AIRFLOW",
+                    jobType="TASK",
                 ),
             ),
         ),
@@ -399,7 +398,7 @@ def test_extractors_extract_run_airflow_task_2_9_plus():
                 name="airflow-host:8081",
                 addresses={"http://airflow-host:8081"},
             ),
-            type=JobTypeDTO.AIRFLOW_TASK,
+            type=JobTypeDTO(type="AIRFLOW_TASK"),
         ),
         status=RunStatusDTO.SUCCEEDED,
         started_at=None,
@@ -426,9 +425,9 @@ def test_extractors_extract_run_airflow_task_2_x():
             name="mydag.mytask",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.TASK,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="AIRFLOW",
+                    jobType="TASK",
                 ),
             ),
         ),
@@ -463,7 +462,7 @@ def test_extractors_extract_run_airflow_task_2_x():
                 name="airflow-host:8081",
                 addresses={"http://airflow-host:8081"},
             ),
-            type=JobTypeDTO.AIRFLOW_TASK,
+            type=JobTypeDTO(type="AIRFLOW_TASK"),
         ),
         status=RunStatusDTO.SUCCEEDED,
         started_at=None,
@@ -490,9 +489,9 @@ def test_extractors_extract_run_airflow_dag_check_with_owner():
             name="mydag",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.DAG,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="AIRFLOW",
+                    jobType="DAG",
                 ),
             ),
         ),
@@ -526,7 +525,7 @@ def test_extractors_extract_run_airflow_dag_check_with_owner():
                 name="airflow-host:8081",
                 addresses={"http://airflow-host:8081"},
             ),
-            type=JobTypeDTO.AIRFLOW_DAG,
+            type=JobTypeDTO(type="AIRFLOW_DAG"),
         ),
         status=RunStatusDTO.SUCCEEDED,
         started_at=None,
@@ -553,9 +552,9 @@ def test_extractors_extract_run_airflow_task_with_owner():
             name="mydag.mytask",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.TASK,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="AIRFLOW",
+                    jobType="TASK",
                 ),
             ),
         ),
@@ -590,7 +589,7 @@ def test_extractors_extract_run_airflow_task_with_owner():
                 name="airflow-host:8081",
                 addresses={"http://airflow-host:8081"},
             ),
-            type=JobTypeDTO.AIRFLOW_TASK,
+            type=JobTypeDTO(type="AIRFLOW_TASK"),
         ),
         status=RunStatusDTO.SUCCEEDED,
         started_at=None,
@@ -617,9 +616,9 @@ def test_extractors_extract_run_airflow_dag_without_owner():
             name="mydag",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.DAG,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="AIRFLOW",
+                    jobType="DAG",
                 ),
             ),
         ),
@@ -653,7 +652,7 @@ def test_extractors_extract_run_airflow_dag_without_owner():
                 name="airflow-host:8081",
                 addresses={"http://airflow-host:8081"},
             ),
-            type=JobTypeDTO.AIRFLOW_DAG,
+            type=JobTypeDTO(type="AIRFLOW_DAG"),
         ),
         status=RunStatusDTO.SUCCEEDED,
         started_at=None,
@@ -680,9 +679,9 @@ def test_extractors_extract_run_airflow_task_without_owner():
             name="mydag.mytask",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.TASK,
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="AIRFLOW",
+                    jobType="TASK",
                 ),
             ),
         ),
@@ -717,7 +716,7 @@ def test_extractors_extract_run_airflow_task_without_owner():
                 name="airflow-host:8081",
                 addresses={"http://airflow-host:8081"},
             ),
-            type=JobTypeDTO.AIRFLOW_TASK,
+            type=JobTypeDTO(type="AIRFLOW_TASK"),
         ),
         status=RunStatusDTO.SUCCEEDED,
         started_at=None,

--- a/tests/test_consumer/test_handlers/test_runs_handler_airflow.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_airflow.py
@@ -11,7 +11,6 @@ from uuid6 import UUID
 
 from data_rentgen.db.models import (
     Job,
-    JobType,
     Location,
     Operation,
     Run,
@@ -66,11 +65,11 @@ async def test_runs_handler_airflow(
     assert jobs[0].location.name == "airflow-host:8081"
     assert len(jobs[0].location.addresses) == 1
     assert jobs[0].location.addresses[0].url == "http://airflow-host:8081"
-    assert jobs[0].type == JobType.AIRFLOW_DAG
+    assert jobs[0].type == "AIRFLOW_DAG"
 
     assert jobs[1].name == "mydag.mytask"
     assert jobs[1].location == jobs[0].location
-    assert jobs[1].type == JobType.AIRFLOW_TASK
+    assert jobs[1].type == "AIRFLOW_TASK"
 
     run_query = select(Run).order_by(Run.id)
     run_scalars = await async_session.scalars(run_query)

--- a/tests/test_consumer/test_handlers/test_runs_handler_spark.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_spark.py
@@ -18,7 +18,6 @@ from data_rentgen.db.models import (
     DatasetSymlinkType,
     Input,
     Job,
-    JobType,
     Location,
     Operation,
     OperationStatus,
@@ -75,7 +74,7 @@ async def test_runs_handler_spark(
     assert jobs[0].location.name == "some.host.name"
     assert len(jobs[0].location.addresses) == 1
     assert jobs[0].location.addresses[0].url == "local://some.host.name"
-    assert jobs[0].type == JobType.SPARK_APPLICATION
+    assert jobs[0].type == "SPARK_APPLICATION"
 
     run_query = select(Run).order_by(Run.id).options(selectinload(Run.started_by_user))
     run_scalars = await async_session.scalars(run_query)

--- a/tests/test_consumer/test_openlineage/test_run_event_airflow.py
+++ b/tests/test_consumer/test_openlineage/test_run_event_airflow.py
@@ -7,9 +7,7 @@ from uuid6 import UUID
 from data_rentgen.consumer.openlineage.job import OpenLineageJob
 from data_rentgen.consumer.openlineage.job_facets import (
     OpenLineageJobFacets,
-    OpenLineageJobIntegrationType,
     OpenLineageJobProcessingType,
-    OpenLineageJobType,
     OpenLineageJobTypeJobFacet,
 )
 from data_rentgen.consumer.openlineage.job_facets.documentation import (
@@ -135,8 +133,8 @@ def test_run_event_airflow_dag_start():
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
                     processingType=OpenLineageJobProcessingType.BATCH,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.DAG,
+                    integration="AIRFLOW",
+                    jobType="DAG",
                 ),
                 documentation=OpenLineageDocumentationJobFacet(
                     description="some description",
@@ -210,8 +208,8 @@ def test_run_event_airflow_dag_end():
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
                     processingType=OpenLineageJobProcessingType.BATCH,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.DAG,
+                    integration="AIRFLOW",
+                    jobType="DAG",
                 ),
             ),
             # unknown facets are ignored
@@ -375,8 +373,8 @@ def test_run_event_airflow_task_start():
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
                     processingType=OpenLineageJobProcessingType.BATCH,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.TASK,
+                    integration="AIRFLOW",
+                    jobType="TASK",
                 ),
                 # unknown facets are ignored
             ),
@@ -504,8 +502,8 @@ def test_run_event_airflow_task_complete():
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
                     processingType=OpenLineageJobProcessingType.BATCH,
-                    integration=OpenLineageJobIntegrationType.AIRFLOW,
-                    jobType=OpenLineageJobType.TASK,
+                    integration="AIRFLOW",
+                    jobType="TASK",
                 ),
             ),
         ),

--- a/tests/test_consumer/test_openlineage/test_run_event_spark.py
+++ b/tests/test_consumer/test_openlineage/test_run_event_spark.py
@@ -28,9 +28,7 @@ from data_rentgen.consumer.openlineage.dataset_facets import (
 from data_rentgen.consumer.openlineage.job import OpenLineageJob
 from data_rentgen.consumer.openlineage.job_facets import (
     OpenLineageJobFacets,
-    OpenLineageJobIntegrationType,
     OpenLineageJobProcessingType,
-    OpenLineageJobType,
     OpenLineageJobTypeJobFacet,
 )
 from data_rentgen.consumer.openlineage.run import OpenLineageRun
@@ -120,9 +118,9 @@ def test_run_event_spark_application_start():
             name="spark_session",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.SPARK,
-                    jobType=OpenLineageJobType.APPLICATION,
+                    processingType=OpenLineageJobProcessingType.NONE,
+                    integration="SPARK",
+                    jobType="APPLICATION",
                 ),
             ),
         ),
@@ -206,9 +204,9 @@ def test_run_event_spark_application_stop():
             name="spark_session",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
-                    processingType=None,
-                    integration=OpenLineageJobIntegrationType.SPARK,
-                    jobType=OpenLineageJobType.APPLICATION,
+                    processingType=OpenLineageJobProcessingType.NONE,
+                    integration="SPARK",
+                    jobType="APPLICATION",
                 ),
             ),
         ),
@@ -440,8 +438,8 @@ def test_run_event_spark_job_running():
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
                     processingType=OpenLineageJobProcessingType.BATCH,
-                    integration=OpenLineageJobIntegrationType.SPARK,
-                    jobType=OpenLineageJobType.JOB,
+                    integration="SPARK",
+                    jobType="SQL_JOB",
                 ),
             ),
         ),

--- a/tests/test_server/fixtures/factories/job_type.py
+++ b/tests/test_server/fixtures/factories/job_type.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from random import choice, randint
+from typing import TYPE_CHECKING, Callable
+
+import pytest_asyncio
+from sqlalchemy import select
+
+from data_rentgen.db.models import JobType
+from tests.test_server.utils.delete import clean_db
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+    from contextlib import AbstractAsyncContextManager
+
+    import pytest
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def job_type_factory(**kwargs):
+    data = {
+        "id": randint(0, 10000000),
+        "type": choice(["SPARK_APPLICATION", "AIRFLOW_DAG", "AIRFLOW_TASK", "UNKNOWN_SOMETHING"]),
+    }
+    data.update(kwargs)
+    return JobType(**data)
+
+
+async def create_job_type(
+    async_session: AsyncSession,
+    job_type_kwargs: dict | None = None,
+) -> JobType:
+    job_type_kwargs = job_type_kwargs or {}
+    job_type = job_type_factory(**job_type_kwargs)
+    del job_type.id
+    job_type_real = await async_session.scalar(select(JobType).where(JobType.type == job_type.type))
+    if job_type_real:
+        return job_type_real
+
+    async_session.add(job_type)
+    await async_session.commit()
+    await async_session.refresh(job_type)
+    return job_type
+
+
+@pytest_asyncio.fixture(params=[{}])
+async def new_job_type(
+    request: pytest.FixtureRequest,
+) -> AsyncGenerator[JobType, None]:
+    params = request.param
+    item = job_type_factory(**params)
+
+    yield item
+
+
+@pytest_asyncio.fixture(params=[{}])
+async def job_type(
+    request: pytest.FixtureRequest,
+    async_session_maker: Callable[[], AbstractAsyncContextManager[AsyncSession]],
+) -> AsyncGenerator[JobType, None]:
+    params = request.param
+
+    async with async_session_maker() as async_session:
+        item = await create_job_type(async_session, job_type_kwargs=params)
+
+        async_session.expunge_all()
+
+    yield item
+
+    async with async_session_maker() as async_session:
+        await clean_db(async_session)
+
+
+@pytest_asyncio.fixture(params=[(5, {})])
+async def job_types(
+    request: pytest.FixtureRequest,
+    async_session_maker: Callable[[], AbstractAsyncContextManager[AsyncSession]],
+) -> AsyncGenerator[list[JobType], None]:
+    size, params = request.param
+
+    async with async_session_maker() as async_session:
+        items = []
+        for _ in range(size):
+            item = await create_job_type(async_session, **params)
+            items.append(item)
+
+        async_session.expunge_all()
+
+    yield items
+
+    async with async_session_maker() as async_session:
+        await clean_db(async_session)

--- a/tests/test_server/fixtures/factories/lineage.py
+++ b/tests/test_server/fixtures/factories/lineage.py
@@ -12,6 +12,7 @@ from data_rentgen.db.utils.uuid import generate_static_uuid
 from tests.test_server.fixtures.factories.dataset import create_dataset, make_symlink
 from tests.test_server.fixtures.factories.input import create_input
 from tests.test_server.fixtures.factories.job import create_job
+from tests.test_server.fixtures.factories.job_type import create_job_type
 from tests.test_server.fixtures.factories.location import create_location
 from tests.test_server.fixtures.factories.operation import create_operation
 from tests.test_server.fixtures.factories.output import create_output
@@ -223,7 +224,8 @@ async def lineage_with_depth(
         # Create a job, run and operation with IO datasets.
         for i in range(num_jobs):
             job_location = await create_location(async_session)
-            job = await create_job(async_session, location_id=job_location.id)
+            job_type = await create_job_type(async_session)
+            job = await create_job(async_session, location_id=job_location.id, job_type_id=job_type.id)
             lineage.jobs.append(job)
 
             run = await create_run(
@@ -304,7 +306,8 @@ async def cyclic_lineage(
             from_dataset, to_dataset = (datasets[0], datasets[1]) if i == 0 else (datasets[1], datasets[0])
 
             job_location = await create_location(async_session)
-            job = await create_job(async_session, location_id=job_location.id)
+            job_type = await create_job_type(async_session)
+            job = await create_job(async_session, location_id=job_location.id, job_type_id=job_type.id)
             lineage.jobs.append(job)
 
             run = await create_run(
@@ -391,7 +394,8 @@ async def duplicated_lineage(
         # Create a job, run and operation with IO datasets.
         for i in range(num_jobs):
             job_location = await create_location(async_session)
-            job = await create_job(async_session, location_id=job_location.id)
+            job_type = await create_job_type(async_session)
+            job = await create_job(async_session, location_id=job_location.id, job_type_id=job_type.id)
             lineage.jobs.append(job)
 
             runs = [
@@ -493,8 +497,14 @@ async def branchy_lineage(
         lineage.datasets.extend(datasets)
 
         job_locations = [await create_location(async_session) for _ in range(num_jobs)]
+        job_type = await create_job_type(async_session)
         jobs = [
-            await create_job(async_session, location_id=job_location.id, job_kwargs={"name": f"job_{i}"})
+            await create_job(
+                async_session,
+                location_id=job_location.id,
+                job_type_id=job_type.id,
+                job_kwargs={"name": f"job_{i}"},
+            )
             for i, job_location in enumerate(job_locations)
         ]
         lineage.jobs.extend(jobs)
@@ -637,7 +647,8 @@ async def lineage_with_symlinks(
         # Make graphs
         for i in range(num_jobs):
             job_location = await create_location(async_session)
-            job = await create_job(async_session, location_id=job_location.id)
+            job_type = await create_job_type(async_session)
+            job = await create_job(async_session, location_id=job_location.id, job_type_id=job_type.id)
             lineage.jobs.append(job)
 
             run = await create_run(

--- a/tests/test_server/fixtures/factories/run.py
+++ b/tests/test_server/fixtures/factories/run.py
@@ -10,6 +10,7 @@ from data_rentgen.db.models import Job, Run, RunStartReason, RunStatus, User
 from data_rentgen.db.utils.uuid import extract_timestamp_from_uuid, generate_new_uuid
 from tests.test_server.fixtures.factories.base import random_datetime, random_string
 from tests.test_server.fixtures.factories.job import create_job
+from tests.test_server.fixtures.factories.job_type import create_job_type
 from tests.test_server.fixtures.factories.location import create_location
 from tests.test_server.utils.delete import clean_db
 
@@ -202,10 +203,12 @@ async def runs_search(
         jobs = []
         for kwargs in job_kwargs:
             location = await create_location(async_session)
+            job_type = await create_job_type(async_session, job_type_kwargs={"type": kwargs["type"]})
             jobs.append(
                 await create_job(
                     async_session,
                     location_id=location.id,
+                    job_type_id=job_type.id,
                     job_kwargs=kwargs,
                 ),
             )

--- a/tests/test_server/utils/convert_to_json.py
+++ b/tests/test_server/utils/convert_to_json.py
@@ -178,7 +178,7 @@ def job_to_json(job: Job):
     return {
         "id": str(job.id),
         "name": job.name,
-        "type": job.type.value,
+        "type": job.type,
         "location": location_to_json(job.location),
     }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

`JobType` enum has hard-coded values like `SPARK_APPLICATION` which prevents using DataRentgen with other OpenLineage integrations (e.g. Flink). Replace it with a small table `job_type` with just one unique column `type: string` there all the unique types are stored (in format `INTEGRATION_SMTH` or `INTEGRATION`). Column `Job.type: text` was converted to `Job.type_id: bigint`.

Also updated field types in `jobType` facet. `processingType` field is mandatory, and instead of null/None it is passed as string `NONE`. `jobType` field is actually optional.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
