### PR TITLE
[DOP-25468] Validate UUID version using Pydantic UUID7 class

### DIFF
--- a/data_rentgen/openlineage/run.py
+++ b/data_rentgen/openlineage/run.py
@@ -1,11 +1,10 @@
 # SPDX-FileCopyrightText: 2024-2025 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
-from pydantic import Field
+from pydantic import UUID7, Field
 
 from data_rentgen.openlineage.base import OpenLineageBase
 from data_rentgen.openlineage.run_facets import OpenLineageRunFacets
-from data_rentgen.utils import UUIDv6Plus
 
 
 class OpenLineageRun(OpenLineageBase):
@@ -13,5 +12,5 @@ class OpenLineageRun(OpenLineageBase):
     See [Run](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json).
     """
 
-    runId: UUIDv6Plus
+    runId: UUID7
     facets: OpenLineageRunFacets = Field(default_factory=OpenLineageRunFacets)

--- a/data_rentgen/openlineage/run_facets/parent_run.py
+++ b/data_rentgen/openlineage/run_facets/parent_run.py
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: 2024-2025 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
+from pydantic import UUID7
+
 from data_rentgen.openlineage.base import OpenLineageBase
 from data_rentgen.openlineage.run_facets.base import OpenLineageRunFacet
-from data_rentgen.utils import UUIDv6Plus
 
 
 class OpenLineageParentJob(OpenLineageBase):
@@ -20,7 +21,7 @@ class OpenLineageParentRun(OpenLineageBase):
     See [ParentRunFacet](https://github.com/OpenLineage/OpenLineage/blob/main/spec/facets/ParentRunFacet.json).
     """
 
-    runId: UUIDv6Plus
+    runId: UUID7
 
 
 class OpenLineageParentRunFacet(OpenLineageRunFacet):

--- a/data_rentgen/server/schemas/v1/lineage.py
+++ b/data_rentgen/server/schemas/v1/lineage.py
@@ -7,13 +7,12 @@ from enum import Enum, IntEnum, IntFlag
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_serializer, field_validator
+from pydantic import UUID7, BaseModel, ConfigDict, Field, ValidationInfo, field_serializer, field_validator
 
 from data_rentgen.server.schemas.v1.dataset import DatasetResponseV1
 from data_rentgen.server.schemas.v1.job import JobResponseV1
 from data_rentgen.server.schemas.v1.operation import OperationResponseV1
 from data_rentgen.server.schemas.v1.run import RunResponseV1
-from data_rentgen.utils import UUIDv6Plus
 
 
 class LineageEntityKindV1(str, Enum):
@@ -99,11 +98,11 @@ class JobLineageQueryV1(BaseLineageQueryV1):
 
 
 class OperationLineageQueryV1(BaseLineageQueryV1):
-    start_node_id: UUIDv6Plus = Field(description="Operation id", examples=["00000000-0000-0000-0000-000000000000"])
+    start_node_id: UUID7 = Field(description="Operation id", examples=["00000000-0000-0000-0000-000000000000"])
 
 
 class RunLineageQueryV1(BaseLineageQueryV1):
-    start_node_id: UUIDv6Plus = Field(description="Run id", examples=["00000000-0000-0000-0000-000000000000"])
+    start_node_id: UUID7 = Field(description="Run id", examples=["00000000-0000-0000-0000-000000000000"])
     granularity: Literal["OPERATION", "RUN"] = Field(
         default="RUN",
         description="Granularity of the run lineage",

--- a/data_rentgen/server/schemas/v1/operation.py
+++ b/data_rentgen/server/schemas/v1/operation.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from fastapi import Query
 from pydantic import (
+    UUID7,
     BaseModel,
     ConfigDict,
     Field,
@@ -18,7 +19,6 @@ from pydantic import (
 )
 
 from data_rentgen.server.schemas.v1.pagination import PaginateQueryV1
-from data_rentgen.utils import UUIDv6Plus
 
 
 class OperationStatusV1(IntEnum):
@@ -115,13 +115,13 @@ class OperationQueryV1(PaginateQueryV1):
             examples=["2008-09-15T15:53:00+05:00"],
         ),
     )
-    operation_id: list[UUIDv6Plus] = Field(
+    operation_id: list[UUID7] = Field(
         Query(
             default_factory=list,
             description="Operation ids, for exact match",
         ),
     )
-    run_id: UUIDv6Plus | None = Field(
+    run_id: UUID7 | None = Field(
         Query(
             default=None,
             description="Run id, can be used only with 'since'",

--- a/data_rentgen/server/schemas/v1/run.py
+++ b/data_rentgen/server/schemas/v1/run.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from fastapi import Query
 from pydantic import (
+    UUID7,
     BaseModel,
     ConfigDict,
     Field,
@@ -19,7 +20,6 @@ from pydantic import (
 
 from data_rentgen.server.schemas.v1.pagination import PaginateQueryV1
 from data_rentgen.server.schemas.v1.user import UserResponseV1
-from data_rentgen.utils import UUIDv6Plus
 
 
 class RunStatusV1(IntEnum):
@@ -129,7 +129,7 @@ class RunsQueryV1(PaginateQueryV1):
             examples=["2008-09-15T15:53:00+05:00"],
         ),
     )
-    run_id: list[UUIDv6Plus] = Field(
+    run_id: list[UUID7] = Field(
         Query(
             default_factory=list,
             description="Run ids, for exact match",
@@ -142,7 +142,7 @@ class RunsQueryV1(PaginateQueryV1):
         ),
     )
 
-    parent_run_id: UUIDv6Plus | None = Field(
+    parent_run_id: UUID7 | None = Field(
         Query(
             default=None,
             description="Parent run id, can be used only with 'since' and 'until'",

--- a/data_rentgen/utils/__init__.py
+++ b/data_rentgen/utils/__init__.py
@@ -1,5 +1,2 @@
 # SPDX-FileCopyrightText: 2024-2025 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
-from data_rentgen.utils.uuid import UUIDv6Plus
-
-__all__ = ["UUIDv6Plus"]

--- a/data_rentgen/utils/uuid.py
+++ b/data_rentgen/utils/uuid.py
@@ -6,15 +6,13 @@ import secrets
 import time
 from datetime import datetime, timezone
 from hashlib import sha1
-from typing import Annotated, Any
+from typing import Any
 from uuid import NAMESPACE_URL, uuid5
 from uuid import UUID as BaseUUID  # noqa: N811
 
-from pydantic import PlainValidator
 from uuid6 import UUID as NewUUID  # noqa: N811
 
 __all__ = [
-    "UUIDv6Plus",
     "extract_timestamp_from_uuid",
     "generate_incremental_uuid",
     "generate_new_uuid",
@@ -108,11 +106,3 @@ def uuid_version_validator(run_id: Any) -> NewUUID:
             raise ValueError(err_msg)
         return run_id
     return run_id
-
-
-# Teach Pydantic how to parse and represent UUID v7
-# Right now use uuid from uuid lib cause: https://github.com/tiangolo/fastapi/issues/10259
-UUIDv6Plus = Annotated[
-    BaseUUID,
-    PlainValidator(uuid_version_validator),
-]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Using `pydantic.UUID7` class for OpenLineage and FastAPI request annotations instead of PlainValidator. This allows to check UUID version on pydantic-core (Rust) side, and pass UUID version to Swagger:
<img width="576" height="103" alt="изображение" src="https://github.com/user-attachments/assets/96e69017-8c1d-49d6-8d56-eb083eadc742" />


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
