### PR TITLE
[DOP-26993] Add custom DataRentgen facets

### DIFF
--- a/data_rentgen/consumer/extractors/impl/unknown.py
+++ b/data_rentgen/consumer/extractors/impl/unknown.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from data_rentgen.consumer.extractors.generic import GenericExtractor
 from data_rentgen.consumer.openlineage.run_event import OpenLineageRunEvent
+from data_rentgen.dto import OperationDTO, RunDTO
+from data_rentgen.dto.run import RunStartReasonDTO
+from data_rentgen.dto.user import UserDTO
 
 
 class UnknownExtractor(GenericExtractor):
@@ -15,6 +18,40 @@ class UnknownExtractor(GenericExtractor):
     def match(self, event: OpenLineageRunEvent) -> bool:
         return True
 
+    def extract_operation(self, event: OpenLineageRunEvent) -> OperationDTO:
+        # if event has only dataRentgen_operation facet, it is Operation. Otherwise it is Run + Operation.
+        if event.run.facets.parent and event.run.facets.dataRentgen_operation and not event.run.facets.dataRentgen_run:
+            run = self.extract_parent_run(event.run.facets.parent)
+        else:
+            run = self.extract_run(event)
+
+        operation = self._extract_operation(event, run)
+        return self._enrich_operation_info(operation, event)
+
+    def extract_run(self, event: OpenLineageRunEvent) -> RunDTO:
+        run = super().extract_run(event)
+        return self._enrich_run_info(run, event)
+
+    def _enrich_run_info(self, run: RunDTO, event: OpenLineageRunEvent) -> RunDTO:
+        run_info_facet = event.run.facets.dataRentgen_run
+        if run_info_facet:
+            run.external_id = run_info_facet.external_id
+            run.attempt = run_info_facet.attempt
+            run.persistent_log_url = run_info_facet.persistent_log_url
+            run.running_log_url = run_info_facet.running_log_url
+            run.start_reason = RunStartReasonDTO(run_info_facet.start_reason) if run_info_facet.start_reason else None
+            run.user = UserDTO(name=run_info_facet.started_by_user) if run_info_facet.started_by_user else None
+        return run
+
+    def _enrich_operation_info(self, operation: OperationDTO, event: OpenLineageRunEvent):
+        operation_info_facet = event.run.facets.dataRentgen_operation
+        if operation_info_facet:
+            operation.name = operation_info_facet.name or operation.name
+            operation.description = operation_info_facet.description
+            operation.position = operation_info_facet.position
+            operation.group = operation_info_facet.group
+        return operation
+
     def is_operation(self, event: OpenLineageRunEvent) -> bool:
         # This is heuristics which prevents creating useless operations
-        return bool(event.inputs or event.outputs)
+        return bool(event.run.facets.dataRentgen_operation or event.inputs or event.outputs)

--- a/data_rentgen/consumer/openlineage/run_facets/__init__.py
+++ b/data_rentgen/consumer/openlineage/run_facets/__init__.py
@@ -13,6 +13,8 @@ from data_rentgen.consumer.openlineage.run_facets.airflow import (
     OpenLineageAirflowTaskRunFacet,
 )
 from data_rentgen.consumer.openlineage.run_facets.base import OpenLineageRunFacet
