### PR TITLE
[DOP-26804] Make granularity=DATASET lineage more precise

### DIFF
--- a/data_rentgen/db/repositories/io_dataset_relation.py
+++ b/data_rentgen/db/repositories/io_dataset_relation.py
@@ -70,11 +70,8 @@ class IODatasetRelationRepository:
             .join(
                 Input,
                 and_(
-                    Output.run_id == Input.run_id,
-                    # if same run executed 1 queries:
-                    # * SELECT max(...) FROM table1
-                    # * INSERT INTO table1
-                    # Avoid returning table1 -> table1 relations. Including ones resolved via symlink.
+                    Output.operation_id == Input.operation_id,
+                    # Avoid returning table1 -> table1 relations.
                     # TODO: cover case with self-reference via symlink
                     Output.dataset_id != Input.dataset_id,
                 ),

--- a/docs/changelog/next_release/264.bugfix.rst
+++ b/docs/changelog/next_release/264.bugfix.rst
@@ -1,0 +1,2 @@
+In 0.3.0 and 0.3.1 lineage with ``granularity=DATASET`` may return datasets which were not interacted with each other,
+but were inputs/outputs of the same run. Now only direct interactions are used while resolving lineage graph.

--- a/tests/test_server/test_lineage/test_dataset_lineage.py
+++ b/tests/test_server/test_lineage/test_dataset_lineage.py
@@ -1666,15 +1666,15 @@ async def test_get_dataset_lineage_with_granularity_dataset_without_output_schem
     }
 
 
-async def test_get_dataset_lineage_with_granularity_dataset_ignore_direct_self_references(
+async def test_get_dataset_lineage_with_granularity_dataset_ignore_self_references(
     test_client: AsyncClient,
     async_session: AsyncSession,
-    direct_self_reference_lineage: LineageResult,
+    self_referencing_lineage: LineageResult,
     mocked_user: MockedUser,
 ):
     # For this lineage:
     # J1 -> R1 -> O1, D1 -> O1 -> D1  # reading duplicates and removing them
-    lineage = direct_self_reference_lineage
+    lineage = self_referencing_lineage
 
     # We start at D1
     [dataset] = await enrich_datasets(lineage.datasets[:1], async_session)
@@ -1718,25 +1718,20 @@ async def test_get_dataset_lineage_with_granularity_dataset_ignore_direct_self_r
     }
 
 
-async def test_get_dataset_lineage_with_granularity_dataset_ignore_indirect_self_references(
+# TODO: handle this case in other granularities
+async def test_get_dataset_lineage_with_granularity_dataset_ignore_not_connected_operations(
     test_client: AsyncClient,
     async_session: AsyncSession,
-    indirect_self_reference_lineage: LineageResult,
+    lineage_with_non_connected_operations: LineageResult,
     mocked_user: MockedUser,
 ):
     # For this lineage:
     # J1 -> R1 -> O1, D1 -> O1        # SELECT max(id) FROM table1
-    # J1 -> R1 -> O2, D2 -> O2 -> D1  # INSERT INTO table1
-    lineage = indirect_self_reference_lineage
-
-    datasets = await enrich_datasets(lineage.datasets, async_session)
-    dataset1, dataset2 = datasets
-
-    inputs_by_dataset_id = {input_.dataset_id: input_ for input_ in lineage.inputs}
-    outputs_by_dataset_id = {output.dataset_id: output for output in lineage.outputs}
+    # J1 -> R1 -> O2,       O2 -> D2  # INSERT INTO table1 VALUES
+    lineage = lineage_with_non_connected_operations
 
     # We start at D1
-    dataset = dataset1
+    [dataset] = await enrich_datasets(lineage.datasets[:1], async_session)
     since = min(run.created_at for run in lineage.runs)
 
     response = await test_client.get(
@@ -1749,39 +1744,24 @@ async def test_get_dataset_lineage_with_granularity_dataset_ignore_indirect_self
         },
     )
 
-    # Return only D2 -> D1
+    # Return only nothing
     assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "relations": {
             "parents": [],
             "symlinks": [],
-            "inputs": [
-                {
-                    "from": {"kind": "DATASET", "id": str(dataset2.id)},
-                    "to": {"kind": "DATASET", "id": str(dataset1.id)},
-                    "num_bytes": None,
-                    "num_rows": None,
-                    "num_files": None,
-                    "last_interaction_at": format_datetime(outputs_by_dataset_id[dataset1.id].created_at),
-                },
-            ],
+            "inputs": [],
             "outputs": [],
             "direct_column_lineage": [],
             "indirect_column_lineage": [],
         },
         "nodes": {
             "datasets": {
-                str(dataset1.id): {
-                    "id": str(dataset1.id),
-                    "name": dataset1.name,
-                    "location": location_to_json(dataset1.location),
-                    "schema": schema_to_json(outputs_by_dataset_id[dataset1.id].schema, "EXACT_MATCH"),
-                },
-                str(dataset2.id): {
-                    "id": str(dataset2.id),
-                    "name": dataset2.name,
-                    "location": location_to_json(dataset2.location),
-                    "schema": schema_to_json(inputs_by_dataset_id[dataset2.id].schema, "EXACT_MATCH"),
+                str(dataset.id): {
+                    "id": str(dataset.id),
+                    "name": dataset.name,
+                    "location": location_to_json(dataset.location),
+                    "schema": None,
                 },
             },
             "jobs": {},


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Joining inputs & outputs by `run_id` may return false positives on lineage graph with `granulaity=DATASET`. Instead join by `operation_id`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
