### PR TITLE
[DOP-27406] Add workaround for Spark sessions with name=unknown

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,9 +10,9 @@ security-scan:
   stage: security-scan
   trigger:
     include:
-      - project: 'devsecops3000Pro/public/pipelines/security-pipeline'
-        file: 'security_pipeline.yaml'
-        ref: 'master'
+      - project: devsecops3000Pro/public/pipelines/security-pipeline
+        file: security_pipeline.yaml
+        ref: master
     forward:
       pipeline_variables: true
       yaml_variables: true

--- a/data_rentgen/consumer/extractors/batch_extraction_result.py
+++ b/data_rentgen/consumer/extractors/batch_extraction_result.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import TypeVar
+from typing import Callable, TypeVar
 
 from data_rentgen.dto import (
     ColumnLineageDTO,
@@ -239,44 +239,50 @@ class BatchExtractionResult:
         lineage.target_dataset = self.get_dataset(lineage.target_dataset.unique_key)
         return lineage
 
+    @staticmethod
+    def _resolve(getter: Callable[[tuple], T], items: dict[tuple, T]) -> list[T]:
+        resolved = list(map(getter, items))
+        unique = {item.unique_key: item for item in resolved}
+        return [unique[key] for key in sorted(unique.keys())]
+
     def locations(self) -> list[LocationDTO]:
-        return list(map(self.get_location, sorted(self._locations)))
+        return self._resolve(self.get_location, self._locations)
 
     def datasets(self) -> list[DatasetDTO]:
-        return list(map(self.get_dataset, sorted(self._datasets)))
+        return self._resolve(self.get_dataset, self._datasets)
 
     def dataset_symlinks(self) -> list[DatasetSymlinkDTO]:
-        return list(map(self.get_dataset_symlink, sorted(self._dataset_symlinks)))
+        return self._resolve(self.get_dataset_symlink, self._dataset_symlinks)
 
     def job_types(self) -> list[JobTypeDTO]:
-        return list(map(self.get_job_type, sorted(self._job_types)))
+        return self._resolve(self.get_job_type, self._job_types)
 
     def jobs(self) -> list[JobDTO]:
-        return list(map(self.get_job, sorted(self._jobs)))
+        return self._resolve(self.get_job, self._jobs)
 
     def runs(self) -> list[RunDTO]:
-        return list(map(self.get_run, sorted(self._runs)))
+        return self._resolve(self.get_run, self._runs)
 
     def operations(self) -> list[OperationDTO]:
-        return list(map(self.get_operation, sorted(self._operations)))
+        return self._resolve(self.get_operation, self._operations)
 
     def inputs(self) -> list[InputDTO]:
-        return list(map(self.get_input, sorted(self._inputs)))
+        return self._resolve(self.get_input, self._inputs)
 
     def outputs(self) -> list[OutputDTO]:
-        return list(map(self.get_output, sorted(self._outputs)))
+        return self._resolve(self.get_output, self._outputs)
 
     def column_lineage(self) -> list[ColumnLineageDTO]:
-        return list(map(self.get_column_lineage, sorted(self._column_lineage)))
+        return self._resolve(self.get_column_lineage, self._column_lineage)
 
     def schemas(self) -> list[SchemaDTO]:
-        return list(map(self.get_schema, sorted(self._schemas)))
+        return self._resolve(self.get_schema, self._schemas)
 
     def sql_queries(self) -> list[SQLQueryDTO]:
-        return list(map(self.get_sql_query, sorted(self._sql_queries)))
+        return self._resolve(self.get_sql_query, self._sql_queries)
 
     def users(self) -> list[UserDTO]:
-        return list(map(self.get_user, sorted(self._users)))
+        return self._resolve(self.get_user, self._users)
 
     def merge(self, other: BatchExtractionResult) -> BatchExtractionResult:  # noqa: C901, PLR0912
         for location in other.locations():

--- a/data_rentgen/consumer/extractors/impl/spark.py
+++ b/data_rentgen/consumer/extractors/impl/spark.py
@@ -37,7 +37,10 @@ class SparkExtractor(GenericExtractor):
 
     def extract_run(self, event: OpenLineageRunEvent) -> RunDTO:
         run = super().extract_run(event)
+        self._enrich_run_identifiers(run, event)
+        return run
 
+    def _enrich_run_identifiers(self, run: RunDTO, event: OpenLineageRunEvent):
         app = event.run.facets.spark_applicationDetails
         if not app:
             return run
@@ -57,6 +60,8 @@ class SparkExtractor(GenericExtractor):
         # For Spark, SQL_JOB --parent-> SPARK_APPLICATION = operation -> run,
         # and parent is always here.
         run = self.extract_parent_run(event.run.facets.parent)  # type: ignore[arg-type]
+        # Workaround for https://github.com/OpenLineage/OpenLineage/issues/3846
+        self._enrich_run_identifiers(run, event)
         operation = super()._extract_operation(event, run)
 
         # in some cases, operation name may contain raw SELECT query with newlines. use spaces instead.

--- a/data_rentgen/dto/job.py
+++ b/data_rentgen/dto/job.py
@@ -24,6 +24,10 @@ class JobDTO:
         self.id = new.id or self.id
         self.location.merge(new.location)
 
+        if self.name == "unknown" and new.name != "unknown":
+            # Workaround for https://github.com/OpenLineage/OpenLineage/issues/3846
+            self.name = new.name
+
         if new.type and self.type:
             self.type.merge(new.type)
         else:

--- a/docs/changelog/next_release/263.improvement.rst
+++ b/docs/changelog/next_release/263.improvement.rst
@@ -1,0 +1,3 @@
+Add workaround if OpenLineage emitted Spark application event with ``job.name=unknown``.
+
+This requires installing OpenLineage with this fix merged: https://github.com/OpenLineage/OpenLineage/pull/3848.

--- a/tests/test_consumer/test_extractors/fixtures/spark_raw.py
+++ b/tests/test_consumer/test_extractors/fixtures/spark_raw.py
@@ -192,6 +192,28 @@ def spark_app_run_event_start() -> OpenLineageRunEvent:
 
 
 @pytest.fixture
+def spark_app_run_event_start_with_unknown_name() -> OpenLineageRunEvent:
+    event_time = datetime(2024, 7, 5, 9, 4, 48, 794900, tzinfo=timezone.utc)
+    run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
+    return OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.START,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="local://some.host.com",
+            name="unknown",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    processingType=OpenLineageJobProcessingType.NONE,
+                    integration="SPARK",
+                    jobType="APPLICATION",
+                ),
+            ),
+        ),
+        run=OpenLineageRun(runId=run_id),
+    )
+
+
+@pytest.fixture
 def spark_app_run_event_stop() -> OpenLineageRunEvent:
     event_time = datetime(2024, 7, 5, 9, 7, 15, 646000, tzinfo=timezone.utc)
     run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
