### PR TITLE
Use dataclass(slots=True) on DTOs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,9 +10,9 @@ security-scan:
   stage: security-scan
   trigger:
     include:
-      - project: 'devsecops3000Pro/public/pipelines/security-pipeline'
-        file: 'security_pipeline.yaml'
-        ref: 'master'
+      - project: devsecops3000Pro/public/pipelines/security-pipeline
+        file: security_pipeline.yaml
+        ref: master
     forward:
       pipeline_variables: true
       yaml_variables: true

--- a/data_rentgen/dto/dataset.py
+++ b/data_rentgen/dto/dataset.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from data_rentgen.dto.location import LocationDTO
 
 
-@dataclass
+@dataclass(slots=True)
 class DatasetDTO:
     location: LocationDTO
     name: str

--- a/data_rentgen/dto/dataset_column_relation.py
+++ b/data_rentgen/dto/dataset_column_relation.py
@@ -28,7 +28,7 @@ class DatasetColumnRelationTypeDTO(IntFlag):
     CONDITIONAL = 2048
 
 
-@dataclass
+@dataclass(slots=True)
 class DatasetColumnRelationDTO:
     type: DatasetColumnRelationTypeDTO
     source_column: str

--- a/data_rentgen/dto/dataset_symlink.py
+++ b/data_rentgen/dto/dataset_symlink.py
@@ -17,7 +17,7 @@ class DatasetSymlinkTypeDTO(str, Enum):
         return self.value
 
 
-@dataclass
+@dataclass(slots=True)
 class DatasetSymlinkDTO:
     from_dataset: DatasetDTO
     to_dataset: DatasetDTO

--- a/data_rentgen/dto/input.py
+++ b/data_rentgen/dto/input.py
@@ -13,7 +13,7 @@ from data_rentgen.dto.schema import SchemaDTO
 from data_rentgen.utils.uuid import generate_incremental_uuid
 
 
-@dataclass
+@dataclass(slots=True)
 class InputDTO:
     created_at: datetime
     operation: OperationDTO

--- a/data_rentgen/dto/job.py
+++ b/data_rentgen/dto/job.py
@@ -9,7 +9,7 @@ from data_rentgen.dto.job_type import JobTypeDTO
 from data_rentgen.dto.location import LocationDTO
 
 
-@dataclass
+@dataclass(slots=True)
 class JobDTO:
     name: str
     location: LocationDTO

--- a/data_rentgen/dto/job_type.py
+++ b/data_rentgen/dto/job_type.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 
-@dataclass
+@dataclass(slots=True)
 class JobTypeDTO:
     type: str
     id: int | None = field(default=None, compare=False)

--- a/data_rentgen/dto/location.py
+++ b/data_rentgen/dto/location.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 
-@dataclass
+@dataclass(slots=True)
 class LocationDTO:
     type: str
     name: str

--- a/data_rentgen/dto/operation.py
+++ b/data_rentgen/dto/operation.py
@@ -3,10 +3,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, IntEnum
-from functools import cached_property
 from uuid import UUID
 
 from data_rentgen.dto.run import RunDTO
@@ -36,9 +35,10 @@ class OperationStatusDTO(IntEnum):
     KILLED = 3
 
 
-@dataclass
+@dataclass(slots=True)
 class OperationDTO:
     id: UUID
+    created_at: datetime = field(init=False)
     run: RunDTO
     name: str | None = None
     type: OperationTypeDTO | None = None
@@ -50,13 +50,12 @@ class OperationDTO:
     started_at: datetime | None = None
     ended_at: datetime | None = None
 
+    def __post_init__(self):
+        self.created_at = extract_timestamp_from_uuid(self.id)
+
     @property
     def unique_key(self) -> tuple:
         return (self.id,)
-
-    @cached_property
-    def created_at(self) -> datetime:
-        return extract_timestamp_from_uuid(self.id)
 
     def merge(self, new: OperationDTO) -> OperationDTO:
         self.run.merge(new.run)

--- a/data_rentgen/dto/output.py
+++ b/data_rentgen/dto/output.py
@@ -27,7 +27,7 @@ class OutputTypeDTO(IntFlag):
     TRUNCATE = 64
 
 
