### PR TITLE
[DOP-26646] Properly track long running operations progress

### DIFF
--- a/data_rentgen/consumer/extractors/generic/__init__.py
+++ b/data_rentgen/consumer/extractors/generic/__init__.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2024-2025 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import timedelta
+
 from data_rentgen.consumer.extractors.generic.column_lineage import ColumnLineageExtractorMixin
 from data_rentgen.consumer.extractors.generic.dataset import DatasetExtractorMixin
 from data_rentgen.consumer.extractors.generic.io import IOExtractorMixin
@@ -28,3 +30,7 @@ class GenericExtractor(
 
     Designed to be inherited by implementation-specific classes.
     """
+
+    def __init__(self, io_time_resolution: timedelta = timedelta(hours=1)):
+        super().__init__()
+        self.io_time_resolution = io_time_resolution

--- a/data_rentgen/consumer/extractors/generic/io.py
+++ b/data_rentgen/consumer/extractors/generic/io.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import datetime, timedelta
 
 from data_rentgen.consumer.openlineage.dataset import (
     OpenLineageDataset,
@@ -12,6 +13,7 @@ from data_rentgen.consumer.openlineage.dataset import (
 from data_rentgen.consumer.openlineage.dataset_facets import (
     OpenLineageSchemaField,
 )
+from data_rentgen.consumer.openlineage.run_event import OpenLineageRunEvent
 from data_rentgen.dto import (
     DatasetDTO,
     DatasetSymlinkDTO,
@@ -28,21 +30,72 @@ WAREHOUSE = DatasetSymlinkTypeDTO.WAREHOUSE
 
 
 class IOExtractorMixin(ABC):
+    io_time_resolution = timedelta(hours=1)
+
     @abstractmethod
     def extract_dataset_and_symlinks(self, dataset: OpenLineageDataset) -> tuple[DatasetDTO, list[DatasetSymlinkDTO]]:
         pass
+
+    def extract_io_created_at(self, operation: OperationDTO, event: OpenLineageRunEvent) -> datetime:
+        """
+        Get `created_at` for input/output/column lineage rows.
+
+        For short living operations we create one input/output/column lineage row per operation+dataset,
+        and just update the same row every time we receive an event with same operation,
+        to store new number of rows/bytes/files.
+
+        For long running operations (mostly streaming), this behavior lead to the following situation:
+        * Flink job started 01.05.2025, sending a `START` event.
+        * This lead to creating input/output with `created_at=2025-05-01`
+        * For every checkpoint interval (60 seconds) OpenLineage sends `RUNNING` event,
+          which only updates IO statistics columns
+        * User fetches lineage graph for this job with `since=2025-06-20` (week ago).
+        * Because `input.created_at`/`output.created_at` don't match `since`,
+          there is no lineage for this Flink job for this interval.
+          But Flink job is working, it is not dead, it performs some IO and sends us OpenLineage events.
+
+        Creating a new input/output/column lineage row every received event
+        (`START`, `RUNNING`, `RUNNING`, ..., `RUNNING`, `COMPLETE`) will flood the database with useless data,
+        as most of these rows will be skipped during lineage graph resolution.
+
+        Creating new rows only for STREAMING operations will not solve the problem,
+        because there are long running BATCH jobs as well which produce RUNNING events.
+
+        So we create new input/output/column lineage for *every hour* since operation was started.
+        Rows look like that:
+        |==================|==============|============|==========|===========|===========|
+        | created_at       | operation_id | dataset_id | num_rows | num_files | num_bytes |
+        |------------------|--------------|------------|----------|-----------|-----------|
+        | 2025-06-20 00:00 | operation1   | dataset1   | 0        | 0         | 0         |
+        | 2025-06-20 01:00 | operation1   | dataset1   | 15       | 0         | 1_000     |
+        | 2025-06-20 02:00 | operation1   | dataset1   | 30       | 0         | 2_000     |
+        | 2025-06-20 03:00 | operation1   | dataset1   | 45       | 0         | 3_000     |
+        |==================|==============|============|==========|===========|===========|
+
+        Time resolution is hardcoded, but can be made configurable in future.
+        """
+        if operation.created_at > event.eventTime:
+            # avoid moving back in time
+            return operation.created_at
+
+        since_start = event.eventTime - operation.created_at
+        whole_ticks_since_start = since_start // self.io_time_resolution
+        return operation.created_at + whole_ticks_since_start * self.io_time_resolution
 
     def extract_input(
         self,
         operation: OperationDTO,
         dataset: OpenLineageInputDataset,
+        event: OpenLineageRunEvent,
     ) -> tuple[InputDTO, list[DatasetSymlinkDTO]]:
         """
         Extract InputDTO with optional symlinks
         """
         resolved_dataset_dto, symlinks = self.extract_dataset_and_symlinks(dataset)
+        created_at = self.extract_io_created_at(operation, event)
 
         result = InputDTO(
+            created_at=created_at,
             operation=operation,
             dataset=resolved_dataset_dto,
             schema=self.extract_schema(dataset),
@@ -57,13 +110,16 @@ class IOExtractorMixin(ABC):
         self,
         operation: OperationDTO,
         dataset: OpenLineageOutputDataset,
+        event: OpenLineageRunEvent,
     ) -> tuple[OutputDTO, list[DatasetSymlinkDTO]]:
         """
         Extract OutputDTO with optional symlinks
         """
         resolved_dataset_dto, symlinks = self.extract_dataset_and_symlinks(dataset)
+        created_at = self.extract_io_created_at(operation, event)
 
         result = OutputDTO(
+            created_at=created_at,
             operation=operation,
             dataset=resolved_dataset_dto,
             type=self._extract_output_type(operation, dataset),

--- a/data_rentgen/consumer/extractors/impl/interface.py
+++ b/data_rentgen/consumer/extractors/impl/interface.py
@@ -43,16 +43,19 @@ class ExtractorInterface(Protocol):
         self,
         operation: OperationDTO,
         dataset: OpenLineageInputDataset,
+        event: OpenLineageRunEvent,
     ) -> tuple[InputDTO, list[DatasetSymlinkDTO]]: ...
 
     def extract_output(
         self,
         operation: OperationDTO,
         dataset: OpenLineageOutputDataset,
+        event: OpenLineageRunEvent,
     ) -> tuple[OutputDTO, list[DatasetSymlinkDTO]]: ...
 
     def extract_column_lineage(
         self,
         operation: OperationDTO,
         output_dataset: OpenLineageDataset,
+        event: OpenLineageRunEvent,
     ) -> list[ColumnLineageDTO]: ...

--- a/data_rentgen/db/repositories/column_lineage.py
+++ b/data_rentgen/db/repositories/column_lineage.py
@@ -105,14 +105,9 @@ class ColumnLineageRepository(Repository[ColumnLineage]):
         if not operation_ids:
             return []
 
-        # Output created_at is always the same as operation's created_at
-        # do not use `tuple_(Output.created_at, Output.operation_id).in_(...),
-        # as this is too complex filter for Postgres to make an optimal query plan
-        min_created_at = extract_timestamp_from_uuid(min(operation_ids))
-        max_created_at = extract_timestamp_from_uuid(max(operation_ids))
         where = [
-            ColumnLineage.created_at >= min_created_at,
-            ColumnLineage.created_at <= max_created_at,
+            # ColumnLineage created_at cannot be below operation's created_at.
+            ColumnLineage.created_at >= extract_timestamp_from_uuid(min(operation_ids)),
             ColumnLineage.operation_id == any_(list(operation_ids)),  # type: ignore[arg-type]
             ColumnLineage.source_dataset_id == any_(list(source_dataset_ids)),  # type: ignore[arg-type]
             ColumnLineage.target_dataset_id == any_(list(target_dataset_ids)),  # type: ignore[arg-type]

--- a/data_rentgen/db/repositories/io_dataset_relation.py
+++ b/data_rentgen/db/repositories/io_dataset_relation.py
@@ -36,86 +36,39 @@ class IODatasetRelationRepository:
         until: datetime | None,
         direction: Literal["UPSTREAM", "DOWNSTREAM"],
     ) -> list[IODatasetRelationRow]:
-        output_partition_by = [Output.run_id, Output.dataset_id]
-        output_order_by = [Output.created_at, Output.schema_id]
-        input_partition_by = [Input.run_id, Input.dataset_id]
-        input_order_by = [Input.created_at, Input.schema_id]
-        match direction:
-            case "UPSTREAM":
-                # dasasets as Outputs
-                where = [
-                    Output.created_at >= since,
-                    Input.created_at >= since,
-                    Output.dataset_id == any_(list(dataset_ids)),  # type: ignore[arg-type]
-                ]
-                if until:
-                    where.extend([Output.created_at <= until, Input.created_at <= until])
+        where = [
+            Input.created_at >= since,
+            Output.created_at >= since,
+        ]
+        if direction == "UPSTREAM":
+            where.append(Output.dataset_id == any_(list(dataset_ids)))  # type: ignore[arg-type]
+        else:
+            where.append(Input.dataset_id == any_(list(dataset_ids)))  # type: ignore[arg-type]
+        if until:
+            where.extend([Output.created_at <= until, Input.created_at <= until])
 
-                base_query = (
-                    select(
-                        Input.dataset_id.label("in_dataset_id"),
-                        Output.created_at.label("created_at"),
-                        Output.dataset_id.label("out_dataset_id"),
-                        func.first_value(Output.schema_id)
-                        .over(partition_by=output_partition_by, order_by=output_order_by)
-                        .label("oldest_output_schema_id"),
-                        func.last_value(Output.schema_id)
-                        .over(partition_by=output_partition_by, order_by=output_order_by)
-                        .label("newest_output_schema_id"),
-                        func.first_value(Input.schema_id)
-                        .over(partition_by=input_partition_by, order_by=input_order_by)
-                        .label("oldest_input_schema_id"),
-                        func.last_value(Input.schema_id)
-                        .over(partition_by=input_partition_by, order_by=input_order_by)
-                        .label("newest_input_schema_id"),
-                    )
-                    .join(Input, Output.run_id == Input.run_id)
-                    .where(*where)
-                    .cte()
-                )
-            case "DOWNSTREAM":
-                # dasasets as Inputs
-                where = [
-                    Input.created_at >= since,
-                    Output.created_at >= since,
-                    Input.dataset_id == any_(list(dataset_ids)),  # type: ignore[arg-type]
-                ]
-                if until:
-                    where.extend([Input.created_at <= until, Output.created_at <= until])
+        unique_ids = [Output.dataset_id, Input.dataset_id]
+        order_by = [Output.created_at, Input.created_at, Output.schema_id, Input.schema_id]
 
-                base_query = (
-                    select(
-                        Input.dataset_id.label("in_dataset_id"),
-                        Input.created_at.label("created_at"),
-                        Output.dataset_id.label("out_dataset_id"),
-                        func.first_value(Output.schema_id)
-                        .over(partition_by=output_partition_by, order_by=output_order_by)
-                        .label("oldest_output_schema_id"),
-                        func.last_value(Output.schema_id)
-                        .over(partition_by=output_partition_by, order_by=output_order_by)
-                        .label("newest_output_schema_id"),
-                        func.first_value(Input.schema_id)
-                        .over(partition_by=input_partition_by, order_by=input_order_by)
-                        .label("oldest_input_schema_id"),
-                        func.last_value(Input.schema_id)
-                        .over(partition_by=input_partition_by, order_by=input_order_by)
-                        .label("newest_input_schema_id"),
-                    )
-                    .join(Output, Input.run_id == Output.run_id)
-                    .where(*where)
-                    .cte()
-                )
-        query = select(
-            func.max(base_query.c.created_at).label("created_at"),
-            base_query.c.in_dataset_id,
-            base_query.c.out_dataset_id,
-            func.min(base_query.c.oldest_output_schema_id).label("min_output_schema_id"),
-            func.max(base_query.c.newest_output_schema_id).label("max_output_schema_id"),
-            func.min(base_query.c.oldest_input_schema_id).label("min_input_schema_id"),
-            func.max(base_query.c.newest_input_schema_id).label("max_input_schema_id"),
-        ).group_by(
-            base_query.c.in_dataset_id,
-            base_query.c.out_dataset_id,
+        # Avoid sorting multiple times by different keys for performance reason,
+        # instead reuse the same window expression
+        def window(expr, order_by=None):
+            return expr.over(partition_by=unique_ids, order_by=order_by)
+
+        # there is no need in GROUP BY, as we already select distinct values
+        query = (
+            select(
+                Input.dataset_id.label("in_dataset_id"),
+                Output.dataset_id.label("out_dataset_id"),
+                window(func.max(Output.created_at)).label("max_created_at"),
+                window(func.first_value(Output.schema_id), order_by).label("oldest_output_schema_id"),
+                window(func.last_value(Output.schema_id), order_by).label("newest_output_schema_id"),
+                window(func.first_value(Input.schema_id), order_by).label("oldest_input_schema_id"),
+                window(func.last_value(Input.schema_id), order_by).label("newest_input_schema_id"),
+            )
+            .distinct(*unique_ids)
+            .join(Input, Output.run_id == Input.run_id)
+            .where(*where)
         )
 
         query_result = await self._session.execute(query)
@@ -123,27 +76,27 @@ class IODatasetRelationRepository:
         for row in query_result.all():
             output_schema_relevance_type: Literal["EXACT_MATCH", "LATEST_KNOWN"] | None
             input_schema_relevance_type: Literal["EXACT_MATCH", "LATEST_KNOWN"] | None
-            if row.max_output_schema_id:
+            if row.newest_output_schema_id:
                 output_schema_relevance_type = (
-                    "EXACT_MATCH" if row.min_output_schema_id == row.max_output_schema_id else "LATEST_KNOWN"
+                    "EXACT_MATCH" if row.oldest_input_schema_id == row.newest_output_schema_id else "LATEST_KNOWN"
                 )
             else:
                 output_schema_relevance_type = None
 
-            if row.max_input_schema_id:
+            if row.newest_input_schema_id:
                 input_schema_relevance_type = (
-                    "EXACT_MATCH" if row.min_input_schema_id == row.max_input_schema_id else "LATEST_KNOWN"
+                    "EXACT_MATCH" if row.oldest_input_schema_id == row.newest_input_schema_id else "LATEST_KNOWN"
                 )
             else:
                 input_schema_relevance_type = None
             results.append(
                 IODatasetRelationRow(
-                    created_at=row.created_at,
+                    created_at=row.max_created_at,
                     in_dataset_id=row.in_dataset_id,
                     out_dataset_id=row.out_dataset_id,
-                    output_schema_id=row.max_output_schema_id,
+                    output_schema_id=row.newest_output_schema_id,
                     output_schema_relevance_type=output_schema_relevance_type,
-                    input_schema_id=row.max_input_schema_id,
+                    input_schema_id=row.newest_input_schema_id,
                     input_schema_relevance_type=input_schema_relevance_type,
                 ),
             )

--- a/data_rentgen/db/repositories/output.py
+++ b/data_rentgen/db/repositories/output.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from typing import Literal
 from uuid import UUID
 
-from sqlalchemy import ColumnElement, Row, any_, func, literal_column, select
+from sqlalchemy import ColumnElement, Row, Select, any_, func, literal_column, select
 from sqlalchemy.dialects.postgresql import insert
 
 from data_rentgen.db.models import Output, OutputType, Schema
@@ -43,6 +43,7 @@ class OutputRepository(Repository[Output]):
         statement = insert_statement.on_conflict_do_update(
             index_elements=[Output.created_at, Output.id],
             set_={
+                "type": new_row.type.op("|")(Output.type),
                 "num_bytes": func.greatest(new_row.num_bytes, Output.num_bytes),
                 "num_rows": func.greatest(new_row.num_rows, Output.num_rows),
                 "num_files": func.greatest(new_row.num_files, Output.num_files),
@@ -77,14 +78,11 @@ class OutputRepository(Repository[Output]):
         if not operation_ids:
             return []
 
-        # Output created_at is always the same as operation's created_at
+        # Output created_at cannot be before operation's created_at
         # do not use `tuple_(Output.created_at, Output.operation_id).in_(...),
         # as this is too complex filter for Postgres to make an optimal query plan
-        min_created_at = extract_timestamp_from_uuid(min(operation_ids))
-        max_created_at = extract_timestamp_from_uuid(max(operation_ids))
         where = [
-            Output.created_at >= min_created_at,
-            Output.created_at <= max_created_at,
+            Output.created_at >= extract_timestamp_from_uuid(min(operation_ids)),
             Output.operation_id == any_(list(operation_ids)),  # type: ignore[arg-type]
         ]
 
@@ -102,7 +100,6 @@ class OutputRepository(Repository[Output]):
 
         min_run_created_at = extract_timestamp_from_uuid(min(run_ids))
         min_created_at = max(min_run_created_at, since.astimezone(timezone.utc))
-
         where = [
             Output.created_at >= min_created_at,
             Output.run_id == any_(list(run_ids)),  # type: ignore[arg-type]
@@ -150,52 +147,63 @@ class OutputRepository(Repository[Output]):
 
         return await self._get_outputs(where, granularity)
 
+    def _get_base_query(
+        self,
+        where: Collection[ColumnElement],
+    ) -> Select:
+        # For operation.type=STREAMING, there can be multiple outputs for same operation+dataset+schema,
+        # so we also need deduplication here
+        unique_ids = [Output.job_id, Output.run_id, Output.operation_id, Output.dataset_id]
+        order_by = [Output.created_at, Output.schema_id]
+
+        # Avoid sorting multiple times by different keys for performance reason,
+        # instead reuse the same window expression
+        def window(expr, order_by=None):
+            return expr.over(partition_by=unique_ids, order_by=order_by)
+
+        return (
+            select(
+                *unique_ids,
+                window(func.max(Output.created_at)).label("created_at"),
+                window(func.max(Output.num_bytes)).label("num_bytes"),
+                window(func.max(Output.num_rows)).label("num_rows"),
+                window(func.max(Output.num_files)).label("num_files"),
+                window(func.bit_or(Output.type)).label("type"),
+                window(func.first_value(Output.schema_id), order_by).label("oldest_schema_id"),
+                window(func.last_value(Output.schema_id), order_by).label("newest_schema_id"),
+            )
+            .distinct(*unique_ids)
+            .where(*where)
+        )
+
     async def _get_outputs(
         self,
         where: Collection[ColumnElement],
         granularity: Literal["JOB", "RUN", "OPERATION"],
     ) -> list[OutputRow]:
+        base_query = self._get_base_query(where).subquery()
         if granularity == "OPERATION":
-            # return Output as-is
-            simple_query = select(Output).where(*where)
-            result = await self._session.scalars(simple_query)
-            return [
-                OutputRow(
-                    created_at=row.created_at,
-                    operation_id=row.operation_id,
-                    run_id=row.run_id,
-                    job_id=row.job_id,
-                    dataset_id=row.dataset_id,
-                    num_bytes=row.num_bytes,
-                    num_rows=row.num_rows,
-                    num_files=row.num_files,
-                    schema_id=row.schema_id,
-                    schema_relevance_type="EXACT_MATCH" if row.schema_id else None,
-                    types_combined=row.type,
-                )
-                for row in result.all()
-            ]
-
-        # return an aggregated Output
-        if granularity == "RUN":
-            partition_by = [Output.run_id, Output.job_id, Output.dataset_id]
-            base_query = (
-                select(
-                    Output,
-                    func.first_value(Output.schema_id)
-                    .over(partition_by=partition_by, order_by=[Output.created_at, Output.schema_id])
-                    .label("oldest_schema_id"),
-                    func.last_value(Output.schema_id)
-                    .over(partition_by=partition_by, order_by=[Output.created_at, Output.schema_id])
-                    .label("newest_schema_id"),
-                )
-                .where(*where)
-                .cte()
-            )
-
             query = select(
-                func.max(base_query.c.created_at).label("created_at"),
-                literal_column("NULL").label("id"),
+                func.max(base_query.c.created_at).label("max_created_at"),
+                base_query.c.operation_id,
+                base_query.c.run_id,
+                base_query.c.job_id,
+                base_query.c.dataset_id,
+                func.sum(base_query.c.num_bytes).label("sum_num_bytes"),
+                func.sum(base_query.c.num_rows).label("sum_num_rows"),
+                func.sum(base_query.c.num_files).label("sum_num_files"),
+                func.bit_or(base_query.c.type).label("types_combined"),
+                func.min(base_query.c.oldest_schema_id).label("min_schema_id"),
+                func.max(base_query.c.newest_schema_id).label("max_schema_id"),
+            ).group_by(
+                base_query.c.operation_id,
+                base_query.c.run_id,
+                base_query.c.job_id,
+                base_query.c.dataset_id,
+            )
+        elif granularity == "RUN":
+            query = select(
+                func.max(base_query.c.created_at).label("max_created_at"),
                 literal_column("NULL").label("operation_id"),
                 base_query.c.run_id,
                 base_query.c.job_id,
@@ -212,24 +220,8 @@ class OutputRepository(Repository[Output]):
                 base_query.c.dataset_id,
             )
         else:
-            partition_by = [Output.job_id, Output.dataset_id]
-            base_query = (
-                select(
-                    Output,
-                    func.first_value(Output.schema_id)
-                    .over(partition_by=partition_by, order_by=[Output.created_at, Output.schema_id])
-                    .label("oldest_schema_id"),
-                    func.last_value(Output.schema_id)
-                    .over(partition_by=partition_by, order_by=[Output.created_at, Output.schema_id])
-                    .label("newest_schema_id"),
-                )
-                .where(*where)
-                .cte()
-            )
-
             query = select(
-                func.max(base_query.c.created_at).label("created_at"),
-                literal_column("NULL").label("id"),
+                func.max(base_query.c.created_at).label("max_created_at"),
                 literal_column("NULL").label("operation_id"),
                 literal_column("NULL").label("run_id"),
                 base_query.c.job_id,
@@ -244,6 +236,7 @@ class OutputRepository(Repository[Output]):
                 base_query.c.job_id,
                 base_query.c.dataset_id,
             )
+
         query_result = await self._session.execute(query)
         results = []
         for row in query_result.all():
@@ -254,7 +247,7 @@ class OutputRepository(Repository[Output]):
                 schema_relevance_type = None
             results.append(
                 OutputRow(
-                    created_at=row.created_at,
+                    created_at=row.max_created_at,
                     operation_id=row.operation_id,
                     run_id=row.run_id,
                     job_id=row.job_id,
@@ -262,9 +255,9 @@ class OutputRepository(Repository[Output]):
                     num_bytes=row.sum_num_bytes,
                     num_rows=row.sum_num_rows,
                     num_files=row.sum_num_files,
+                    types_combined=row.types_combined,
                     schema_id=row.max_schema_id,
                     schema_relevance_type=schema_relevance_type,
-                    types_combined=row.types_combined,
                 ),
             )
         return results
@@ -273,27 +266,20 @@ class OutputRepository(Repository[Output]):
         if not operation_ids:
             return {}
 
-        # Input created_at is always the same as operation's created_at
-        # do not use `tuple_(Input.created_at, Input.operation_id).in_(...),
-        # as this is too complex filter for Postgres to make an optimal query plan
-        min_created_at = extract_timestamp_from_uuid(min(operation_ids))
-        max_created_at = extract_timestamp_from_uuid(max(operation_ids))
+        where = [
+            # Output created_at cannot be before operation's created_at
+            Output.created_at >= extract_timestamp_from_uuid(min(operation_ids)),
+            Output.operation_id == any_(list(operation_ids)),  # type: ignore[arg-type]
+        ]
 
-        query = (
-            select(
-                Output.operation_id.label("operation_id"),
-                func.count(Output.dataset_id.distinct()).label("total_datasets"),
-                func.sum(Output.num_bytes).label("total_bytes"),
-                func.sum(Output.num_rows).label("total_rows"),
-                func.sum(Output.num_files).label("total_files"),
-            )
-            .where(
-                Output.created_at >= min_created_at,
-                Output.created_at <= max_created_at,
-                Output.operation_id == any_(list(operation_ids)),  # type: ignore[arg-type]
-            )
-            .group_by(Output.operation_id)
-        )
+        base_query = self._get_base_query(where).subquery()
+        query = select(
+            base_query.c.operation_id.label("operation_id"),
+            func.count(base_query.c.dataset_id.distinct()).label("total_datasets"),
+            func.sum(base_query.c.num_bytes).label("total_bytes"),
+            func.sum(base_query.c.num_rows).label("total_rows"),
+            func.sum(base_query.c.num_files).label("total_files"),
+        ).group_by(base_query.c.operation_id)
 
         query_result = await self._session.execute(query)
         return {row.operation_id: row for row in query_result.all()}
@@ -303,21 +289,19 @@ class OutputRepository(Repository[Output]):
             return {}
 
         # unlike list_by_run_ids, we need to get all statistics for specific runs, regardless of time range
-        min_created_at = extract_timestamp_from_uuid(min(run_ids))
-        query = (
-            select(
-                Output.run_id.label("run_id"),
-                func.count(Output.dataset_id.distinct()).label("total_datasets"),
-                func.sum(Output.num_bytes).label("total_bytes"),
-                func.sum(Output.num_rows).label("total_rows"),
-                func.sum(Output.num_files).label("total_files"),
-            )
-            .where(
-                Output.created_at >= min_created_at,
-                Output.run_id == any_(list(run_ids)),  # type: ignore[arg-type]
-            )
-            .group_by(Output.run_id)
-        )
+        where = [
+            Output.created_at >= extract_timestamp_from_uuid(min(run_ids)),
+            Output.run_id == any_(list(run_ids)),  # type: ignore[arg-type]
+        ]
+
+        base_query = self._get_base_query(where).subquery()
+        query = select(
+            base_query.c.run_id.label("run_id"),
+            func.count(base_query.c.dataset_id.distinct()).label("total_datasets"),
+            func.sum(base_query.c.num_bytes).label("total_bytes"),
+            func.sum(base_query.c.num_rows).label("total_rows"),
+            func.sum(base_query.c.num_files).label("total_files"),
+        ).group_by(base_query.c.run_id)
 
         query_result = await self._session.execute(query)
         return {row.run_id: row for row in query_result.all()}

--- a/data_rentgen/dto/column_lineage.py
+++ b/data_rentgen/dto/column_lineage.py
@@ -19,6 +19,7 @@ from data_rentgen.utils.uuid import generate_incremental_uuid, generate_static_u
 
 @dataclass
 class ColumnLineageDTO:
+    created_at: datetime
     operation: OperationDTO
     source_dataset: DatasetDTO
     target_dataset: DatasetDTO
@@ -48,10 +49,6 @@ class ColumnLineageDTO:
         ]
         return generate_incremental_uuid(self.created_at, ".".join(id_components))
 
-    @property
-    def created_at(self) -> datetime:
-        return self.operation.created_at
-
     @cached_property
     def fingerprint(self) -> UUID:
         id_components = sorted((*item.unique_key, item.type) for item in self.column_relations)
@@ -60,6 +57,7 @@ class ColumnLineageDTO:
 
     def merge(self, new: ColumnLineageDTO) -> ColumnLineageDTO:
         return ColumnLineageDTO(
+            created_at=min([new.created_at, self.created_at]),
             operation=self.operation.merge(new.operation),
             source_dataset=self.source_dataset.merge(new.source_dataset),
             target_dataset=self.target_dataset.merge(new.target_dataset),

--- a/data_rentgen/dto/input.py
+++ b/data_rentgen/dto/input.py
@@ -15,6 +15,7 @@ from data_rentgen.utils.uuid import generate_incremental_uuid
 
 @dataclass
 class InputDTO:
+    created_at: datetime
     operation: OperationDTO
     dataset: DatasetDTO
     schema: SchemaDTO | None = None
@@ -40,10 +41,6 @@ class InputDTO:
         ]
         return generate_incremental_uuid(self.created_at, ".".join(id_components))
 
-    @property
-    def created_at(self) -> datetime:
-        return self.operation.created_at
-
     def merge(self, new: InputDTO) -> InputDTO:
         schema: SchemaDTO | None
         if self.schema and new.schema:  # noqa: SIM108
@@ -52,6 +49,7 @@ class InputDTO:
             schema = new.schema or self.schema
 
         return InputDTO(
+            created_at=min([new.created_at, self.created_at]),
             operation=self.operation.merge(new.operation),
             dataset=self.dataset.merge(new.dataset),
             schema=schema,

--- a/data_rentgen/dto/output.py
+++ b/data_rentgen/dto/output.py
@@ -29,6 +29,7 @@ class OutputTypeDTO(IntFlag):
 
 @dataclass
 class OutputDTO:
+    created_at: datetime
     operation: OperationDTO
     dataset: DatasetDTO
     type: OutputTypeDTO
@@ -55,10 +56,6 @@ class OutputDTO:
         ]
         return generate_incremental_uuid(self.created_at, ".".join(id_components))
 
-    @property
-    def created_at(self) -> datetime:
-        return self.operation.created_at
-
     def merge(self, new: OutputDTO) -> OutputDTO:
         schema: SchemaDTO | None
         if self.schema and new.schema:  # noqa: SIM108
@@ -67,6 +64,7 @@ class OutputDTO:
             schema = new.schema or self.schema
 
         return OutputDTO(
+            created_at=min([new.created_at, self.created_at]),
             operation=self.operation.merge(new.operation),
             dataset=self.dataset.merge(new.dataset),
             type=self.type,

--- a/docs/changelog/next_release/253.feature.rst
+++ b/docs/changelog/next_release/253.feature.rst
@@ -1,0 +1,11 @@
+Improve storing lineage data for long running operations.
+
+Previously if operation was running for a long time (more than a day, Flink streaming jobs can easily run for months or years),
+and lineage was fetched for last day, there was no Flink job/run/operation in the graph.
+This is because we created input/output/column lineage at operation start,
+and ``RUNNING`` events of the same operation (checkpoints) were just updating the same row statistics.
+
+Now we create new input/output/column lineage row for checkpoints events as well.
+But only one row for each hour since operation was started, as increasing number of rows slows down lineage graph resolution.
+
+For short-lived operations (most of batch operations take less than hour) behavior remains unchanged.

--- a/docs/quickstart/airflow/index.rst
+++ b/docs/quickstart/airflow/index.rst
@@ -9,7 +9,7 @@ Requirements
 ------------
 
 * `Apache Airflow <https://airflow.apache.org/>`_ 2.x or 3.x
-* OpenLineage 1.19.0 or higher, recommended 1.33.0+
+* OpenLineage 1.19.0 or higher, recommended 1.34.0+
 * OpenLineage integration for Airflow (see below)
 
 Entity mapping
@@ -27,13 +27,13 @@ Install
 
   .. code:: console
 
-    $ pip install "apache-airflow-providers-openlineage>=2.3.0" "openlineage-python[kafka]>=1.33.0" zstd
+    $ pip install "apache-airflow-providers-openlineage>=2.3.0" "openlineage-python[kafka]>=1.34.0" zstd
 
 * For Airflow 2.1.x-2.6.x, use `OpenLineage integration for Airflow <https://openlineage.io/docs/integrations/airflow/>`_ 1.19.0 or higher
 
   .. code:: console
 
-    $ pip install "openlineage-airflow>=1.33.0" "openlineage-python[kafka]>=1.33.0" zstd
+    $ pip install "openlineage-airflow>=1.34.0" "openlineage-python[kafka]>=1.34.0" zstd
 
 Setup
 -----

--- a/docs/quickstart/dbt/index.rst
+++ b/docs/quickstart/dbt/index.rst
@@ -9,7 +9,7 @@ Requirements
 ------------
 
 * `dbt <https://www.getdbt.com/>`_ 1.3 or higher
-* OpenLineage 1.19.0 or higher, recommended 1.33.0+
+* OpenLineage 1.19.0 or higher, recommended 1.34.0+
 
 Entity mapping
 --------------
@@ -23,7 +23,7 @@ Install
 
 .. code:: console
 
-    $ pip install "openlineage-dbt>=1.33.0" "openlineage-python[kafka]>=1.33.0" zstd
+    $ pip install "openlineage-dbt>=1.34.0" "openlineage-python[kafka]>=1.34.0" zstd
 
 Setup
 -----

--- a/docs/quickstart/flink1/index.rst
+++ b/docs/quickstart/flink1/index.rst
@@ -9,7 +9,7 @@ Requirements
 ------------
 
 * `Apache Flink <https://flink.apache.org/>`_ 1.x
-* OpenLineage 1.31.0 or higher, recommended 1.33.0+
+* OpenLineage 1.31.0 or higher, recommended 1.34.0+
 
 Entity mapping
 --------------
@@ -25,7 +25,7 @@ Installation
   .. code-block:: groovy
     :caption: build.gradle
 
-    implementation "io.openlineage:openlineage-flink:1.33.0"
+    implementation "io.openlineage:openlineage-flink:1.34.0"
     implementation "org.apache.kafka:kafka-clients:3.9.0"
 
 * Register ``OpenLineageFlinkJobListener`` in the code of your Flink job:
@@ -60,6 +60,10 @@ Setup
     job:
         namespace: http://some.host.name:18081  # set namespace to match Flink address
         name: flink_examples_stateful  # set job name
+
+    # Send RUNNING event every 1 hour.
+    # Using default interval (1 minute) just floods Kafka with useless RUNNING events.
+    trackingIntervalInSeconds: 3600
 
     transport:
         type: kafka

--- a/docs/quickstart/flink2/index.rst
+++ b/docs/quickstart/flink2/index.rst
@@ -9,7 +9,7 @@ Requirements
 ------------
 
 * `Apache Flink <https://flink.apache.org/>`_ 2.x
-* OpenLineage 1.31.0 or higher, recommended 1.33.0+
+* OpenLineage 1.31.0 or higher, recommended 1.34.0+
 
 Entity mapping
 --------------
@@ -66,6 +66,10 @@ Setup
 
   .. code-block:: yaml
     :caption: openlineage.yml
+
+    # Send RUNNING event every 1 hour.
+    # Using default interval (1 minute) just floods Kafka with useless RUNNING events.
+    trackingIntervalInSeconds: 600
 
     transport:
         type: kafka

--- a/docs/quickstart/spark/index.rst
+++ b/docs/quickstart/spark/index.rst
@@ -9,7 +9,7 @@ Requirements
 ------------
 
 * `Apache Spark <https://spark.apache.org/>`_ 3.x or higher
-* OpenLineage 1.23.0 or higher, recommended 1.33.0+
+* OpenLineage 1.23.0 or higher, recommended 1.34.0+
 
 Entity mapping
 --------------
@@ -62,7 +62,7 @@ Via OpenLineage config file
         # install OpenLineage integration and Kafka client
         .config(
             "spark.jars.packages",
-            "io.openlineage:openlineage-spark_2.12:1.33.0,org.apache.kafka:kafka-clients:3.9.0",
+            "io.openlineage:openlineage-spark_2.12:1.34.0,org.apache.kafka:kafka-clients:3.9.0",
         )
         .config(
             "spark.extraListeners", "io.openlineage.spark.agent.OpenLineageSparkListener"
@@ -90,7 +90,7 @@ Add OpenLineage integration package, setup ``OpenLineageSparkListener`` in Spark
         # install OpenLineage integration and Kafka client
         .config(
             "spark.jars.packages",
-            "io.openlineage:openlineage-spark_2.12:1.33.0,org.apache.kafka:kafka-clients:3.9.0",
+            "io.openlineage:openlineage-spark_2.12:1.34.0,org.apache.kafka:kafka-clients:3.9.0",
         )
         .config(
             "spark.extraListeners", "io.openlineage.spark.agent.OpenLineageSparkListener"

--- a/tests/test_consumer/test_extractors/fixtures/airflow_dto.py
+++ b/tests/test_consumer/test_extractors/fixtures/airflow_dto.py
@@ -119,6 +119,7 @@ def extracted_airflow_postgres_input(
     extracted_dataset_schema: SchemaDTO,
 ) -> InputDTO:
     return InputDTO(
+        created_at=extracted_airflow_task_operation.created_at,
         operation=extracted_airflow_task_operation,
         dataset=extracted_postgres_dataset,
         schema=extracted_dataset_schema,
@@ -132,6 +133,7 @@ def extracted_airflow_hdfs_output(
     extracted_dataset_schema: SchemaDTO,
 ) -> OutputDTO:
     return OutputDTO(
+        created_at=extracted_airflow_task_operation.created_at,
         type=OutputTypeDTO.CREATE,
         operation=extracted_airflow_task_operation,
         dataset=extracted_hdfs_dataset1,

--- a/tests/test_consumer/test_extractors/fixtures/dbt_dto.py
+++ b/tests/test_consumer/test_extractors/fixtures/dbt_dto.py
@@ -116,6 +116,7 @@ def extracted_dbt_spark_input(
     extracted_dbt_spark_source_schema: SchemaDTO,
 ) -> InputDTO:
     return InputDTO(
+        created_at=extracted_dbt_operation.created_at,
         operation=extracted_dbt_operation,
         dataset=extracted_dbt_spark_source_dataset,
         schema=extracted_dbt_spark_source_schema,
@@ -138,6 +139,7 @@ def extracted_dbt_spark_output(
     extracted_dbt_spark_target_dataset: DatasetDTO,
 ) -> OutputDTO:
     return OutputDTO(
+        created_at=extracted_dbt_operation.created_at,
         type=OutputTypeDTO.APPEND,
         operation=extracted_dbt_operation,
         dataset=extracted_dbt_spark_target_dataset,

--- a/tests/test_consumer/test_extractors/fixtures/flink_dto.py
+++ b/tests/test_consumer/test_extractors/fixtures/flink_dto.py
@@ -82,6 +82,7 @@ def extracted_flink_postgres_input(
     extracted_dataset_schema: SchemaDTO,
 ) -> InputDTO:
     return InputDTO(
+        created_at=extracted_flink_job_operation.created_at,
         operation=extracted_flink_job_operation,
         dataset=extracted_postgres_dataset,
         schema=extracted_dataset_schema,
@@ -95,6 +96,7 @@ def extracted_flink_kafka_output(
     extracted_dataset_schema: SchemaDTO,
 ) -> OutputDTO:
     return OutputDTO(
+        created_at=extracted_flink_job_operation.created_at,
         type=OutputTypeDTO.APPEND,
         operation=extracted_flink_job_operation,
         dataset=extracted_kafka_dataset,

--- a/tests/test_consumer/test_extractors/fixtures/hive_dto.py
+++ b/tests/test_consumer/test_extractors/fixtures/hive_dto.py
@@ -96,6 +96,7 @@ def extracted_hive_input(
     extracted_dataset_schema: SchemaDTO,
 ) -> InputDTO:
     return InputDTO(
+        created_at=extracted_hive_operation.created_at,
         operation=extracted_hive_operation,
         dataset=extracted_hive_dataset1,
         schema=extracted_dataset_schema,
@@ -109,6 +110,7 @@ def extracted_hive_output(
     extracted_dataset_schema: SchemaDTO,
 ) -> OutputDTO:
     return OutputDTO(
+        created_at=extracted_hive_operation.created_at,
         type=OutputTypeDTO.CREATE,
         operation=extracted_hive_operation,
         dataset=extracted_hive_dataset2,

--- a/tests/test_consumer/test_extractors/fixtures/spark_dto.py
+++ b/tests/test_consumer/test_extractors/fixtures/spark_dto.py
@@ -80,6 +80,7 @@ def extracted_spark_postgres_input(
     extracted_dataset_schema: SchemaDTO,
 ) -> InputDTO:
     return InputDTO(
+        created_at=extracted_spark_operation.created_at,
         operation=extracted_spark_operation,
         dataset=extracted_postgres_dataset,
         schema=extracted_dataset_schema,
@@ -93,6 +94,7 @@ def extracted_spark_hive_output(
     extracted_dataset_schema: SchemaDTO,
 ) -> OutputDTO:
     return OutputDTO(
+        created_at=extracted_spark_operation.created_at,
         type=OutputTypeDTO.CREATE,
         operation=extracted_spark_operation,
         dataset=extracted_hive_dataset1,

--- a/tests/test_consumer/test_extractors/fixtures/unknown_dto.py
+++ b/tests/test_consumer/test_extractors/fixtures/unknown_dto.py
@@ -75,6 +75,7 @@ def extracted_unknown_postgres_input(
     extracted_dataset_schema: SchemaDTO,
 ) -> InputDTO:
     return InputDTO(
+        created_at=extracted_unknown_operation.created_at,
         operation=extracted_unknown_operation,
         dataset=extracted_postgres_dataset,
         schema=extracted_dataset_schema,
@@ -88,6 +89,7 @@ def extracted_unknown_hdfs_output(
     extracted_dataset_schema: SchemaDTO,
 ) -> OutputDTO:
     return OutputDTO(
+        created_at=extracted_unknown_operation.created_at,
         type=OutputTypeDTO.CREATE,
         operation=extracted_unknown_operation,
         dataset=extracted_hdfs_dataset1,

--- a/tests/test_consumer/test_handlers/test_runs_handler_flink.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_flink.py
@@ -200,7 +200,7 @@ async def test_runs_handler_flink(
         },
     ]
 
-    input_query = select(Input).order_by(Input.dataset_id)
+    input_query = select(Input).order_by(Input.dataset_id, Input.created_at)
     input_scalars = await async_session.scalars(input_query)
     inputs = input_scalars.all()
     assert len(inputs) == 1
@@ -216,7 +216,7 @@ async def test_runs_handler_flink(
     assert kafka_input.num_rows is None
     assert kafka_input.num_files is None
 
-    output_query = select(Output).order_by(Output.dataset_id)
+    output_query = select(Output).order_by(Output.dataset_id, Output.created_at)
     output_scalars = await async_session.scalars(output_query)
     outputs = output_scalars.all()
     assert len(outputs) == 1

--- a/tests/test_server/fixtures/factories/input.py
+++ b/tests/test_server/fixtures/factories/input.py
@@ -19,8 +19,8 @@ def input_factory(**kwargs) -> Input:
     data = {
         "id": input_id,
         "created_at": extract_timestamp_from_uuid(input_id),
-        "operation_id": generate_new_uuid(),
-        "run_id": generate_new_uuid(),
+        "operation_id": generate_new_uuid(created_at),
+        "run_id": generate_new_uuid(created_at),
         "job_id": randint(0, 10000000),
         "dataset_id": randint(0, 10000000),
         "schema_id": randint(0, 10000000),

--- a/tests/test_server/fixtures/factories/output.py
+++ b/tests/test_server/fixtures/factories/output.py
@@ -19,8 +19,8 @@ def output_factory(**kwargs) -> Output:
     data = {
         "id": output_id,
         "created_at": extract_timestamp_from_uuid(output_id),
-        "operation_id": generate_new_uuid(),
-        "run_id": generate_new_uuid(),
+        "operation_id": generate_new_uuid(created_at),
+        "run_id": generate_new_uuid(created_at),
         "job_id": randint(0, 10000000),
         "dataset_id": randint(0, 10000000),
         "type": choice(list(OutputType)),

--- a/tests/test_server/fixtures/factories/relations.py
+++ b/tests/test_server/fixtures/factories/relations.py
@@ -11,7 +11,8 @@ from data_rentgen.utils.uuid import extract_timestamp_from_uuid, generate_new_uu
 from tests.test_server.fixtures.factories.base import random_string
 
 if TYPE_CHECKING:
-    from sqlalchemy import UUID
+    from uuid import UUID
+
     from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -49,7 +50,7 @@ def column_lineage_factory(**kwargs) -> ColumnLineage:
     column_lineage_id = generate_new_uuid(created_at)
     data = {
         "id": column_lineage_id,
-        "created_at": extract_timestamp_from_uuid(column_lineage_id),
+        "created_at": created_at or extract_timestamp_from_uuid(column_lineage_id),
         "operation_id": generate_new_uuid(created_at),
         "run_id": generate_new_uuid(created_at),
         "job_id": randint(0, 10000000),

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -1111,3 +1111,78 @@ async def test_get_run_lineage_with_combined_output_types(
             "operations": {},
         },
     }
+
+
+async def test_get_run_lineage_for_long_running_operations(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    lineage_for_long_running_operations: LineageResult,
+    mocked_user: MockedUser,
+):
+    lineage = lineage_for_long_running_operations
+
+    run = lineage.runs[0]
+
+    # use only latest IO for each operation+dataset
+    raw_inputs = [input for input in lineage.inputs if input.run_id == run.id]
+    latest_inputs = {}
+    for input in raw_inputs:
+        index = (input.operation_id, input.dataset_id)
+        existing = latest_inputs.get(index)
+        if not existing or input.created_at > existing.created_at:
+            latest_inputs[index] = input
+    inputs = list(latest_inputs.values())
+    assert inputs
+
+    raw_outputs = [output for output in lineage.outputs if output.run_id == run.id]
+    latest_outputs = {}
+    for output in raw_outputs:
+        index = (output.operation_id, input.dataset_id)
+        existing = latest_outputs.get(index)
+        if not existing or output.created_at > existing.created_at:
+            latest_outputs[index] = output
+    outputs = list(latest_outputs.values())
+    assert outputs
+
+    dataset_ids = {input.dataset_id for input in inputs} | {output.dataset_id for output in outputs}
+    datasets = [dataset for dataset in lineage.datasets if dataset.id in dataset_ids]
+    assert datasets
+
+    job = next(job for job in lineage.jobs if job.id == run.job_id)
+
+    datasets = await enrich_datasets(datasets, async_session)
+    [job] = await enrich_jobs([job], async_session)
+    [run] = await enrich_runs([run], async_session)
+
+    response = await test_client.get(
+        "v1/runs/lineage",
+        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
+        params={
+            "since": run.created_at.isoformat(),
+            "start_node_id": str(run.id),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "relations": {
+            "parents": run_parents_to_json([run]),
+            "symlinks": [],
+            "inputs": [
+                *inputs_to_json(merge_io_by_jobs(inputs), granularity="JOB"),
+                *inputs_to_json(merge_io_by_runs(inputs), granularity="RUN"),
+            ],
+            "outputs": [
+                *outputs_to_json(merge_io_by_jobs(outputs), granularity="JOB"),
+                *outputs_to_json(merge_io_by_runs(outputs), granularity="RUN"),
+            ],
+            "direct_column_lineage": [],
+            "indirect_column_lineage": [],
+        },
+        "nodes": {
+            "datasets": datasets_to_json(datasets, outputs, inputs),
+            "jobs": jobs_to_json([job]),
+            "runs": runs_to_json([run]),
+            "operations": {},
+        },
+    }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

For short living operations we create one input/output/column lineage row per operation+dataset, and just update the same row every time we receive an event with same operation, to store new number of rows/bytes/files.

For long running operations (mostly streaming), this behavior lead to the following situation:
* Flink job started 01.05.2025, sending a `START` event.
* This lead to creating input/output with `created_at=2025-05-01`
* For every checkpoint interval (60 seconds) OpenLineage sends `RUNNING` event, which only updates IO statistics columns
* User fetches lineage graph for this job with `since=2025-06-20` (week ago).
* Because `input.created_at`/`output.created_at` don't match `since`, there is no lineage for this Flink job for this interval. But Flink job is working, it is not dead, it performs some IO and sends us OpenLineage events.

Now we create new input/output/column lineage every hour since operation was started. Rows look like that:
| created_at       | operation_id | dataset_id | num_rows | num_files | num_bytes |
|------------------|--------------|------------|----------|-----------|-----------|
| 2025-06-20 00:00 | operation1   | dataset1   | 0        | 0         | 0         |
| 2025-06-20 01:00 | operation1   | dataset1   | 15       | 0         | 1_000     |
| 2025-06-20 02:00 | operation1   | dataset1   | 30       | 0         | 2_000     |
| 2025-06-20 03:00 | operation1   | dataset1   | 45       | 0         | 3_000     |

Storing data in this way is a bit costly, so we don't create new row for each received event (`START`, `RUNNING`, `RUNNING`, ..., `RUNNING`, `COMPLETE`). Time resolution for now is hardcoded, but can be made configurable in future.

What was changed:
* InputDTO, OutputDTO, ColumnLineageDTO `created_at` is not a property, but a field which is extracted from OpenLineage event and rounded to `io_time_resolution`.
* Removed limits on `created_at < max(operation.created_at)`, because this is not the case now.
* Updated queries for fetching input/output lineage - use latest row for each operation+dataset, and only then apply `SUM` here, to select distinct values only.
* Update queries for `ganularity=DATASET` lineage - as we don't sum over IO statistics here, `DISTINCT ON()` is enough to get all the data we need, no `GROUP BY` here.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