@@ -244,6 +266,15 @@ def spark_operation_run_event_start() -> OpenLineageRunEvent:
                         runId=run_id,
                     ),
                 ),
+                spark_applicationDetails=OpenLineageSparkApplicationDetailsRunFacet(
+                    master="local[*]",
+                    appName="spark_session",
+                    applicationId="local-1719136537510",
+                    deployMode=OpenLineageSparkDeployMode.CLIENT,
+                    driverHost="127.0.0.1",
+                    userName="myuser",
+                    uiWebUrl="http://127.0.0.1:4040",
+                ),
             ),
         ),
     )
@@ -279,6 +310,15 @@ def spark_operation_run_event_running() -> OpenLineageRunEvent:
                     run=OpenLineageParentRun(
                         runId=run_id,
                     ),
+                ),
+                spark_applicationDetails=OpenLineageSparkApplicationDetailsRunFacet(
+                    master="local[*]",
+                    appName="spark_session",
+                    applicationId="local-1719136537510",
+                    deployMode=OpenLineageSparkDeployMode.CLIENT,
+                    driverHost="127.0.0.1",
+                    userName="myuser",
+                    uiWebUrl="http://127.0.0.1:4040",
                 ),
             ),
         ),

--- a/tests/test_consumer/test_extractors/test_extractors_batch_spark.py
+++ b/tests/test_consumer/test_extractors/test_extractors_batch_spark.py
@@ -92,6 +92,45 @@ def test_extractors_extract_batch_spark_without_lineage(
     assert not extracted.outputs()
 
 
+def test_extractors_extract_batch_spark_openlineage_emitted_unknown_name(
+    spark_app_run_event_start_with_unknown_name: OpenLineageRunEvent,
+    spark_app_run_event_stop: OpenLineageRunEvent,
+    spark_operation_run_event_start: OpenLineageRunEvent,
+    spark_operation_run_event_running: OpenLineageRunEvent,
+    spark_operation_run_event_stop: OpenLineageRunEvent,
+    extracted_spark_location: LocationDTO,
+    extracted_spark_app_job: JobDTO,
+    extracted_user: UserDTO,
+    extracted_spark_app_run: RunDTO,
+    extracted_spark_operation: OperationDTO,
+):
+    events = [
+        spark_app_run_event_start_with_unknown_name,
+        spark_operation_run_event_start,
+        spark_operation_run_event_running,
+        spark_operation_run_event_stop,
+        spark_app_run_event_stop,
+    ]
+
+    extracted = BatchExtractor().add_events(events)
+
+    # the result is the same as above
+    assert extracted.locations() == [
+        extracted_spark_location,
+    ]
+
+    assert extracted.jobs() == [extracted_spark_app_job]
+    assert extracted.users() == [extracted_user]
+    assert extracted.runs() == [extracted_spark_app_run]
+    assert extracted.operations() == [extracted_spark_operation]
+
+    assert not extracted.datasets()
+    assert not extracted.dataset_symlinks()
+    assert not extracted.schemas()
+    assert not extracted.inputs()
+    assert not extracted.outputs()
+
+
 @pytest.mark.parametrize(
     "input_transformation",
     [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Sometimes Spark application-level STARTED event is emitted with `job.name=unknown` and no information about Spark session (applicationId, urls, user name and so on).

https://github.com/OpenLineage/OpenLineage/pull/3848 implements a workaround - Spark command events now have `spark_applicationDetails` facet as well, so we can extract this information from other events emitted by integration.

Current PR implements extraction of Spark application data for all event types, and adds tests for this behavior.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