+from data_rentgen.consumer.openlineage.run_facets.data_rentgen_operation import DataRentgenOperationInfoFacet
+from data_rentgen.consumer.openlineage.run_facets.data_rentgen_run import DataRentgenRunInfoFacet
 from data_rentgen.consumer.openlineage.run_facets.dbt_run import OpenLineageDbtRunRunFacet
 from data_rentgen.consumer.openlineage.run_facets.flink_job import (
     OpenLineageFlinkJobDetailsRunFacet,
@@ -36,6 +38,8 @@ from data_rentgen.consumer.openlineage.run_facets.spark_job import (
 )
 
 __all__ = [
+    "DataRentgenOperationInfoFacet",
+    "DataRentgenRunInfoFacet",
     "OpenLineageAirflowDagInfo",
     "OpenLineageAirflowDagRunFacet",
     "OpenLineageAirflowDagRunInfo",
@@ -65,6 +69,8 @@ class OpenLineageRunFacets(OpenLineageBase):
 
     parent: OpenLineageParentRunFacet | None = None
     processing_engine: OpenLineageProcessingEngineRunFacet | None = None
+    dataRentgen_run: DataRentgenRunInfoFacet | None = None
+    dataRentgen_operation: DataRentgenOperationInfoFacet | None = None
     spark_applicationDetails: OpenLineageSparkApplicationDetailsRunFacet | None = None
     spark_jobDetails: OpenLineageSparkJobDetailsRunFacet | None = None
     airflow: OpenLineageAirflowTaskRunFacet | None = None

--- a/data_rentgen/consumer/openlineage/run_facets/data_rentgen_operation.py
+++ b/data_rentgen/consumer/openlineage/run_facets/data_rentgen_operation.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2024-2025 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+
+from data_rentgen.consumer.openlineage.run_facets.base import OpenLineageRunFacet
+
+
+class DataRentgenOperationInfoFacet(OpenLineageRunFacet):
+    """
+    Custom facet representing DataRentgen Operation fields.
+
+    If OpenLineage Run have this facet, it is considered a DataRentgen Operation,
+    or DataRentgen Run + Operation if DataRentgenRunInfoFacet is also present.
+    """
+
+    name: str | None = None
+    description: str | None = None
+    group: str | None = None
+    position: int | None = None

--- a/data_rentgen/consumer/openlineage/run_facets/data_rentgen_run.py
+++ b/data_rentgen/consumer/openlineage/run_facets/data_rentgen_run.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024-2025 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Literal
+
+from data_rentgen.consumer.openlineage.run_facets.base import OpenLineageRunFacet
+
+
+class DataRentgenRunInfoFacet(OpenLineageRunFacet):
+    """
+    Custom facet representing DataRentgen Run fields.
+
+    If OpenLineage Run have this facet, it is considered a DataRentgen Run,
+    or DataRentgen Run + Operation if DataRentgenOperationInfoFacet is also present.
+    """
+
+    external_id: str | None = None
+    attempt: str | None = None
+    running_log_url: str | None = None
+    persistent_log_url: str | None = None
+    start_reason: Literal["AUTOMATIC", "MANUAL"] | None = None
+    started_by_user: str | None = None

--- a/docs/changelog/next_release/265.feature.rst
+++ b/docs/changelog/next_release/265.feature.rst
@@ -1,0 +1,4 @@
+Add custom ``dataRentgen_run`` and ``dataRentgen_operation`` facets allowing to:
+  * Passing custom ``external_id``, ``persistent_log_url`` and other fields of Run.
+  * Passing custom ``name``, ``description``, ``group``, ``positition`` fields of Operation.
+  * mark event as containing only Operation or both Run + Operation data.

--- a/tests/test_consumer/test_extractors/test_extractors_operation_unknown.py
+++ b/tests/test_consumer/test_extractors/test_extractors_operation_unknown.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 import pytest
 from uuid6 import UUID
 
-from data_rentgen.consumer.extractors.generic import GenericExtractor
+from data_rentgen.consumer.extractors.impl import UnknownExtractor
 from data_rentgen.consumer.openlineage.job import OpenLineageJob
 from data_rentgen.consumer.openlineage.job_facets import (
     OpenLineageJobFacets,
@@ -23,6 +23,8 @@ from data_rentgen.consumer.openlineage.run_facets import (
     OpenLineageParentRunFacet,
     OpenLineageRunFacets,
 )
+from data_rentgen.consumer.openlineage.run_facets.data_rentgen_operation import DataRentgenOperationInfoFacet
+from data_rentgen.consumer.openlineage.run_facets.data_rentgen_run import DataRentgenRunInfoFacet
 from data_rentgen.dto import (
     JobDTO,
     JobTypeDTO,
@@ -33,11 +35,14 @@ from data_rentgen.dto import (
     RunDTO,
     RunStatusDTO,
 )
+from data_rentgen.dto.run import RunStartReasonDTO
+from data_rentgen.dto.user import UserDTO
 
 
 def test_extractors_extract_operation_unknown():
     now = datetime(2024, 7, 5, 9, 6, 29, 462000, tzinfo=timezone.utc)
-    run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
+    run_id = UUID("01908225-1fd7-746b-910C-70d24f2898b1")
+    parent_run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
 
     operation = OpenLineageRunEvent(
         eventType=OpenLineageRunEventType.START,
@@ -52,13 +57,13 @@ def test_extractors_extract_operation_unknown():
                         name="parentjob",
                     ),
                     run=OpenLineageParentRun(
-                        runId=run_id,
+                        runId=parent_run_id,
                     ),
                 ),
             ),
         ),
     )