-@dataclass
+@dataclass(slots=True)
 class OutputDTO:
     created_at: datetime
     operation: OperationDTO

--- a/data_rentgen/dto/pagination.py
+++ b/data_rentgen/dto/pagination.py
@@ -9,7 +9,7 @@ from typing import Generic, TypeVar
 T = TypeVar("T")
 
 
-@dataclass
+@dataclass(slots=True)
 class PaginationDTO(Generic[T]):
     items: list[T]
     page: int

--- a/data_rentgen/dto/run.py
+++ b/data_rentgen/dto/run.py
@@ -3,10 +3,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, IntEnum
-from functools import cached_property
 from uuid import UUID
 
 from data_rentgen.dto.job import JobDTO
@@ -30,9 +29,10 @@ class RunStartReasonDTO(str, Enum):
         return str(self.value)
 
 
-@dataclass
+@dataclass(slots=True)
 class RunDTO:
     id: UUID
+    created_at: datetime = field(init=False)
     job: JobDTO
     parent_run: RunDTO | None = None
     status: RunStatusDTO = RunStatusDTO.UNKNOWN
@@ -45,13 +45,12 @@ class RunDTO:
     running_log_url: str | None = None
     persistent_log_url: str | None = None
 
+    def __post_init__(self):
+        self.created_at = extract_timestamp_from_uuid(self.id)
+
     @property
     def unique_key(self) -> tuple:
         return (self.id,)
-
-    @cached_property
-    def created_at(self) -> datetime:
-        return extract_timestamp_from_uuid(self.id)
 
     def merge(self, new: RunDTO) -> RunDTO:
         self.job.merge(new.job)

--- a/data_rentgen/dto/schema.py
+++ b/data_rentgen/dto/schema.py
@@ -5,24 +5,23 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from functools import cached_property
 from uuid import UUID
 
 from data_rentgen.utils.uuid import generate_static_uuid
 
 
-@dataclass
+@dataclass(slots=True)
 class SchemaDTO:
     fields: list[dict]
+    digest: UUID = field(init=False)
     id: int | None = field(default=None, compare=False)
+
+    def __post_init__(self):
+        self.digest = generate_static_uuid(json.dumps(self.fields, sort_keys=True))
 
     @property
     def unique_key(self) -> tuple:
         return (self.digest,)
-
-    @cached_property
-    def digest(self) -> UUID:
-        return generate_static_uuid(json.dumps(self.fields, sort_keys=True))
 
     def merge(self, new: SchemaDTO) -> SchemaDTO:
         self.id = new.id or self.id

--- a/data_rentgen/dto/sql_query.py
+++ b/data_rentgen/dto/sql_query.py
@@ -3,24 +3,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from functools import cached_property
 from uuid import UUID
 
 from data_rentgen.utils.uuid import generate_static_uuid
 
 
-@dataclass
+@dataclass(slots=True)
 class SQLQueryDTO:
     query: str
+    fingerprint: UUID = field(init=False)
     id: int | None = field(default=None, compare=False)
+
+    def __post_init__(self):
+        self.fingerprint = generate_static_uuid(self.query)
 
     @property
     def unique_key(self) -> tuple:
         return (self.fingerprint,)
-
-    @cached_property
-    def fingerprint(self) -> UUID:
-        return generate_static_uuid(self.query)
 
     def merge(self, new: SQLQueryDTO) -> SQLQueryDTO:
         self.id = new.id or self.id

--- a/data_rentgen/dto/user.py
+++ b/data_rentgen/dto/user.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 
-@dataclass
+@dataclass(slots=True)
 class UserDTO:
     name: str
     id: int | None = field(default=None, compare=False)

--- a/tests/test_consumer/test_extractors/test_extractors_operation_airflow.py
+++ b/tests/test_consumer/test_extractors/test_extractors_operation_airflow.py
@@ -41,7 +41,7 @@ from data_rentgen.dto import (
 
 def test_extractors_extract_operation_airflow():
     now = datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc)
