### PR TITLE
[DOP-26065] add script to clean old partitions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Remove Partitions
         run: |
-          make db-clean-partitions ARGS="remove_data --keep-after $(date -v1d '+%Y-%m-%d')"
+          make db-clean-partitions ARGS="remove_data --keep-after $(date --date='yesterday' '+%Y-%m-%d')"
 
       - name: Dump DB logs on failure
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Remove Partitions
         run: |
-          make db-clean-partitions ARGS="remove_data --keep-after $(date --date='yesterday' '+%Y-%m-%d')"
+          make db-clean-partitions-ci ARGS="remove_data --keep-after $(date --date='yesterday' '+%Y-%m-%d')"
 
       - name: Dump DB logs on failure
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,10 @@ jobs:
           mkdir -p reports/
           make test-ci
 
+      - name: Remove Partitions
+        run: |
+          make db-clean-partitions ARGS="remove_data --keep-after $(date -v1d '+%Y-%m-%d')"
+
       - name: Dump DB logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,10 @@ repos:
       - id: chmod
         args: ['644']
         exclude_types: [shell]
-        exclude: ^(.*__main__\.py|data_rentgen/server/scripts/export_openapi_schema\.py|data_rentgen/db/scripts/create_partitions\.py|data_rentgen/db/scripts/refresh_analytic_views\.py)$
+        exclude: ^(.*__main__\.py|data_rentgen/server/scripts/export_openapi_schema\.py|data_rentgen/db/scripts/create_partitions\.py|data_rentgen/db/scripts/refresh_analytic_views\.py|data_rentgen/db/scripts/clean_partitions\.py)$
       - id: chmod
         args: ['755']
-        files: ^(.*__main__\.py|data_rentgen/server/scripts/export_openapi_schema\.py|data_rentgen/db/scripts/create_partitions\.py|data_rentgen/db/scripts/refresh_analytic_views\.py)$
+        files: ^(.*__main__\.py|data_rentgen/server/scripts/export_openapi_schema\.py|data_rentgen/db/scripts/create_partitions\.py|data_rentgen/db/scripts/refresh_analytic_views\.py|data_rentgen/db/scripts/clean_partitions\.py)$
       - id: insert-license
         files: .*\.py$
         exclude: ^(data_rentgen/dependencies/stub.py|docs/.*\.py|tests/.*\.py)$

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,10 @@ db-partitions: ##@DB Create partitions
 db-clean-partitions: ##@DB Clean partitions
 	${POETRY} run python -m data_rentgen.db.scripts.clean_partitions $(ARGS)
 
+db-clean-partitions-ci: ##@DB Clean partitions in CI
+	${POETRY} run python -m data_rentgen.db.scripts.clean_partitions $(ARGS)
 db-views: ##@DB Create views
-	${POETRY} run python -m data_rentgen.db.scripts.refresh_analytic_views $(ARGS)
+	${POETRY} run coveratge run python -m data_rentgen.db.scripts.refresh_analytic_views $(ARGS)
 
 broker: broker-start ##@Broker Prepare broker (in docker)
 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ db-downgrade: ##@DB Downgrade head migration
 db-partitions: ##@DB Create partitions
 	${POETRY} run python -m data_rentgen.db.scripts.create_partitions --start 2024-07-01
 
+db-clean-partitions: ##@DB Clean partitions
+	${POETRY} run python -m data_rentgen.db.scripts.clean_partitions $(ARGS)
+
 db-views: ##@DB Create views
 	${POETRY} run python -m data_rentgen.db.scripts.refresh_analytic_views $(ARGS)
 

--- a/data_rentgen/db/scripts/clean_partitions.py
+++ b/data_rentgen/db/scripts/clean_partitions.py
@@ -21,6 +21,8 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from data_rentgen.db.factory import create_session_factory
+from data_rentgen.db.models import Input, Operation, Output, Run
+from data_rentgen.db.models.column_lineage import ColumnLineage
 from data_rentgen.db.settings import DatabaseSettings
 from data_rentgen.logging.settings import LoggingSettings
 from data_rentgen.logging.setup_logging import setup_logging
@@ -29,11 +31,18 @@ logger = logging.getLogger(__name__)
 
 PARTITION_GRANULARITY_PATERN = re.compile(r"(\w+)_y(\d{4})(?:_m(\d{1,2})(?:_d(\d{1,2}))?)?")
 