-    assert GenericExtractor().extract_operation(operation) == OperationDTO(
+    assert UnknownExtractor().extract_operation(operation) == OperationDTO(
         id=run_id,
         run=RunDTO(
             id=run_id,
@@ -71,7 +76,7 @@ def test_extractors_extract_operation_unknown():
                 ),
             ),
             parent_run=RunDTO(
-                id=run_id,
+                id=parent_run_id,
                 job=JobDTO(
                     name="parentjob",
                     location=LocationDTO(
@@ -109,7 +114,8 @@ def test_extractors_extract_operation_unknown_finished(
     expected_status: OperationStatusDTO,
 ):
     now = datetime(2024, 7, 5, 9, 6, 29, 462000, tzinfo=timezone.utc)
-    run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
+    run_id = UUID("01908225-1fd7-746b-910C-70d24f2898b1")
+    parent_run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
     operation = OpenLineageRunEvent(
         eventType=event_type,
         eventTime=now,
@@ -133,7 +139,7 @@ def test_extractors_extract_operation_unknown_finished(
                         name="parentjob",
                     ),
                     run=OpenLineageParentRun(
-                        runId=run_id,
+                        runId=parent_run_id,
                     ),
                 ),
             ),
@@ -142,7 +148,7 @@ def test_extractors_extract_operation_unknown_finished(
 
     ended_at = now if expected_status != OperationStatusDTO.UNKNOWN else None
 
-    assert GenericExtractor().extract_operation(operation) == OperationDTO(
+    assert UnknownExtractor().extract_operation(operation) == OperationDTO(
         id=run_id,
         run=RunDTO(
             id=run_id,
@@ -156,7 +162,7 @@ def test_extractors_extract_operation_unknown_finished(
                 ),
             ),
             parent_run=RunDTO(
-                id=run_id,
+                id=parent_run_id,
                 job=JobDTO(
                     name="parentjob",
                     location=LocationDTO(
@@ -177,4 +183,150 @@ def test_extractors_extract_operation_unknown_finished(
         status=expected_status,
         started_at=None,
         ended_at=ended_at,
+    )
+
+
+def test_extractors_extract_operation_unknown_with_explicit_operation_info():
+    now = datetime(2024, 7, 5, 9, 6, 29, 462000, tzinfo=timezone.utc)
+    operation_id = UUID("01908225-1fd7-746b-910C-70d24f2898b1")
+    run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
+    operation = OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.COMPLETE,
+        eventTime=now,
+        job=OpenLineageJob(
+            namespace="anything",
+            name="someoperation",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="UNKNOWN",
+                    jobType="SOMETHING",
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=operation_id,
+            facets=OpenLineageRunFacets(
+                parent=OpenLineageParentRunFacet(
+                    job=OpenLineageParentJob(
+                        namespace="anything",
+                        name="myjob",
+                    ),
+                    run=OpenLineageParentRun(
+                        runId=run_id,
+                    ),
+                ),
+                dataRentgen_operation=DataRentgenOperationInfoFacet(
+                    description="some description",
+                    group="some group",
+                    position=1,
+                ),
+            ),
+        ),
+    )
+
+    assert UnknownExtractor().extract_operation(operation) == OperationDTO(
+        id=operation_id,
+        run=RunDTO(
+            id=run_id,
+            job=JobDTO(
+                name="myjob",
+                location=LocationDTO(
+                    type="unknown",
+                    name="anything",
+                    addresses={"unknown://anything"},
+                ),
+            ),
+            status=RunStatusDTO.UNKNOWN,
+        ),
+        name="someoperation",
+        type=OperationTypeDTO.BATCH,
+        position=1,
+        description="some description",
+        group="some group",
+        status=OperationStatusDTO.SUCCEEDED,
+        started_at=None,
+        ended_at=now,
+    )
+
+
+@pytest.mark.parametrize(
+    ["custom_operation_name", "expected_operation_name"],
+    [
+        (None, "myjob"),
+        ("custom_operation_name", "custom_operation_name"),
+    ],
+)
+def test_extractors_extract_operation_unknown_with_explicit_operation_and_run_info(
+    custom_operation_name: str | None,
+    expected_operation_name: str,
+):
+    now = datetime(2024, 7, 5, 9, 6, 29, 462000, tzinfo=timezone.utc)
+    run_id = UUID("01908225-1fd7-746b-910C-70d24f2898b1")
+    operation = OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.COMPLETE,
+        eventTime=now,
+        job=OpenLineageJob(
+            namespace="anything",
+            name="myjob",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    processingType=OpenLineageJobProcessingType.BATCH,
+                    integration="UNKNOWN",
+                    jobType="SOMETHING",
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=run_id,
+            facets=OpenLineageRunFacets(
+                dataRentgen_operation=DataRentgenOperationInfoFacet(
+                    name=custom_operation_name,
+                    description="some description",
+                    group="some group",
+                    position=1,
+                ),
+                dataRentgen_run=DataRentgenRunInfoFacet(
+                    external_id="external_id",
+                    attempt="attempt",
+                    running_log_url="running_log_url",
+                    persistent_log_url="persistent_log_url",
+                    start_reason="AUTOMATIC",
+                    started_by_user="someuser",
+                ),
+            ),
+        ),
+    )
+
+    assert UnknownExtractor().extract_operation(operation) == OperationDTO(
+        id=run_id,
+        run=RunDTO(
+            id=run_id,
+            job=JobDTO(
+                name="myjob",
+                type=JobTypeDTO(type="UNKNOWN_SOMETHING"),
+                location=LocationDTO(
+                    type="unknown",
+                    name="anything",
+                    addresses={"unknown://anything"},
+                ),
+            ),
+            status=RunStatusDTO.SUCCEEDED,
+            started_at=None,
+            start_reason=RunStartReasonDTO.AUTOMATIC,
+            ended_at=now,
+            external_id="external_id",
+            attempt="attempt",
+            persistent_log_url="persistent_log_url",
+            running_log_url="running_log_url",
+            user=UserDTO(name="someuser"),
+        ),
+        name=expected_operation_name,
+        type=OperationTypeDTO.BATCH,
+        position=1,
+        description="some description",
+        group="some group",
+        status=OperationStatusDTO.SUCCEEDED,
+        started_at=None,
+        ended_at=now,
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

* Added new facets `dataRentgen_run` and `dataRentgen_operation` with fields resembling Run and Operation DTOs.
* Added logic of extracting these fields to `UnknownExtractor`, with tests.

These facets allow informing DataRentgen that it should create either Operation, Run or both from specific runEvent, which is important for custom integrations.

This doesn't include documentation, it will be added later.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