-    run_id = UUID("1efc1e7f-4015-6970-b4f9-12e828cb9b91")
+    run_id = UUID("01908223-0782-79b8-9495-b1c38aaee839")
     operation = OpenLineageRunEvent(
         eventType=OpenLineageRunEventType.COMPLETE,
         eventTime=now,
@@ -117,7 +117,7 @@ def test_extractors_extract_operation_airflow():
 
 def test_extractors_extract_operation_airflow_task_group():
     now = datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc)
-    run_id = UUID("1efc1e7f-4015-6970-b4f9-12e828cb9b91")
+    run_id = UUID("01908223-0782-79b8-9495-b1c38aaee839")
     operation = OpenLineageRunEvent(
         eventType=OpenLineageRunEventType.COMPLETE,
         eventTime=now,
@@ -194,7 +194,7 @@ def test_extractors_extract_operation_airflow_task_group():
 
 def test_extractors_extract_operation_airflow_map_index():
     now = datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc)
-    run_id = UUID("1efc1e7f-4015-6970-b4f9-12e828cb9b91")
+    run_id = UUID("01908223-0782-79b8-9495-b1c38aaee839")
     operation = OpenLineageRunEvent(
         eventType=OpenLineageRunEventType.COMPLETE,
         eventTime=now,

--- a/tests/test_consumer/test_extractors/test_extractors_run_airflow.py
+++ b/tests/test_consumer/test_extractors/test_extractors_run_airflow.py
@@ -516,7 +516,7 @@ def test_extractors_extract_run_airflow_task_log_url_2_x():
 )
 def test_extractors_extract_run_airflow_dag_owner(owner: str, extracted_user: UserDTO | None):
     now = datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc)
-    run_id = UUID("1efc1e4c-04e5-6cc0-b991-358ae6c316c8")
+    run_id = UUID("01908223-0782-79b8-9495-b1c38aaee839")
     run = OpenLineageRunEvent(
         eventType=OpenLineageRunEventType.COMPLETE,
         eventTime=now,
@@ -588,7 +588,7 @@ def test_extractors_extract_run_airflow_dag_owner(owner: str, extracted_user: Us
 )
 def test_extractors_extract_run_airflow_task_owner(owner: str, extracted_user: UserDTO | None):
     now = datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc)
-    run_id = UUID("1efc1e7f-4015-6970-b4f9-12e828cb9b91")
+    run_id = UUID("01908223-0782-79b8-9495-b1c38aaee839")
     run = OpenLineageRunEvent(
         eventType=OpenLineageRunEventType.COMPLETE,
         eventTime=now,
@@ -653,7 +653,7 @@ def test_extractors_extract_run_airflow_task_owner(owner: str, extracted_user: U
 
 def test_extractors_extract_run_airflow_3_x_task_map_index():
     now = datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc)
-    run_id = UUID("1efc1e7f-4015-6970-b4f9-12e828cb9b91")
+    run_id = UUID("01908223-0782-79b8-9495-b1c38aaee839")
     run = OpenLineageRunEvent(
         eventType=OpenLineageRunEventType.COMPLETE,
         eventTime=now,
@@ -724,7 +724,7 @@ def test_extractors_extract_run_airflow_3_x_task_map_index():
 
 def test_extractors_extract_run_airflow_2_x_task_map_index():
     now = datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc)
-    run_id = UUID("1efc1e7f-4015-6970-b4f9-12e828cb9b91")
+    run_id = UUID("01908223-0782-79b8-9495-b1c38aaee839")
     run = OpenLineageRunEvent(
         eventType=OpenLineageRunEventType.COMPLETE,
         eventTime=now,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

`dataclass(slots=True)` reduces memory usage and speeds up attribute access a little bit.

This conflicts with `@cached_property` (it requires class to have `__dict__` attribute), so I've replaced it with regular field initialized within constructor. This doesn't work with `ColumnLineageDTO` because it's `fingerprint` depends on list of `DatasetColumnRelationDTO` which is dynamic.

Before - extraction takes 38.27% of al consumer method calls:
![profile_dto-inplace](https://github.com/user-attachments/assets/42a3add8-30f9-4b83-8dda-abf361e9dcb9)

After - 37.36%
![profile_dto-inplace-slots](https://github.com/user-attachments/assets/92b663c9-367b-4405-afd0-59d70a3f36de)


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