+PARTITIONED_TABLES = (
+    Run.__tablename__,
+    Operation.__tablename__,
+    Input.__tablename__,
+    Output.__tablename__,
+    ColumnLineage.__tablename__,
+)
 
 granularity_output_format = {
-    "year": "y%Y",
-    "month": "y%Y_m%m",
-    "day": "y%Y_m%m_d%d",
+    "year": "_y%Y",
+    "month": "_y%Y_m%m",
+    "day": "_y%Y_m%m_d%d",
 }
 
 
@@ -46,7 +55,7 @@ class Command(str, Enum):
 
 def get_parser() -> ArgumentParser:
     parser = ArgumentParser(
-        usage="python3 -m data_rentgen.db.scripts.clean_partitions command truncate --keep-after 2025-01-01",
+        usage="python3 -m data_rentgen.db.scripts.clean_partitions truncate --keep-after 2025-01-01",
         description="Truncate or detach partitions, before provided date.",
     )
     parser.add_argument(
@@ -55,7 +64,7 @@ def get_parser() -> ArgumentParser:
         choices=[item.value for item in Command],
         default=Command.DRY_RUN.value,
         nargs="?",
-        help="Operation mode.",
+        help="Operation mode",
     )
     parser.add_argument(
         "--keep-after",
@@ -68,17 +77,21 @@ def get_parser() -> ArgumentParser:
 
 
 @dataclass()
-class TabelPartitions:
-    partitions: list[date] = field(default_factory=list)
+class TablePartition:
+    name: str
+    date: date
     granularity: Literal["year", "month", "day"] = field(default="year")
 
+    @property
+    def qualified_name(self):
+        return self.name + self.date.strftime(granularity_output_format[self.granularity])
 
-async def get_partitioned_tables(session: AsyncSession) -> dict[str, TabelPartitions] | None:
-    tables: dict[str, TabelPartitions] = defaultdict(TabelPartitions)
-    query = text(
-        "select c.relname as table_name from pg_class c where c.relispartition = True and c.relkind = 'r' order by c.relname",  # noqa: E501
-    )
-    result = await session.execute(query)
+
+async def get_partitioned_tables(session: AsyncSession) -> dict[str, list[TablePartition]] | None:
+    tables: dict[str, list[TablePartition]] = defaultdict(list)
+    query = "select c.relname as table_name from pg_class c where c.relispartition = True and c.relkind = 'r' order by c.relname"  # noqa: E501
+    query = query.format(partitioned_tables=PARTITIONED_TABLES)
+    result = await session.execute(text(query))
     table_names = result.all()
     if not table_names:
         logger.info("There is no partitioned tables")
@@ -99,53 +112,52 @@ async def get_partitioned_tables(session: AsyncSession) -> dict[str, TabelPartit
             granularity = "day"
         else:
             day = 1
-        tables[name].partitions.append(date(year, month, day))
-        tables[name].granularity = granularity
+        tables[name].append(TablePartition(name=name, date=date(year, month, day), granularity=granularity))
     return tables
 
 
-def get_partitions(tables: dict[str, TabelPartitions], end_date: date):
-    for table_name, value in tables.items():
-        partitions_to_remove = [partition for partition in value.partitions if partition < end_date]
-        tables[table_name].partitions = partitions_to_remove
-    return tables
+def get_partitions(tables: dict[str, list[TablePartition]], end_date: date) -> dict[str, list[TablePartition]]:
+    tables_to_remove: dict[str, list[TablePartition]] = defaultdict(list)
+    for table_name, partitions in tables.items():
+        tables_to_remove[table_name].extend(partition for partition in partitions if partition.date < end_date)
+    return tables_to_remove
 
 
-def get_query(tables: dict[str, TabelPartitions], query_type: str):
+def get_query(tables: dict[str, list[TablePartition]], query_type: str) -> list[str]:
     queries = []
     query_template = ""
     match query_type:
         case "detach":
-            query_template = "ALTER TABLE {table_name} DETACH PARTITION {table_name}_{partition};"
+            query_template = "ALTER TABLE {table_name} DETACH PARTITION {qualified_name};"
         case "remove":
-            query_template = "DROP TABLE {table_name}_{partition};"
+            query_template = "DROP TABLE {qualified_name};"
         case "truncate":
-            query_template = "TRUNCATE TABLE {table_name}_{partition};"
-    for table_name, value in tables.items():
+            query_template = "TRUNCATE TABLE {qualified_name};"
+    for table_name, partitions in tables.items():
+        if not partitions:
+            logger.info("No partitions of %s to %s", table_name, query_type)
+            continue
         queries_per_table = [
             query_template.format(
                 table_name=table_name,
-                partition=partition.strftime(granularity_output_format[value.granularity]),
+                qualified_name=partition.qualified_name,
             )
-            for partition in value.partitions
+            for partition in partitions
         ]
         queries.extend(queries_per_table)
     return queries
 
 
-def show_removing_partitions(tables: dict[str, TabelPartitions]):
-    for table_name, value in tables.items():
+def show_removing_partitions(tables: dict[str, list[TablePartition]]):
+    for table_name, partitions in tables.items():
         logger.info("Partitions to remove from table: %s", table_name)
         partitions_names = " ".join(
-            [
-                f"{table_name}_{partition.strftime(granularity_output_format[value.granularity])}"
-                for partition in value.partitions
-            ],
+            [partition.qualified_name for partition in partitions],
         )
         logger.info(partitions_names)
 
 
-async def detach_partitions(tables: dict[str, TabelPartitions], session: AsyncSession):
+async def detach_partitions(tables: dict[str, list[TablePartition]], session: AsyncSession):
     partitions_to_detach = get_query(tables, "detach")
     for query in partitions_to_detach:
         logger.debug("Detach partitions with query: %s", query)
@@ -153,7 +165,7 @@ async def detach_partitions(tables: dict[str, TabelPartitions], session: AsyncSe
         await session.commit()
 
 
-async def remove_data(tables: dict[str, TabelPartitions], session: AsyncSession):
+async def remove_data(tables: dict[str, list[TablePartition]], session: AsyncSession):
     partitions_to_remove = get_query(tables, "remove")
     for query in partitions_to_remove:
         logger.debug("Remove table with query: %s", query)
@@ -161,7 +173,7 @@ async def remove_data(tables: dict[str, TabelPartitions], session: AsyncSession)
         await session.commit()
 
 
-async def truncate_data(tables: dict[str, TabelPartitions], session: AsyncSession):
+async def truncate_data(tables: dict[str, list[TablePartition]], session: AsyncSession):
     partitions_to_truncate = get_query(tables, "truncate")
     for query in partitions_to_truncate:
         logger.debug("Truncate partition with query: %s", query)
@@ -178,22 +190,19 @@ async def main(args: list[str]) -> None:
     session_factory = create_session_factory(db_settings)
     async with session_factory() as session:
         tables = await get_partitioned_tables(session)
-        tables_to_remove = get_partitions(
-            tables.copy(),  # type: ignore[union-attr]
-            end_date,
-        )
+        tables_to_remove = get_partitions(tables, end_date)  # type: ignore[arg-type]
         match params.command:
             case "dry_run":
                 show_removing_partitions(tables_to_remove)
             case "detach_partitions":
-                logger.info("detach_partitions")
+                logger.info("Detach partitions starting from: %s", end_date)
                 await detach_partitions(tables_to_remove, session)
             case "remove_data":
-                logger.info("remove_data")
+                logger.info("Remove data from partitions starting from: %s", end_date)
                 await detach_partitions(tables_to_remove, session)
                 await remove_data(tables_to_remove, session)
             case "truncate":
-                logger.info("truncate")
+                logger.info("Truncate partitions starting from: %s", end_date)
                 await truncate_data(tables_to_remove, session)
             case _:
                 logger.error("No such command: %s", params.command)

--- a/data_rentgen/db/scripts/clean_partitions.py
+++ b/data_rentgen/db/scripts/clean_partitions.py
@@ -101,6 +101,8 @@ async def get_partitioned_tables(session: AsyncSession) -> dict[str, list[TableP
         granularity: Literal["year", "month", "day"] = "year"
         match = re.search(PARTITION_GRANULARITY_PATERN, tabel_name)
         (name, year, month, day) = match.groups()  # type: ignore[union-attr]
+        if name not in PARTITIONED_TABLES:
+            continue
         year = int(year)
         if month:
             month = int(month)

--- a/data_rentgen/db/scripts/clean_partitions.py
+++ b/data_rentgen/db/scripts/clean_partitions.py
@@ -100,7 +100,12 @@ async def get_partitioned_tables(session: AsyncSession) -> dict[str, list[TableP
     for (tabel_name,) in table_names:
         granularity: Literal["year", "month", "day"] = "year"
         match = re.search(PARTITION_GRANULARITY_PATERN, tabel_name)
+
+        if not match:
+            continue
+
         (name, year, month, day) = match.groups()  # type: ignore[union-attr]
+
         if name not in PARTITIONED_TABLES:
             continue
         year = int(year)

--- a/data_rentgen/db/scripts/clean_partitions.py
+++ b/data_rentgen/db/scripts/clean_partitions.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2024-2025 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import sys
+from argparse import ArgumentParser
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+from enum import Enum
+from typing import Literal
+
+from dateutil.parser import isoparse
+from dateutil.relativedelta import relativedelta
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from data_rentgen.db.factory import create_session_factory
+from data_rentgen.db.settings import DatabaseSettings
+from data_rentgen.logging.settings import LoggingSettings
+from data_rentgen.logging.setup_logging import setup_logging
+
+logger = logging.getLogger(__name__)
+
+PARTITION_GRANULARITY_PATERN = re.compile(r"(\w+)_y(\d{4})(?:_m(\d{1,2})(?:_d(\d{1,2}))?)?")
+
+
+granularity_output_format = {
+    "year": "y%Y",
+    "month": "y%Y_m%m",
+    "day": "y%Y_m%m_d%d",
+}
+
+
+class Command(str, Enum):
+    DRY_RUN = "dry_run"
+    DETATCH_PARTITIONS = "detach_partitions"
+    REMOVE_DATA = "remove_data"
+    TRUNCATE = "truncate"
+
+
+def get_parser() -> ArgumentParser:
+    parser = ArgumentParser(
+        usage="python3 -m data_rentgen.db.scripts.clean_partitions command truncate --keep-after $(date -v2m '+%Y-%m-%d')",  # noqa: E501
+        description="Truncate or detach partitions, before provided date.",
+    )
+    parser.add_argument(
+        "command",
+        choices=[item.value for item in Command],
+        default=Command.DRY_RUN.value,
+        nargs="?",
+        help="Operation mode.",
+    )
+    parser.add_argument(
+        "--keep-after",
+        type=isoparse,
+        default=(datetime.now(tz=UTC) - relativedelta(days=1)),
+        nargs="?",
+        help="Partitions with data before this date will be considered for cleanup",
+    )
+    return parser
+
+
+@dataclass()
+class Partition:
+    partitions: list[date] = field(default_factory=list)
+    granularity: Literal["year", "month", "day"] = field(default="year")
+
+
+async def get_partitioned_tables(session: AsyncSession) -> dict[str, Partition] | None:
+    tables: dict[str, Partition] = defaultdict(Partition)
+    query = text(
+        "select c.relname as table_name from pg_class c where c.relispartition = True and c.relkind = 'r' order by c.relname",  # noqa: E501
+    )
+    result = await session.execute(query)
+    table_names = result.all()
+    if not table_names:
+        logger.info("There is no partitioned tables")
+        return tables
+    # parse tabel_names
+    for (tabel_name,) in table_names:
+        granularity: Literal["year", "month", "day"] = "year"
+        match = re.search(PARTITION_GRANULARITY_PATERN, tabel_name)
+        (name, year, month, day) = match.groups()  # type: ignore[union-attr]
+        year = int(year)
+        if month:
+            month = int(month)
+            granularity = "month"
+        else:
+            month = 1
+        if day:
+            day = int(day)
+            granularity = "day"
+        else:
+            day = 1
+        tables[name].partitions.append(date(year, month, day))
+        tables[name].granularity = granularity
+    return tables
+
+
+def get_partitions(tables: dict[str, Partition], end_date: date):
+    for table_name, value in tables.items():
+        partitions_to_remove = [partition for partition in value.partitions if partition < end_date]
+        tables[table_name].partitions = partitions_to_remove
+    return tables
+
+
+def get_query(tables: dict[str, Partition], query_type: str):
+    queries = []
+    query_template = ""
+    match query_type:
+        case "detach":
+            query_template = "ALTER TABLE {table_name} DETACH PARTITION {table_name}_{partition};"
+        case "remove":
+            query_template = "DROP TABLE {table_name}_{partition};"
+        case "truncate":
+            query_template = "TRUNCATE TABLE {table_name}_{partition};"
+    for table_name, value in tables.items():
+        queries_per_table = [
+            query_template.format(
+                table_name=table_name,
+                partition=partition.strftime(granularity_output_format[value.granularity]),
+            )
+            for partition in value.partitions
+        ]
+        queries.extend(queries_per_table)
+    return queries
+
+
+def show_removing_partitions(tables: dict[str, Partition]):
+    for table_name, value in tables.items():
+        logger.info("Removing next partitions for table: %s", table_name)
+        partitions_names = " ".join(
+            [
+                f"{table_name}_{partition.strftime(granularity_output_format[value.granularity])}"
+                for partition in value.partitions
+            ],
+        )
+        logger.info(partitions_names)
+
+
+async def detach_partitions(tables: dict[str, Partition], session: AsyncSession):
+    partitions_to_detach = get_query(tables, "detach")
+    for query in partitions_to_detach:
+        logger.info("Detach partitions with query: %s", query)
+        await session.execute(text(query))
+        await session.commit()
+
+
+async def remove_data(tables: dict[str, Partition], session: AsyncSession):
+    partitions_to_remove = get_query(tables, "remove")
+    for query in partitions_to_remove:
+        logger.info("Remove table with query: %s", query)
+        await session.execute(text(query))
+        await session.commit()
+
+
+async def truncate_data(tables: dict[str, Partition], session: AsyncSession):
+    partitions_to_truncate = get_query(tables, "truncate")
+    for query in partitions_to_truncate:
+        logger.info("Truncate partition with query: %s", query)
+        await session.execute(text(query))
+        await session.commit()
+
+
+async def main(args: list[str]) -> None:
+    setup_logging(LoggingSettings())
+    parser = get_parser()
+    params = parser.parse_args(args)
+    logger.info("Starting clean partition script with params: %s", params)
+    end_date = params.keep_after.date()
+    db_settings = DatabaseSettings()  # type: ignore[call-arg]
+    session_factory = create_session_factory(db_settings)
+    async with session_factory() as session:
+        tables = await get_partitioned_tables(session)
+        tables_to_remove = get_partitions(
+            tables.copy(),  # type: ignore[union-attr]
+            end_date,
+        )
+        match params.command:
+            case "dry_run":
+                show_removing_partitions(tables_to_remove)
+            case "detach_partitions":
+                logger.info("detach_partitions")
+                await detach_partitions(tables_to_remove, session)
+            case "remove_data":
+                logger.info("remove_data")
+                await detach_partitions(tables_to_remove, session)
+                await remove_data(tables_to_remove, session)
+            case "truncate":
+                logger.info("truncate")
+                await truncate_data(tables_to_remove, session)
+            case _:
+                logger.error("No such command: %s", params.command)
+
+
+if __name__ == "__main__":
+    asyncio.run(main(sys.argv[1:]))

--- a/docs/changelog/next_release/254.improvement.rst
+++ b/docs/changelog/next_release/254.improvement.rst
@@ -1,0 +1,1 @@
+Add ``clean_partitions.py`` script to automate the cleanup of old table partitions.

--- a/docs/reference/database/clean_data_cli.rst
+++ b/docs/reference/database/clean_data_cli.rst
@@ -39,7 +39,7 @@ Examples
 
 1. Perform a Dry Run (default):
 
-.. code::shel
+.. code:: shell
 
     python3 -m data_rentgen.db.scripts.clean_partitions dry_run --keep-after 2024-01-01
 
@@ -47,7 +47,7 @@ This command will log which partitions would be affected if you were to clean up
 
 2. Detach Partitions Older Than a Specific Date:
 
-.. code::shel
+.. code:: shell
 
     python3 -m data_rentgen.db.scripts.clean_partitions detach_partitions --keep-after 2024-01-01
 
@@ -55,7 +55,7 @@ This will detach all partitions created before January 1, 2024, from their paren
 
 3. Remove Data and Drop Partitions Older Than a Specific Date:
 
-.. code::shel
+.. code:: shell
 
     python3 -m data_rentgen.db.scripts.clean_partitions remove_data --keep-after 2024-01-01
 
@@ -65,7 +65,7 @@ This will detach and then **drop all partitions** created before January 1, 2024
 
 This option is preferred with streaming ``Jobs``
 
-.. code::shel
+.. code:: shell
 
     python3 -m data_rentgen.db.scripts.clean_partitions truncate --keep-after 2024-01-01
 

--- a/docs/reference/database/clean_data_cli.rst
+++ b/docs/reference/database/clean_data_cli.rst
@@ -9,7 +9,7 @@ This script is designed to manage PostgreSQL table partitions by providing funct
  usage: python3 -m data_rentgen.db.scripts.clean_partitions --command truncate --keep-after $(date -v2m '+%Y-%m-%d')
 
 
-The ``clean_partitions.py`` script helps automate the cleanup of old PostgreSQL table partitions based on a specified keep-after date. It supports different commands for dry runs, detaching partitions, removing data, and truncating partitions.
+The ``clean_partitions.py`` script helps automate the cleanup of old table partitions based on a specified keep-after date. It supports different commands for dry runs, detaching partitions, removing data, and truncating partitions.
 It's automatically inditifies partitioned tables and their granularity.
 
 Arguments

--- a/docs/reference/database/clean_data_cli.rst
+++ b/docs/reference/database/clean_data_cli.rst
@@ -1,0 +1,72 @@
+.. _clean-partitions-cli:
+
+CLI for cleaning partitions data
+================================
+This script is designed to manage PostgreSQL table partitions by providing functionalities to list, detach, remove, or truncate old partitions.
+
+::
+
+ usage: python3 -m data_rentgen.db.scripts.clean_partitions --command truncate --keep-after $(date -v2m '+%Y-%m-%d')
+
+
+The ``clean_partitions.py`` script helps automate the cleanup of old PostgreSQL table partitions based on a specified keep-after date. It supports different commands for dry runs, detaching partitions, removing data, and truncating partitions.
+It's automatically inditifies partitioned tables and their granularity.
+
+Arguments
+~~~~~~~~~
+
+* ``command``: (Optional) Specifies the operation mode.
+    * Choices: ``dry_run``, ``detach_partitions``, ``remove_data``, ``truncate``
+    * Default: ``dry_run``
+    * Description:
+        * ``dry_run``: Logs the names of partitions that would be affected by the cleanup without executing any SQL commands.
+
+        * ``detach_partitions``: Generates and executes ``ALTER TABLE ... DETACH PARTITION ...`` commands for identified old partitions. This makes the partitions independent tables but keeps their data.
+
+        * ``remove_data``: First detaches partitions, then generates and executes ``DROP TABLE ...`` commands, permanently deleting the partition tables and their data.
+
+        * ``truncate``: Generates and executes ``TRUNCATE TABLE ...`` commands, removing all rows from the identified old partition tables but keeping the table structure. **This option is preferred if you have streaming data**.
+
+* ``--keep-after``: (Optional) The cut-off date for partitions. Partitions with data before this date will be considered for cleanup.
+    * Type: Date (e.g., ``YYYY-MM-DD``). The script uses isoparse for parsing, so various ISO formats are supported.
+
+    * Default: The current date - 1 day.
+
+    * Description: Only partitions whose date components are strictly before this specified date will be processed taking into account granularity of the table.
+
+Examples
+~~~~~~~~
+
+1. Perform a Dry Run (default):
+
+::
+
+    python3 -m data_rentgen.db.scripts.clean_partitions command dry_run --keep-after 2024-01-01
+
+This command will log which partitions would be affected if you were to clean up partitions older than January 1, 2024, without making any changes to your database.
+
+2. Detach Partitions Older Than a Specific Date:
+
+::
+
+    python3 -m data_rentgen.db.scripts.clean_partitions command detach_partitions --keep-after 2024-01-01
+
+This will detach all partitions created before January 1, 2024, from their parent tables. The detached tables will still exist with their data.
+
+3. Remove Data and Drop Partitions Older Than a Specific Date:
+
+::
+
+    python3 -m data_rentgen.db.scripts.clean_partitions command remove_data --keep-after 2024-06-01
+
+This will detach and then **drop all partitions** created before January 1, 2024, permanently deleting their data.
+
+4. Truncate Data in Partitions Older Than a Specific Date:
+
+This option is preferred with streaming ``Jobs``
+
+::
+
+    python3 -m data_rentgen.db.scripts.clean_partitions command truncate --keep-after 2023-01-01
+
+This will delete all rows from partitions created before January 1, 2023, but will keep the empty partition tables.

--- a/docs/reference/database/clean_data_cli.rst
+++ b/docs/reference/database/clean_data_cli.rst
@@ -6,7 +6,7 @@ This script is designed to manage PostgreSQL table partitions by providing funct
 
 ::
 
- usage: python3 -m data_rentgen.db.scripts.clean_partitions command truncate --keep-after 2025-01-01
+ usage: python3 -m data_rentgen.db.scripts.clean_partitions truncate --keep-after 2025-01-01
 
 
 The ``clean_partitions.py`` script helps automate the cleanup of old table partitions based on a specified keep-after date. It supports different commands for dry runs, detaching partitions, removing data, and truncating partitions.
@@ -39,25 +39,25 @@ Examples
 
 1. Perform a Dry Run (default):
 
-::
+.. code::shel
 
-    python3 -m data_rentgen.db.scripts.clean_partitions command dry_run --keep-after 2024-01-01
+    python3 -m data_rentgen.db.scripts.clean_partitions dry_run --keep-after 2024-01-01
 
 This command will log which partitions would be affected if you were to clean up partitions older than January 1, 2024, without making any changes to your database.
 
 2. Detach Partitions Older Than a Specific Date:
 
-::
+.. code::shel
 
-    python3 -m data_rentgen.db.scripts.clean_partitions command detach_partitions --keep-after 2024-01-01
+    python3 -m data_rentgen.db.scripts.clean_partitions detach_partitions --keep-after 2024-01-01
 
 This will detach all partitions created before January 1, 2024, from their parent tables. The detached tables will still exist with their data.
 
 3. Remove Data and Drop Partitions Older Than a Specific Date:
 
-::
+.. code::shel
 
-    python3 -m data_rentgen.db.scripts.clean_partitions command remove_data --keep-after 2024-01-01
+    python3 -m data_rentgen.db.scripts.clean_partitions remove_data --keep-after 2024-01-01
 
 This will detach and then **drop all partitions** created before January 1, 2024, permanently deleting their data.
 
@@ -65,8 +65,8 @@ This will detach and then **drop all partitions** created before January 1, 2024
 
 This option is preferred with streaming ``Jobs``
 
-::
+.. code::shel
 
-    python3 -m data_rentgen.db.scripts.clean_partitions command truncate --keep-after 2023-01-01
+    python3 -m data_rentgen.db.scripts.clean_partitions truncate --keep-after 2024-01-01
 
-This will delete all rows from partitions created before January 1, 2023, but will keep the empty partition tables.
+This will delete all rows from partitions created before January 1, 2024, but will keep the empty partition tables.

--- a/docs/reference/database/clean_data_cli.rst
+++ b/docs/reference/database/clean_data_cli.rst
@@ -6,7 +6,7 @@ This script is designed to manage PostgreSQL table partitions by providing funct
 
 ::
 
- usage: python3 -m data_rentgen.db.scripts.clean_partitions --command truncate --keep-after $(date -v2m '+%Y-%m-%d')
+ usage: python3 -m data_rentgen.db.scripts.clean_partitions command truncate --keep-after 2025-01-01
 
 
 The ``clean_partitions.py`` script helps automate the cleanup of old table partitions based on a specified keep-after date. It supports different commands for dry runs, detaching partitions, removing data, and truncating partitions.
@@ -21,16 +21,16 @@ Arguments
     * Description:
         * ``dry_run``: Logs the names of partitions that would be affected by the cleanup without executing any SQL commands.
 
-        * ``detach_partitions``: Generates and executes ``ALTER TABLE ... DETACH PARTITION ...`` commands for identified old partitions. This makes the partitions independent tables but keeps their data.
+        * ``detach_partitions``: Generates and executes ``ALTER TABLE ... DETACH PARTITION ...`` commands for identified old partitions. This keeps partition data intact, but consumer & server will have no access to these partitions.
 
         * ``remove_data``: First detaches partitions, then generates and executes ``DROP TABLE ...`` commands, permanently deleting the partition tables and their data.
 
-        * ``truncate``: Generates and executes ``TRUNCATE TABLE ...`` commands, removing all rows from the identified old partition tables but keeping the table structure. **This option is preferred if you have streaming data**.
+        * ``truncate``: Generates and executes ``TRUNCATE TABLE ...`` commands, removing all rows from the identified old partition tables but keeping the table structure. **This option is preferred if you have streaming operations, g.e. Flink or Spark Streaming jobs**.
 
 * ``--keep-after``: (Optional) The cut-off date for partitions. Partitions with data before this date will be considered for cleanup.
     * Type: Date (e.g., ``YYYY-MM-DD``). The script uses isoparse for parsing, so various ISO formats are supported.
 
-    * Default: The current date - 1 day.
+    * Default: The current date - 1 year.
 
     * Description: Only partitions whose date components are strictly before this specified date will be processed taking into account granularity of the table.
 
@@ -57,7 +57,7 @@ This will detach all partitions created before January 1, 2024, from their paren
 
 ::
 
-    python3 -m data_rentgen.db.scripts.clean_partitions command remove_data --keep-after 2024-06-01
+    python3 -m data_rentgen.db.scripts.clean_partitions command remove_data --keep-after 2024-01-01
 
 This will detach and then **drop all partitions** created before January 1, 2024, permanently deleting their data.
 

--- a/docs/reference/database/index.rst
+++ b/docs/reference/database/index.rst
@@ -31,6 +31,10 @@ By default, it creates monthly partitions, for current and next month. This can 
 This script should run on schedule, depending on partitions granularity.
 Scheduling can be done by adding a dedicated entry to `crontab <https://help.ubuntu.com/community/CronHowto>`_.
 
+
+It's strongly recommended also to setup cleaning data in old partitions :ref:`clean-partitions-cli`.
+Scheduling setup is same is for creating of partitions.
+
 Analytic views
 ---------------
 
@@ -105,6 +109,17 @@ With Docker
   .. code:: text
 
     0 0 * * * docker exec data-rentgen-server-1 "python -m data_rentgen.db.scripts.refresh_analytic_views"
+
+* Add cleaning partitions script to crontab:
+
+.. code:: console
+
+    $ crontab -e
+
+  .. code:: text
+
+    0 0 * * * docker exec data-rentgen-server-1 "python -m data_rentgen.db.scripts.clean_partitions command truncate --keep-after $(date -v2m '+%Y-%m-%d')"
+
 
 
 Without Docker
@@ -182,6 +197,18 @@ Without Docker
     # read settings from .env file, and run script using a specific venv with all required dependencies
     0 0 * * * /bin/bash -c "source /some/.env && /some/.venv/bin/python -m data_rentgen.db.scripts.refresh_analytic_views"
 
+* Add partitions cleaning script to crontab, to run every day:
+
+  .. code:: console
+
+    $ crontab -e
+
+  .. code:: text
+
+    # read settings from .env file, and run script using a specific venv with all required dependencies
+    0 0 * * * /bin/bash -c "source /some/.env && /some/.venv/bin/python -m data_rentgen.db.scripts.clean_partitions command truncate --keep-after $(date -v2m '+%Y-%m-%d')"
+
+
 See also
 --------
 
@@ -191,4 +218,5 @@ See also
     configuration
     partitions_cli
     analytic_views_cli
+    clean_data_cli
     structure

--- a/docs/reference/database/index.rst
+++ b/docs/reference/database/index.rst
@@ -118,7 +118,8 @@ With Docker
 
   .. code:: text
 
-    0 0 * * * docker exec data-rentgen-server-1 "python -m data_rentgen.db.scripts.clean_partitions command truncate --keep-after $(date -v2m '+%Y-%m-%d')"
+    # Remove partitions older than 1 year
+    0 0 * * * docker exec data-rentgen-server-1 "python -m data_rentgen.db.scripts.clean_partitions truncate --keep-after $(date -v1y '+%Y-%m-%d')"
 
 
 
@@ -205,8 +206,9 @@ Without Docker
 
   .. code:: text
 
-    # read settings from .env file, and run script using a specific venv with all required dependencies
-    0 0 * * * /bin/bash -c "source /some/.env && /some/.venv/bin/python -m data_rentgen.db.scripts.clean_partitions command truncate --keep-after $(date -v2m '+%Y-%m-%d')"
+    # Read settings from .env file, and run script using a specific venv with all required dependencies
+    # Remove partitions older than 1 year
+    0 0 * * * /bin/bash -c "source /some/.env && /some/.venv/bin/python -m data_rentgen.db.scripts.clean_partitions truncate --keep-after $(date -v1y '+%Y-%m-%d')"
 
 
 See also

--- a/docs/reference/database/index.rst
+++ b/docs/reference/database/index.rst
@@ -32,7 +32,7 @@ This script should run on schedule, depending on partitions granularity.
 Scheduling can be done by adding a dedicated entry to `crontab <https://help.ubuntu.com/community/CronHowto>`_.
 
 
-It's strongly recommended also to setup cleaning data in old partitions :ref:`clean-partitions-cli`.
+It's strongly recommended also to add old partitions cleanup script to cron :ref:`clean-partitions-cli`.
 Scheduling setup is same is for creating of partitions.
 
 Analytic views


### PR DESCRIPTION
## Change Summary

Add script for cleaning old partitions.
The ``clean_partitions.py`` script helps automate the cleanup of old table partitions based on a specified keep-after date. It supports different commands for dry runs, detaching partitions, removing data, and truncating partitions.
It's automatically inditifies partitioned tables and their granularity.


## Related issue number

[DOP-26065]

## Checklist

* [ ] Commit message and PR title is comprehensive
* [ ] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [ ] My PR is ready to review.
