### PR TITLE
[DOP-27661] Exclude self-references from granularity=DATASET

### DIFF
--- a/docs/changelog/next_release/261.bugfix.rst
+++ b/docs/changelog/next_release/261.bugfix.rst
@@ -1,0 +1,2 @@
+If some run uses the same table as both input and output (e.g. merging duplicates or performing some checks before writing),
+DataRentgen excludes ``dataset1 -> dataset1`` relations from lineage with ``granularity=DATASET``.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Add check that `SELECT input.dataset_id, output.dataset_id FROM input JOIN output` doesn't return the same dataset in both columns, as this is completely useless information for `granularity=DATASET`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
