### PR TITLE
[DOP-25469] Drop unused indexes from custom_user_properties

### DIFF
--- a/data_rentgen/db/migrations/versions/2025-04-25_2d2fe3f2f348_add_job_type.py
+++ b/data_rentgen/db/migrations/versions/2025-04-25_2d2fe3f2f348_add_job_type.py
@@ -90,9 +90,9 @@ def downgrade() -> None:
     op.execute(
         sa.text(
             """
-        UPDATE job
-        SET type = (SELECT job_type.type FROM job_type WHERE job_type.id = job.type);
-        """,
+            UPDATE job
+            SET type = (SELECT job_type.type FROM job_type WHERE job_type.id = job.type);
+            """,
         ),
     )
     op.create_index("ix__job__type", "job", ["type"], unique=False)

--- a/data_rentgen/db/migrations/versions/2025-07-14_b8f1e422143d_add_tags_for_datasets.py
+++ b/data_rentgen/db/migrations/versions/2025-07-14_b8f1e422143d_add_tags_for_datasets.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2024-2025 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
-"""add_tags_for_datasets
+"""Add tags for datasets
 
 Revision ID: b8f1e422143d
 Revises: def0be789a48

--- a/data_rentgen/db/migrations/versions/2025-07-23_4655ed1b9501_drop_custom_user_properties_unused_.py
+++ b/data_rentgen/db/migrations/versions/2025-07-23_4655ed1b9501_drop_custom_user_properties_unused_.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2024-2025 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+"""Drop custom_user_properties unused indexes
+
+Revision ID: 4655ed1b9501
+Revises: b8f1e422143d
+Create Date: 2025-07-23 12:55:28.351325
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4655ed1b9501"
+down_revision = "b8f1e422143d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ExcludeConstraint already created index under the hood, on the same columns
+    op.drop_index(op.f("ix__custom_user_properties__property_id"), table_name="custom_user_properties")
+    op.drop_index(op.f("ix__custom_user_properties__user_id"), table_name="custom_user_properties")
+
+
+def downgrade() -> None:
+    op.create_index(
+        op.f("ix__custom_user_properties__user_id"),
+        table_name="custom_user_properties",
+        columns=["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix__custom_user_properties__property_id"),
+        table_name="custom_user_properties",
+        columns=["property_id"],
+        unique=False,
+    )

--- a/data_rentgen/db/models/custom_user_properties.py
+++ b/data_rentgen/db/models/custom_user_properties.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+from datetime import datetime
+
 from sqlalchemy import BigInteger, ForeignKey, text
-from sqlalchemy.dialects.postgresql import JSONB, TSTZRANGE, ExcludeConstraint
+from sqlalchemy.dialects.postgresql import JSONB, TSTZRANGE, ExcludeConstraint, Range
 from sqlalchemy.orm import Mapped, mapped_column
 
 from data_rentgen.db.models.base import Base
@@ -25,7 +27,6 @@ class CustomUserProperties(Base):
     user_id: Mapped[int] = mapped_column(
         BigInteger,
         ForeignKey("user.id", ondelete="CASCADE"),
-        index=True,
         nullable=False,
         doc="Id of corresponding user",
     )
@@ -33,7 +34,6 @@ class CustomUserProperties(Base):
     property_id: Mapped[int] = mapped_column(
         BigInteger,
         ForeignKey("custom_properties.id", ondelete="CASCADE"),
-        index=True,
         nullable=False,
         doc="Id of user's custom property",
     )
@@ -41,10 +41,12 @@ class CustomUserProperties(Base):
     value: Mapped[JSONB] = mapped_column(
         JSONB,
         nullable=False,
+        doc="Value of user's custom property",
     )
 
-    during: Mapped[TSTZRANGE] = mapped_column(
+    during: Mapped[Range[datetime]] = mapped_column(
         TSTZRANGE,
         server_default=text("tstzrange(now(), NULL, '[)')"),
         nullable=False,
+        doc="Duration when value of user's custom property is valid",
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Exclusion constraints in PostgreSQL creates an index, so indexes on user_id and property_id can be replaced with one index user_id + property_id + duration.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
