### PR TITLE
[DOP-25470] Enable authentication using personal tokens

### DIFF
--- a/data_rentgen/consumer/__init__.py
+++ b/data_rentgen/consumer/__init__.py
@@ -74,7 +74,7 @@ def application_factory(settings: ConsumerApplicationSettings) -> AsgiFastStream
                 await settings.kafka.security.destroy()
                 tg.cancel_scope.cancel()
         except ExceptionGroup as e:
-            for exception in e.exceptions:
+            for exception in e.exceptions:  # type: ignore[attr-defined]
                 raise exception from None
 
     return FastStream(

--- a/data_rentgen/consumer/settings/__init__.py
+++ b/data_rentgen/consumer/settings/__init__.py
@@ -39,7 +39,10 @@ class ConsumerApplicationSettings(BaseSettings):
         DATA_RENTGEN__LOGGING__PRESET=json
     """  # noqa: E501
 
-    database: DatabaseSettings = Field(description=":ref:`Database settings <configuration-database>`")
+    database: DatabaseSettings = Field(
+        default_factory=DatabaseSettings,  # type: ignore[arg-type]
+        description=":ref:`Database settings <configuration-database>`",
+    )
     logging: LoggingSettings = Field(
         default_factory=LoggingSettings,
         description=":ref:`Logging settings <configuration-consumer-logging>`",

--- a/data_rentgen/http2kafka/settings.py
+++ b/data_rentgen/http2kafka/settings.py
@@ -6,7 +6,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from data_rentgen.consumer.settings.kafka import KafkaSettings
 from data_rentgen.consumer.settings.producer import ProducerSettings
+from data_rentgen.db.settings import DatabaseSettings
 from data_rentgen.logging.settings import LoggingSettings
+from data_rentgen.server.settings.auth import AuthSettings
 from data_rentgen.server.settings.server import ServerSettings
 
 
@@ -41,6 +43,14 @@ class Http2KafkaApplicationSettings(BaseSettings):
         DATA_RENTGEN__PRODUCER__MAIN_TOPIC="input.runs"
     """  # noqa: E501
 
+    auth: AuthSettings = Field(
+        default_factory=AuthSettings,
+        description=":ref:`Authentication settings <configuration-server-authentication>`",
+    )
+    database: DatabaseSettings = Field(
+        default_factory=DatabaseSettings,  # type: ignore[arg-type]
+        description=":ref:`Database settings <configuration-database>`",
+    )
     logging: LoggingSettings = Field(
         default_factory=LoggingSettings,
         description=":ref:`Logging settings <configuration-server-logging>`",

--- a/data_rentgen/server/api/handlers.py
+++ b/data_rentgen/server/api/handlers.py
@@ -95,15 +95,14 @@ def application_exception_handler(request: Request, exc: ApplicationError) -> Re
 
 
 def not_authorized_redirect_exception_handler(request: Request, exc: RedirectError) -> Response:
-    logger.debug("Redirect user to keycloak")
     response = get_response_for_exception(RedirectError)
     if not response:
         return unknown_exception_handler(request, exc)
+
     content = response.schema(  # type: ignore[call-arg]
         message=exc.message,
         details=exc.details,
     )
-
     return exception_json_response(
         status=response.status,
         content=content,

--- a/data_rentgen/server/errors/registration.py
+++ b/data_rentgen/server/errors/registration.py
@@ -20,11 +20,18 @@ _responses_by_exception: dict[type[Exception], APIErrorResponse] = {}
 _responses_by_status_code: dict[int, APIErrorResponse] = {}
 
 
-def register_error_response(exception: type[Exception], status: http.HTTPStatus):
+def register_error_response(
+    exception: type[Exception],
+    status: http.HTTPStatus,
+):
     """Register mapping between exception, status code and JSON body schema."""
 
     def wrapper(cls):
-        response = APIErrorResponse(status.value, status.phrase, cls)
+        response = APIErrorResponse(
+            status=status.value,
+            description=status.phrase,
+            schema=cls,
+        )
         _responses_by_exception[exception] = response
         _responses_by_status_code[status.value] = response
         return cls

--- a/data_rentgen/server/providers/auth/personal_token_provider.py
+++ b/data_rentgen/server/providers/auth/personal_token_provider.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2024-2025 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from datetime import UTC, datetime, timedelta
+from pprint import pformat
+from typing import Annotated, Any, Literal
+from uuid import UUID
+
+from cachetools import LRUCache, TTLCache
+from fastapi import Depends, FastAPI, Request
+
+from data_rentgen.db.models import PersonalToken, User
+from data_rentgen.dependencies import Stub
+from data_rentgen.exceptions.auth import AuthorizationError
+from data_rentgen.exceptions.entity import EntityNotFoundError
+from data_rentgen.server.services.personal_token import PersonalTokenService
+from data_rentgen.server.settings.auth.personal_token import PersonalTokenSettings
+from data_rentgen.server.utils.jwt import decode_jwt, sign_jwt
+from data_rentgen.utils.uuid import extract_timestamp_from_uuid
+
+logger = logging.getLogger(__name__)
+
+
+class PersonalTokenCache:
+    def __init__(self, maxsize: int, ttl_seconds: int):
+        self.alive_cache: TTLCache[UUID, Literal[True]] = TTLCache(
+            maxsize=maxsize,
+            ttl=ttl_seconds,
+        )
+        # revoked tokens cannot be resurrected, no TTL
+        self.revoked_cache: LRUCache[UUID, Literal[True]] = LRUCache(maxsize=maxsize)
+
+    def is_revoked(self, token_id: UUID) -> bool | None:
+        if token_id in self.revoked_cache:
+            return True
+        if token_id in self.alive_cache:
+            return False
+        return None
+
+    def add_token(self, token_id: UUID) -> None:
+        self.alive_cache[token_id] = True
+
+    def revoke_token(self, token_id: UUID) -> None:
+        self.revoked_cache[token_id] = True
+        self.alive_cache.pop(token_id, None)
+
+
+class PersonalTokenAuthProvider:
+    """Auth provider which only accepts personal tokens.
+
+    Used internally by DataRentgen. Cannot not be used as a regular AuthProvider.
+    """
+
+    def __init__(
+        self,
+        settings: Annotated[PersonalTokenSettings, Depends(Stub(PersonalTokenSettings))],
+        token_cache: Annotated[PersonalTokenCache, Depends(Stub(PersonalTokenCache))],
+        personal_token_service: Annotated[PersonalTokenService, Depends()],
+    ) -> None:
+        self._settings = settings
+        self._token_cache = token_cache
+        self._personal_token_service = personal_token_service
+
+    @classmethod
+    def setup(cls, app: FastAPI) -> FastAPI:
+        settings = PersonalTokenSettings.model_validate(
+            app.state.settings.auth.personal_tokens,
+        )
+        token_cache = PersonalTokenCache(
+            maxsize=settings.cache_size,
+            ttl_seconds=settings.cache_ttl_seconds,
+        )
+        logger.info("Initializing %s provider with settings:\n%s", cls.__name__, pformat(settings))
+
+        async def get_settings():
+            return settings
+
+        async def get_token_cache():
+            return token_cache
+
+        app.dependency_overrides[PersonalTokenSettings] = get_settings
+        app.dependency_overrides[PersonalTokenCache] = get_token_cache
+        return app
+
+    def generate_jwt(
+        self,
+        user: User,
+        token: PersonalToken,
+    ) -> str:
+        since = datetime.combine(token.since, datetime.min.time(), tzinfo=UTC)
+        until = datetime.combine(token.until, datetime.min.time(), tzinfo=UTC) + timedelta(days=1)
+        claims = {
+            "jti": str(token.id),
+            "token_name": token.name,
+            "sub_id": user.id,
+            "preferred_username": user.name,
+            "scope": " ".join(token.scopes),
+            "iat": int(extract_timestamp_from_uuid(token.id).timestamp()),
+            "nbf": since.timestamp(),
+            "exp": until.timestamp(),
+        }
+        jwt = sign_jwt(
+            payload=claims,
+            secret_key=self._settings.secret_key.get_secret_value(),  # type: ignore[union-attr]
+            security_algorithm=self._settings.security_algorithm,
+        )
+        return f"personal_token_{jwt}"
+
+    def extract_token(
+        self,
+        jwt_string: str,
+    ) -> tuple[User, PersonalToken]:
+        claims = decode_jwt(
+            token=jwt_string.replace("personal_token_", ""),
+            secret_key=self._settings.secret_key.get_secret_value(),  # type: ignore[union-attr]
+            security_algorithm=self._settings.security_algorithm,
+        )
+        try:
+            token = PersonalToken(
+                id=UUID(claims["jti"]),
+                since=datetime.fromtimestamp(float(claims["nbf"]), tz=UTC),
+                until=datetime.fromtimestamp(float(claims["exp"]), tz=UTC),
+                name=claims["token_name"],
+                user_id=claims["sub_id"],
+                scopes=claims["scope"].split(" "),
+            )
+            user = User(id=int(claims["sub_id"]), name=claims["preferred_username"])
+        except (KeyError, TypeError, ValueError) as e:
+            msg = "Invalid token"
+            raise AuthorizationError(msg) from e
+        return user, token
+
+    async def get_current_user(self, access_token: str | None, request: Request) -> User:
+        if not access_token:
+            msg = "Missing Authorization header"
+            raise AuthorizationError(msg)
+
+        if not access_token.startswith("personal_token_"):
+            details = "Access token was passed but PersonalToken was expected"
+            msg = "Invalid token"
+            raise AuthorizationError(msg, details)
+
+        if not self._settings.enabled:
+            msg = "Authentication using PersonalTokens is disabled"
+            raise AuthorizationError(msg)
+
+        user, token = self.extract_token(access_token)
+        is_revoked = await self.check_token_revoked(user, token)
+        if is_revoked:
+            details = f"PersonalToken name='{token.name}', id={token.id} is revoked"
+            msg = "Invalid token"
+            raise AuthorizationError(msg, details)
+        logger.debug("Got user %r from token %r", user, token)
+        return user
+
+    async def get_optional_user(self, access_token: str | None, request: Request) -> User | None:
+        if not access_token or not access_token.startswith("personal_token_"):
+            return None
+
+        if not self._settings.enabled:
+            msg = "Authentication using PersonalTokens is disabled"
+            raise AuthorizationError(msg)
+
+        user, token = self.extract_token(access_token)
+        is_revoked = await self.check_token_revoked(user, token)
+        if is_revoked:
+            details = f"PersonalToken name='{token.name}', id={token.id} is revoked"
+            msg = "Invalid token"
+            raise AuthorizationError(msg, details)
+        logger.debug("Got user %r from token %r", user, token)
+        return user
+
+    async def check_token_revoked(self, user: User, token: PersonalToken) -> bool:
+        is_revoked = self._token_cache.is_revoked(token.id)
+        if is_revoked is not None:
+            return is_revoked
+
+        try:
+            await self._personal_token_service.get(user, token.id)
+            is_revoked = False
+        except EntityNotFoundError:
+            is_revoked = True
+
+        if is_revoked:
+            self._token_cache.revoke_token(token.id)
+        else:
+            self._token_cache.add_token(token.id)
+        return is_revoked
+
+    async def get_token_password_grant(
+        self,
+        login: str,
+        password: str,
+    ) -> dict[str, Any]:
+        msg = "Password grant is not supported by PersonalTokenAuthProvider"
+        raise NotImplementedError(msg)
+
+    async def get_token_authorization_code_grant(
+        self,
+        code: str,
+    ) -> dict[str, Any]:
+        msg = "Authorization code grant is not supported by PersonalTokenAuthProvider"
+        raise NotImplementedError(msg)
+
+    async def logout(self, user: User, refresh_token: str | None) -> None:
+        msg = "Logout method is not implemented for PersonalTokenAuthProvider"
+        raise NotImplementedError(msg)

--- a/data_rentgen/server/services/__init__.py
+++ b/data_rentgen/server/services/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024-2025 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 from data_rentgen.server.services.dataset import DatasetService
-from data_rentgen.server.services.get_user import get_user
+from data_rentgen.server.services.get_user import PersonalTokenPolicy, get_user
 from data_rentgen.server.services.job import JobService
 from data_rentgen.server.services.lineage import LineageService
 from data_rentgen.server.services.location import LocationService
@@ -15,6 +15,7 @@ __all__ = [
     "LineageService",
     "LocationService",
     "OperationService",
+    "PersonalTokenPolicy",
     "PersonalTokenService",
     "RunService",
     "get_user",

--- a/data_rentgen/server/services/get_user.py
+++ b/data_rentgen/server/services/get_user.py
@@ -1,30 +1,86 @@
 # SPDX-FileCopyrightText: 2024-2025 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Callable, Coroutine
+from enum import Enum
 from typing import Annotated, Any
 
 from fastapi import Depends, Request
-from fastapi.security import OAuth2PasswordBearer
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer, OAuth2PasswordBearer
 
 from data_rentgen.db.models import User
-from data_rentgen.dependencies import Stub
+from data_rentgen.exceptions.auth import AuthorizationError
 from data_rentgen.server.providers.auth import AuthProvider
+from data_rentgen.server.providers.auth.personal_token_provider import PersonalTokenAuthProvider
 
-oauth_schema = OAuth2PasswordBearer(tokenUrl="v1/auth/token", auto_error=False)
+
+class PersonalTokenPolicy(str, Enum):
+    ALLOW = "allow"
+    DENY = "deny"
+    REQUIRE = "require"
 
 
-def get_user() -> Callable[[Request, AuthProvider, str], Coroutine[Any, Any, User]]:
-    async def wrapper(
-        request: Request,
-        auth_provider: Annotated[AuthProvider, Depends(Stub(AuthProvider))],
-        access_token: Annotated[str | None, Depends(oauth_schema)],
-    ) -> User:
-        # keycloak provider patches session and store access_token in cookie,
-        # dummy auth stores access_token in "Authorization" header
-        access_token = request.session.get("access_token") or access_token
-        return await auth_provider.get_current_user(  # type: ignore[return-value]
-            access_token=access_token,
-            request=request,
-        )
+personal_token_schema = HTTPBearer(
+    description="Perform authentication using PersonalToken",
+    auto_error=False,
+)
+oauth2_schema = OAuth2PasswordBearer(
+    description="Perform authentication using configured AuthProvider",
+    tokenUrl="v1/auth/token",
+    auto_error=False,
+)
 
-    return wrapper
+
+async def get_user_via_any_credentials_source(
+    request: Request,
+    real_auth_provider: Annotated[AuthProvider, Depends()],
+    personal_token_provider: Annotated[PersonalTokenAuthProvider, Depends()],
+    access_token: Annotated[str | None, Depends(oauth2_schema)],
+    credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(personal_token_schema)],
+) -> User:
+    result = await personal_token_provider.get_optional_user(
+        access_token=credentials.credentials if credentials else access_token,
+        request=request,
+    )
+    if result:
+        return result
+
+    return await real_auth_provider.get_current_user(
+        access_token=access_token,
+        request=request,
+    )
+
+
+async def get_user_via_personal_token(
+    request: Request,
+    auth_provider: Annotated[PersonalTokenAuthProvider, Depends()],
+    credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(personal_token_schema)],
+) -> User:
+    result = await auth_provider.get_current_user(
+        access_token=credentials.credentials if credentials else None,
+        request=request,
+    )
+    if result:
+        return result
+    msg = "Missing Authorization header"
+    raise AuthorizationError(msg)
+
+
+async def get_user_via_access_token_or_cookie(
+    request: Request,
+    auth_provider: Annotated[AuthProvider, Depends()],
+    access_token: Annotated[str | None, Depends(oauth2_schema)],
+) -> User:
+    return await auth_provider.get_current_user(
+        access_token=access_token,
+        request=request,
+    )
+
+
+def get_user(
+    personal_token_policy: PersonalTokenPolicy = PersonalTokenPolicy.ALLOW,
+) -> Callable[..., Coroutine[Any, Any, User]]:
+    if personal_token_policy is PersonalTokenPolicy.REQUIRE:
+        return get_user_via_personal_token
+    if personal_token_policy is PersonalTokenPolicy.DENY:
+        return get_user_via_access_token_or_cookie
+    return get_user_via_any_credentials_source

--- a/data_rentgen/server/settings/__init__.py
+++ b/data_rentgen/server/settings/__init__.py
@@ -42,7 +42,10 @@ class ServerApplicationSettings(BaseSettings):
         default_factory=AuthSettings,
         description="Auth settings",
     )
-    database: DatabaseSettings = Field(description=":ref:`Database settings <configuration-database>`")
+    database: DatabaseSettings = Field(
+        default_factory=DatabaseSettings,  # type: ignore[arg-type]
+        description=":ref:`Database settings <configuration-database>`",
+    )
     logging: LoggingSettings = Field(
         default_factory=LoggingSettings,
         description=":ref:`Logging settings <configuration-server-logging>`",

--- a/data_rentgen/server/settings/auth/__init__.py
+++ b/data_rentgen/server/settings/auth/__init__.py
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: 2024-2025 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
-from pydantic import BaseModel, ConfigDict, Field, ImportString
+from pydantic import BaseModel, ConfigDict, Field, ImportString, field_validator
 
+from data_rentgen.server.providers.auth.base_provider import AuthProvider
 from data_rentgen.server.settings.auth.personal_token import PersonalTokenSettings
 
 
@@ -34,3 +35,11 @@ class AuthSettings(BaseModel):
     )
 
     model_config = ConfigDict(extra="allow")
+
+    @field_validator("provider", mode="after")
+    @classmethod
+    def _validate_provider(cls, value: type) -> type[AuthProvider]:
+        if not issubclass(value, AuthProvider):
+            msg = f"Class {value.__qualname__} is not a subclass of {AuthProvider}"
+            raise TypeError(msg)
+        return value

--- a/data_rentgen/server/settings/auth/personal_token.py
+++ b/data_rentgen/server/settings/auth/personal_token.py
@@ -58,12 +58,20 @@ class PersonalTokenSettings(BaseModel):
         description="Maximum duration of Personal Token in days",
     )
 
+    cache_ttl_seconds: int = Field(
+        default=300,
+        description="Maximum duration of Personal Token cache in seconds",
+    )
+
+    cache_size: int = Field(
+        default=500,
+        description="Maximum number of Personal Tokens in cache",
+    )
+
     @field_validator("secret_key", mode="after")
     @classmethod
     def _check_secret_key(cls, value: SecretStr | None, info: ValidationInfo) -> SecretStr | None:
-        if not info.data.get("enabled"):
-            return None
-        if not value:
+        if info.data.get("enabled") and not value:
             error_message = "Personal Access Tokens are enabled, but 'secret_key' is not set"
             raise ValueError(error_message)
         return value

--- a/poetry.lock
+++ b/poetry.lock
@@ -134,14 +134,14 @@ files = [
 
 [[package]]
 name = "anyio"
-version = "4.9.0"
-description = "High level compatibility layer for multiple asynchronous event loop implementations"
+version = "4.10.0"
+description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "test"]
 files = [
-    {file = "anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c"},
-    {file = "anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028"},
+    {file = "anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1"},
+    {file = "anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6"},
 ]
 
 [package.dependencies]
@@ -151,8 +151,6 @@ sniffio = ">=1.1"
 typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
-doc = ["Sphinx (>=8.2,<9.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
-test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "trustme", "truststore (>=0.9.1) ; python_version >= \"3.10\"", "uvloop (>=0.21) ; platform_python_implementation == \"CPython\" and platform_system != \"Windows\" and python_version < \"3.14\""]
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
@@ -332,15 +330,28 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
+name = "cachetools"
+version = "6.1.0"
+description = "Extensible memoizing collections and decorators"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"server\" or extra == \"http2kafka\""
+files = [
+    {file = "cachetools-6.1.0-py3-none-any.whl", hash = "sha256:1c7bb3cf9193deaf3508b7c5f2a79986c13ea38965c5adcff1f84519cf39163e"},
+    {file = "cachetools-6.1.0.tar.gz", hash = "sha256:b4c4f404392848db3ce7aac34950d17be4d864da4b8b66911008e430bc544587"},
+]
+
+[[package]]
 name = "certifi"
-version = "2025.7.14"
+version = "2025.8.3"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "docs", "test"]
 files = [
-    {file = "certifi-2025.7.14-py3-none-any.whl", hash = "sha256:6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2"},
-    {file = "certifi-2025.7.14.tar.gz", hash = "sha256:8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995"},
+    {file = "certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5"},
+    {file = "certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407"},
 ]
 
 [[package]]
@@ -589,100 +600,100 @@ cron = ["capturer (>=2.4)"]
 
 [[package]]
 name = "coverage"
-version = "7.10.1"
+version = "7.10.2"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["test"]
 files = [
-    {file = "coverage-7.10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1c86eb388bbd609d15560e7cc0eb936c102b6f43f31cf3e58b4fd9afe28e1372"},
-    {file = "coverage-7.10.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6b4ba0f488c1bdb6bd9ba81da50715a372119785458831c73428a8566253b86b"},
-    {file = "coverage-7.10.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:083442ecf97d434f0cb3b3e3676584443182653da08b42e965326ba12d6b5f2a"},
-    {file = "coverage-7.10.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c1a40c486041006b135759f59189385da7c66d239bad897c994e18fd1d0c128f"},
-    {file = "coverage-7.10.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3beb76e20b28046989300c4ea81bf690df84ee98ade4dc0bbbf774a28eb98440"},
-    {file = "coverage-7.10.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:bc265a7945e8d08da28999ad02b544963f813a00f3ed0a7a0ce4165fd77629f8"},
-    {file = "coverage-7.10.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:47c91f32ba4ac46f1e224a7ebf3f98b4b24335bad16137737fe71a5961a0665c"},
-    {file = "coverage-7.10.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1a108dd78ed185020f66f131c60078f3fae3f61646c28c8bb4edd3fa121fc7fc"},
-    {file = "coverage-7.10.1-cp310-cp310-win32.whl", hash = "sha256:7092cc82382e634075cc0255b0b69cb7cada7c1f249070ace6a95cb0f13548ef"},
-    {file = "coverage-7.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:ac0c5bba938879c2fc0bc6c1b47311b5ad1212a9dcb8b40fe2c8110239b7faed"},
-    {file = "coverage-7.10.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b45e2f9d5b0b5c1977cb4feb5f594be60eb121106f8900348e29331f553a726f"},
-    {file = "coverage-7.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3a7a4d74cb0f5e3334f9aa26af7016ddb94fb4bfa11b4a573d8e98ecba8c34f1"},
-    {file = "coverage-7.10.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d4b0aab55ad60ead26159ff12b538c85fbab731a5e3411c642b46c3525863437"},
-    {file = "coverage-7.10.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:dcc93488c9ebd229be6ee1f0d9aad90da97b33ad7e2912f5495804d78a3cd6b7"},
-    {file = "coverage-7.10.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa309df995d020f3438407081b51ff527171cca6772b33cf8f85344b8b4b8770"},
-    {file = "coverage-7.10.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cfb8b9d8855c8608f9747602a48ab525b1d320ecf0113994f6df23160af68262"},
-    {file = "coverage-7.10.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:320d86da829b012982b414c7cdda65f5d358d63f764e0e4e54b33097646f39a3"},
-    {file = "coverage-7.10.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dc60ddd483c556590da1d9482a4518292eec36dd0e1e8496966759a1f282bcd0"},
-    {file = "coverage-7.10.1-cp311-cp311-win32.whl", hash = "sha256:4fcfe294f95b44e4754da5b58be750396f2b1caca8f9a0e78588e3ef85f8b8be"},
-    {file = "coverage-7.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:efa23166da3fe2915f8ab452dde40319ac84dc357f635737174a08dbd912980c"},
-    {file = "coverage-7.10.1-cp311-cp311-win_arm64.whl", hash = "sha256:d12b15a8c3759e2bb580ffa423ae54be4f184cf23beffcbd641f4fe6e1584293"},
-    {file = "coverage-7.10.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6b7dc7f0a75a7eaa4584e5843c873c561b12602439d2351ee28c7478186c4da4"},
-    {file = "coverage-7.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:607f82389f0ecafc565813aa201a5cade04f897603750028dd660fb01797265e"},
-    {file = "coverage-7.10.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f7da31a1ba31f1c1d4d5044b7c5813878adae1f3af8f4052d679cc493c7328f4"},
-    {file = "coverage-7.10.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:51fe93f3fe4f5d8483d51072fddc65e717a175490804e1942c975a68e04bf97a"},
-    {file = "coverage-7.10.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e59d00830da411a1feef6ac828b90bbf74c9b6a8e87b8ca37964925bba76dbe"},
-    {file = "coverage-7.10.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:924563481c27941229cb4e16eefacc35da28563e80791b3ddc5597b062a5c386"},
-    {file = "coverage-7.10.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:ca79146ee421b259f8131f153102220b84d1a5e6fb9c8aed13b3badfd1796de6"},
-    {file = "coverage-7.10.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2b225a06d227f23f386fdc0eab471506d9e644be699424814acc7d114595495f"},
-    {file = "coverage-7.10.1-cp312-cp312-win32.whl", hash = "sha256:5ba9a8770effec5baaaab1567be916c87d8eea0c9ad11253722d86874d885eca"},
-    {file = "coverage-7.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:9eb245a8d8dd0ad73b4062135a251ec55086fbc2c42e0eb9725a9b553fba18a3"},
-    {file = "coverage-7.10.1-cp312-cp312-win_arm64.whl", hash = "sha256:7718060dd4434cc719803a5e526838a5d66e4efa5dc46d2b25c21965a9c6fcc4"},
-    {file = "coverage-7.10.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ebb08d0867c5a25dffa4823377292a0ffd7aaafb218b5d4e2e106378b1061e39"},
-    {file = "coverage-7.10.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f32a95a83c2e17422f67af922a89422cd24c6fa94041f083dd0bb4f6057d0bc7"},
-    {file = "coverage-7.10.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c4c746d11c8aba4b9f58ca8bfc6fbfd0da4efe7960ae5540d1a1b13655ee8892"},
-    {file = "coverage-7.10.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7f39edd52c23e5c7ed94e0e4bf088928029edf86ef10b95413e5ea670c5e92d7"},
-    {file = "coverage-7.10.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab6e19b684981d0cd968906e293d5628e89faacb27977c92f3600b201926b994"},
-    {file = "coverage-7.10.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5121d8cf0eacb16133501455d216bb5f99899ae2f52d394fe45d59229e6611d0"},
-    {file = "coverage-7.10.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:df1c742ca6f46a6f6cbcaef9ac694dc2cb1260d30a6a2f5c68c5f5bcfee1cfd7"},
-    {file = "coverage-7.10.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:40f9a38676f9c073bf4b9194707aa1eb97dca0e22cc3766d83879d72500132c7"},
-    {file = "coverage-7.10.1-cp313-cp313-win32.whl", hash = "sha256:2348631f049e884839553b9974f0821d39241c6ffb01a418efce434f7eba0fe7"},
-    {file = "coverage-7.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:4072b31361b0d6d23f750c524f694e1a417c1220a30d3ef02741eed28520c48e"},
-    {file = "coverage-7.10.1-cp313-cp313-win_arm64.whl", hash = "sha256:3e31dfb8271937cab9425f19259b1b1d1f556790e98eb266009e7a61d337b6d4"},
-    {file = "coverage-7.10.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:1c4f679c6b573a5257af6012f167a45be4c749c9925fd44d5178fd641ad8bf72"},
-    {file = "coverage-7.10.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:871ebe8143da284bd77b84a9136200bd638be253618765d21a1fce71006d94af"},
-    {file = "coverage-7.10.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:998c4751dabf7d29b30594af416e4bf5091f11f92a8d88eb1512c7ba136d1ed7"},
-    {file = "coverage-7.10.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:780f750a25e7749d0af6b3631759c2c14f45de209f3faaa2398312d1c7a22759"},
-    {file = "coverage-7.10.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:590bdba9445df4763bdbebc928d8182f094c1f3947a8dc0fc82ef014dbdd8324"},
-    {file = "coverage-7.10.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b2df80cb6a2af86d300e70acb82e9b79dab2c1e6971e44b78dbfc1a1e736b53"},
-    {file = "coverage-7.10.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:d6a558c2725bfb6337bf57c1cd366c13798bfd3bfc9e3dd1f4a6f6fc95a4605f"},
-    {file = "coverage-7.10.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e6150d167f32f2a54690e572e0a4c90296fb000a18e9b26ab81a6489e24e78dd"},
-    {file = "coverage-7.10.1-cp313-cp313t-win32.whl", hash = "sha256:d946a0c067aa88be4a593aad1236493313bafaa27e2a2080bfe88db827972f3c"},
-    {file = "coverage-7.10.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e37c72eaccdd5ed1130c67a92ad38f5b2af66eeff7b0abe29534225db2ef7b18"},
-    {file = "coverage-7.10.1-cp313-cp313t-win_arm64.whl", hash = "sha256:89ec0ffc215c590c732918c95cd02b55c7d0f569d76b90bb1a5e78aa340618e4"},
-    {file = "coverage-7.10.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:166d89c57e877e93d8827dac32cedae6b0277ca684c6511497311249f35a280c"},
-    {file = "coverage-7.10.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bed4a2341b33cd1a7d9ffc47df4a78ee61d3416d43b4adc9e18b7d266650b83e"},
-    {file = "coverage-7.10.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ddca1e4f5f4c67980533df01430184c19b5359900e080248bbf4ed6789584d8b"},
-    {file = "coverage-7.10.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:37b69226001d8b7de7126cad7366b0778d36777e4d788c66991455ba817c5b41"},
-    {file = "coverage-7.10.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2f22102197bcb1722691296f9e589f02b616f874e54a209284dd7b9294b0b7f"},
-    {file = "coverage-7.10.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1e0c768b0f9ac5839dac5cf88992a4bb459e488ee8a1f8489af4cb33b1af00f1"},
-    {file = "coverage-7.10.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:991196702d5e0b120a8fef2664e1b9c333a81d36d5f6bcf6b225c0cf8b0451a2"},
-    {file = "coverage-7.10.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae8e59e5f4fd85d6ad34c2bb9d74037b5b11be072b8b7e9986beb11f957573d4"},
-    {file = "coverage-7.10.1-cp314-cp314-win32.whl", hash = "sha256:042125c89cf74a074984002e165d61fe0e31c7bd40ebb4bbebf07939b5924613"},
-    {file = "coverage-7.10.1-cp314-cp314-win_amd64.whl", hash = "sha256:a22c3bfe09f7a530e2c94c87ff7af867259c91bef87ed2089cd69b783af7b84e"},
-    {file = "coverage-7.10.1-cp314-cp314-win_arm64.whl", hash = "sha256:ee6be07af68d9c4fca4027c70cea0c31a0f1bc9cb464ff3c84a1f916bf82e652"},
-    {file = "coverage-7.10.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d24fb3c0c8ff0d517c5ca5de7cf3994a4cd559cde0315201511dbfa7ab528894"},
-    {file = "coverage-7.10.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1217a54cfd79be20512a67ca81c7da3f2163f51bbfd188aab91054df012154f5"},
-    {file = "coverage-7.10.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:51f30da7a52c009667e02f125737229d7d8044ad84b79db454308033a7808ab2"},
-    {file = "coverage-7.10.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ed3718c757c82d920f1c94089066225ca2ad7f00bb904cb72b1c39ebdd906ccb"},
-    {file = "coverage-7.10.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc452481e124a819ced0c25412ea2e144269ef2f2534b862d9f6a9dae4bda17b"},
-    {file = "coverage-7.10.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9d6f494c307e5cb9b1e052ec1a471060f1dea092c8116e642e7a23e79d9388ea"},
-    {file = "coverage-7.10.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:fc0e46d86905ddd16b85991f1f4919028092b4e511689bbdaff0876bd8aab3dd"},
-    {file = "coverage-7.10.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:80b9ccd82e30038b61fc9a692a8dc4801504689651b281ed9109f10cc9fe8b4d"},
-    {file = "coverage-7.10.1-cp314-cp314t-win32.whl", hash = "sha256:e58991a2b213417285ec866d3cd32db17a6a88061a985dbb7e8e8f13af429c47"},
-    {file = "coverage-7.10.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e88dd71e4ecbc49d9d57d064117462c43f40a21a1383507811cf834a4a620651"},
-    {file = "coverage-7.10.1-cp314-cp314t-win_arm64.whl", hash = "sha256:1aadfb06a30c62c2eb82322171fe1f7c288c80ca4156d46af0ca039052814bab"},
-    {file = "coverage-7.10.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:57b6e8789cbefdef0667e4a94f8ffa40f9402cee5fc3b8e4274c894737890145"},
-    {file = "coverage-7.10.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:85b22a9cce00cb03156334da67eb86e29f22b5e93876d0dd6a98646bb8a74e53"},
-    {file = "coverage-7.10.1-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:97b6983a2f9c76d345ca395e843a049390b39652984e4a3b45b2442fa733992d"},
-    {file = "coverage-7.10.1-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ddf2a63b91399a1c2f88f40bc1705d5a7777e31c7e9eb27c602280f477b582ba"},
-    {file = "coverage-7.10.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47ab6dbbc31a14c5486420c2c1077fcae692097f673cf5be9ddbec8cdaa4cdbc"},
-    {file = "coverage-7.10.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:21eb7d8b45d3700e7c2936a736f732794c47615a20f739f4133d5230a6512a88"},
-    {file = "coverage-7.10.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:283005bb4d98ae33e45f2861cd2cde6a21878661c9ad49697f6951b358a0379b"},
-    {file = "coverage-7.10.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:fefe31d61d02a8b2c419700b1fade9784a43d726de26495f243b663cd9fe1513"},
-    {file = "coverage-7.10.1-cp39-cp39-win32.whl", hash = "sha256:e8ab8e4c7ec7f8a55ac05b5b715a051d74eac62511c6d96d5bb79aaafa3b04cf"},
-    {file = "coverage-7.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:c36baa0ecde742784aa76c2b816466d3ea888d5297fda0edbac1bf48fa94688a"},
-    {file = "coverage-7.10.1-py3-none-any.whl", hash = "sha256:fa2a258aa6bf188eb9a8948f7102a83da7c430a0dce918dbd8b60ef8fcb772d7"},
-    {file = "coverage-7.10.1.tar.gz", hash = "sha256:ae2b4856f29ddfe827106794f3589949a57da6f0d38ab01e24ec35107979ba57"},
+    {file = "coverage-7.10.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:79f0283ab5e6499fd5fe382ca3d62afa40fb50ff227676a3125d18af70eabf65"},
+    {file = "coverage-7.10.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e4545e906f595ee8ab8e03e21be20d899bfc06647925bc5b224ad7e8c40e08b8"},
+    {file = "coverage-7.10.2-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ae385e1d58fbc6a9b1c315e5510ac52281e271478b45f92ca9b5ad42cf39643f"},
+    {file = "coverage-7.10.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6f0cbe5f7dd19f3a32bac2251b95d51c3b89621ac88a2648096ce40f9a5aa1e7"},
+    {file = "coverage-7.10.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd17f427f041f6b116dc90b4049c6f3e1230524407d00daa2d8c7915037b5947"},
+    {file = "coverage-7.10.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7f10ca4cde7b466405cce0a0e9971a13eb22e57a5ecc8b5f93a81090cc9c7eb9"},
+    {file = "coverage-7.10.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3b990df23dd51dccce26d18fb09fd85a77ebe46368f387b0ffba7a74e470b31b"},
+    {file = "coverage-7.10.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cc3902584d25c7eef57fb38f440aa849a26a3a9f761a029a72b69acfca4e31f8"},
+    {file = "coverage-7.10.2-cp310-cp310-win32.whl", hash = "sha256:9dd37e9ac00d5eb72f38ed93e3cdf2280b1dbda3bb9b48c6941805f265ad8d87"},
+    {file = "coverage-7.10.2-cp310-cp310-win_amd64.whl", hash = "sha256:99d16f15cb5baf0729354c5bd3080ae53847a4072b9ba1e10957522fb290417f"},
+    {file = "coverage-7.10.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2c3b210d79925a476dfc8d74c7d53224888421edebf3a611f3adae923e212b27"},
+    {file = "coverage-7.10.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf67d1787cd317c3f8b2e4c6ed1ae93497be7e30605a0d32237ac37a37a8a322"},
+    {file = "coverage-7.10.2-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:069b779d03d458602bc0e27189876e7d8bdf6b24ac0f12900de22dd2154e6ad7"},
+    {file = "coverage-7.10.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4c2de4cb80b9990e71c62c2d3e9f3ec71b804b1f9ca4784ec7e74127e0f42468"},
+    {file = "coverage-7.10.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75bf7ab2374a7eb107602f1e07310cda164016cd60968abf817b7a0b5703e288"},
+    {file = "coverage-7.10.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3f37516458ec1550815134937f73d6d15b434059cd10f64678a2068f65c62406"},
+    {file = "coverage-7.10.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:de3c6271c482c250d3303fb5c6bdb8ca025fff20a67245e1425df04dc990ece9"},
+    {file = "coverage-7.10.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:98a838101321ac3089c9bb1d4bfa967e8afed58021fda72d7880dc1997f20ae1"},
+    {file = "coverage-7.10.2-cp311-cp311-win32.whl", hash = "sha256:f2a79145a531a0e42df32d37be5af069b4a914845b6f686590739b786f2f7bce"},
+    {file = "coverage-7.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:e4f5f1320f8ee0d7cfa421ceb257bef9d39fd614dd3ddcfcacd284d4824ed2c2"},
+    {file = "coverage-7.10.2-cp311-cp311-win_arm64.whl", hash = "sha256:d8f2d83118f25328552c728b8e91babf93217db259ca5c2cd4dd4220b8926293"},
+    {file = "coverage-7.10.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:890ad3a26da9ec7bf69255b9371800e2a8da9bc223ae5d86daeb940b42247c83"},
+    {file = "coverage-7.10.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:38fd1ccfca7838c031d7a7874d4353e2f1b98eb5d2a80a2fe5732d542ae25e9c"},
+    {file = "coverage-7.10.2-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:76c1ffaaf4f6f0f6e8e9ca06f24bb6454a7a5d4ced97a1bc466f0d6baf4bd518"},
+    {file = "coverage-7.10.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:86da8a3a84b79ead5c7d0e960c34f580bc3b231bb546627773a3f53c532c2f21"},
+    {file = "coverage-7.10.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99cef9731c8a39801830a604cc53c93c9e57ea8b44953d26589499eded9576e0"},
+    {file = "coverage-7.10.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ea58b112f2966a8b91eb13f5d3b1f8bb43c180d624cd3283fb33b1cedcc2dd75"},
+    {file = "coverage-7.10.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:20f405188d28da9522b7232e51154e1b884fc18d0b3a10f382d54784715bbe01"},
+    {file = "coverage-7.10.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:64586ce42bbe0da4d9f76f97235c545d1abb9b25985a8791857690f96e23dc3b"},
+    {file = "coverage-7.10.2-cp312-cp312-win32.whl", hash = "sha256:bc2e69b795d97ee6d126e7e22e78a509438b46be6ff44f4dccbb5230f550d340"},
+    {file = "coverage-7.10.2-cp312-cp312-win_amd64.whl", hash = "sha256:adda2268b8cf0d11f160fad3743b4dfe9813cd6ecf02c1d6397eceaa5b45b388"},
+    {file = "coverage-7.10.2-cp312-cp312-win_arm64.whl", hash = "sha256:164429decd0d6b39a0582eaa30c67bf482612c0330572343042d0ed9e7f15c20"},
+    {file = "coverage-7.10.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:aca7b5645afa688de6d4f8e89d30c577f62956fefb1bad021490d63173874186"},
+    {file = "coverage-7.10.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:96e5921342574a14303dfdb73de0019e1ac041c863743c8fe1aa6c2b4a257226"},
+    {file = "coverage-7.10.2-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:11333094c1bff621aa811b67ed794865cbcaa99984dedea4bd9cf780ad64ecba"},
+    {file = "coverage-7.10.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6eb586fa7d2aee8d65d5ae1dd71414020b2f447435c57ee8de8abea0a77d5074"},
+    {file = "coverage-7.10.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d358f259d8019d4ef25d8c5b78aca4c7af25e28bd4231312911c22a0e824a57"},
+    {file = "coverage-7.10.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5250bda76e30382e0a2dcd68d961afcab92c3a7613606e6269855c6979a1b0bb"},
+    {file = "coverage-7.10.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a91e027d66eff214d88d9afbe528e21c9ef1ecdf4956c46e366c50f3094696d0"},
+    {file = "coverage-7.10.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:228946da741558904e2c03ce870ba5efd9cd6e48cbc004d9a27abee08100a15a"},
+    {file = "coverage-7.10.2-cp313-cp313-win32.whl", hash = "sha256:95e23987b52d02e7c413bf2d6dc6288bd5721beb518052109a13bfdc62c8033b"},
+    {file = "coverage-7.10.2-cp313-cp313-win_amd64.whl", hash = "sha256:f35481d42c6d146d48ec92d4e239c23f97b53a3f1fbd2302e7c64336f28641fe"},
+    {file = "coverage-7.10.2-cp313-cp313-win_arm64.whl", hash = "sha256:65b451949cb789c346f9f9002441fc934d8ccedcc9ec09daabc2139ad13853f7"},
+    {file = "coverage-7.10.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:e8415918856a3e7d57a4e0ad94651b761317de459eb74d34cc1bb51aad80f07e"},
+    {file = "coverage-7.10.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f287a25a8ca53901c613498e4a40885b19361a2fe8fbfdbb7f8ef2cad2a23f03"},
+    {file = "coverage-7.10.2-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:75cc1a3f8c88c69bf16a871dab1fe5a7303fdb1e9f285f204b60f1ee539b8fc0"},
+    {file = "coverage-7.10.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ca07fa78cc9d26bc8c4740de1abd3489cf9c47cc06d9a8ab3d552ff5101af4c0"},
+    {file = "coverage-7.10.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2e117e64c26300032755d4520cd769f2623cde1a1d1c3515b05a3b8add0ade1"},
+    {file = "coverage-7.10.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:daaf98009977f577b71f8800208f4d40d4dcf5c2db53d4d822787cdc198d76e1"},
+    {file = "coverage-7.10.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:ea8d8fe546c528535c761ba424410bbeb36ba8a0f24be653e94b70c93fd8a8ca"},
+    {file = "coverage-7.10.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:fe024d40ac31eb8d5aae70215b41dafa264676caa4404ae155f77d2fa95c37bb"},
+    {file = "coverage-7.10.2-cp313-cp313t-win32.whl", hash = "sha256:8f34b09f68bdadec122ffad312154eda965ade433559cc1eadd96cca3de5c824"},
+    {file = "coverage-7.10.2-cp313-cp313t-win_amd64.whl", hash = "sha256:71d40b3ac0f26fa9ffa6ee16219a714fed5c6ec197cdcd2018904ab5e75bcfa3"},
+    {file = "coverage-7.10.2-cp313-cp313t-win_arm64.whl", hash = "sha256:abb57fdd38bf6f7dcc66b38dafb7af7c5fdc31ac6029ce373a6f7f5331d6f60f"},
+    {file = "coverage-7.10.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a3e853cc04987c85ec410905667eed4bf08b1d84d80dfab2684bb250ac8da4f6"},
+    {file = "coverage-7.10.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0100b19f230df72c90fdb36db59d3f39232391e8d89616a7de30f677da4f532b"},
+    {file = "coverage-7.10.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9c1cd71483ea78331bdfadb8dcec4f4edfb73c7002c1206d8e0af6797853f5be"},
+    {file = "coverage-7.10.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9f75dbf4899e29a37d74f48342f29279391668ef625fdac6d2f67363518056a1"},
+    {file = "coverage-7.10.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7df481e7508de1c38b9b8043da48d94931aefa3e32b47dd20277e4978ed5b95"},
+    {file = "coverage-7.10.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:835f39e618099325e7612b3406f57af30ab0a0af350490eff6421e2e5f608e46"},
+    {file = "coverage-7.10.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:12e52b5aa00aa720097d6947d2eb9e404e7c1101ad775f9661ba165ed0a28303"},
+    {file = "coverage-7.10.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:718044729bf1fe3e9eb9f31b52e44ddae07e434ec050c8c628bf5adc56fe4bdd"},
+    {file = "coverage-7.10.2-cp314-cp314-win32.whl", hash = "sha256:f256173b48cc68486299d510a3e729a96e62c889703807482dbf56946befb5c8"},
+    {file = "coverage-7.10.2-cp314-cp314-win_amd64.whl", hash = "sha256:2e980e4179f33d9b65ac4acb86c9c0dde904098853f27f289766657ed16e07b3"},
+    {file = "coverage-7.10.2-cp314-cp314-win_arm64.whl", hash = "sha256:14fb5b6641ab5b3c4161572579f0f2ea8834f9d3af2f7dd8fbaecd58ef9175cc"},
+    {file = "coverage-7.10.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:e96649ac34a3d0e6491e82a2af71098e43be2874b619547c3282fc11d3840a4b"},
+    {file = "coverage-7.10.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1a2e934e9da26341d342d30bfe91422bbfdb3f1f069ec87f19b2909d10d8dcc4"},
+    {file = "coverage-7.10.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:651015dcd5fd9b5a51ca79ece60d353cacc5beaf304db750407b29c89f72fe2b"},
+    {file = "coverage-7.10.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:81bf6a32212f9f66da03d63ecb9cd9bd48e662050a937db7199dbf47d19831de"},
+    {file = "coverage-7.10.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d800705f6951f75a905ea6feb03fff8f3ea3468b81e7563373ddc29aa3e5d1ca"},
+    {file = "coverage-7.10.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:248b5394718e10d067354448dc406d651709c6765669679311170da18e0e9af8"},
+    {file = "coverage-7.10.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:5c61675a922b569137cf943770d7ad3edd0202d992ce53ac328c5ff68213ccf4"},
+    {file = "coverage-7.10.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:52d708b5fd65589461381fa442d9905f5903d76c086c6a4108e8e9efdca7a7ed"},
+    {file = "coverage-7.10.2-cp314-cp314t-win32.whl", hash = "sha256:916369b3b914186b2c5e5ad2f7264b02cff5df96cdd7cdad65dccd39aa5fd9f0"},
+    {file = "coverage-7.10.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5b9d538e8e04916a5df63052d698b30c74eb0174f2ca9cd942c981f274a18eaf"},
+    {file = "coverage-7.10.2-cp314-cp314t-win_arm64.whl", hash = "sha256:04c74f9ef1f925456a9fd23a7eef1103126186d0500ef9a0acb0bd2514bdc7cc"},
+    {file = "coverage-7.10.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:765b13b164685a2f8b2abef867ad07aebedc0e090c757958a186f64e39d63dbd"},
+    {file = "coverage-7.10.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a219b70100500d0c7fd3ebb824a3302efb6b1a122baa9d4eb3f43df8f0b3d899"},
+    {file = "coverage-7.10.2-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e33e79a219105aa315439ee051bd50b6caa705dc4164a5aba6932c8ac3ce2d98"},
+    {file = "coverage-7.10.2-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bc3945b7bad33957a9eca16e9e5eae4b17cb03173ef594fdaad228f4fc7da53b"},
+    {file = "coverage-7.10.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9bdff88e858ee608a924acfad32a180d2bf6e13e059d6a7174abbae075f30436"},
+    {file = "coverage-7.10.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:44329cbed24966c0b49acb386352c9722219af1f0c80db7f218af7793d251902"},
+    {file = "coverage-7.10.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:be127f292496d0fbe20d8025f73221b36117b3587f890346e80a13b310712982"},
+    {file = "coverage-7.10.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6c031da749a05f7a01447dd7f47beedb498edd293e31e1878c0d52db18787df0"},
+    {file = "coverage-7.10.2-cp39-cp39-win32.whl", hash = "sha256:22aca3e691c7709c5999ccf48b7a8ff5cf5a8bd6fe9b36efbd4993f5a36b2fcf"},
+    {file = "coverage-7.10.2-cp39-cp39-win_amd64.whl", hash = "sha256:c7195444b932356055a8e287fa910bf9753a84a1bc33aeb3770e8fca521e032e"},
+    {file = "coverage-7.10.2-py3-none-any.whl", hash = "sha256:95db3750dd2e6e93d99fa2498f3a1580581e49c494bddccc6f85c5c21604921f"},
+    {file = "coverage-7.10.2.tar.gz", hash = "sha256:5d6e6d84e6dd31a8ded64759626627247d676a23c1b892e1326f7c55c8d61055"},
 ]
 
 [package.extras]
@@ -837,49 +848,49 @@ dev = ["black (==22.3.0)", "hypothesis (==6.60.0)", "numpy", "pytest (>=5.30)", 
 
 [[package]]
 name = "cryptography"
-version = "45.0.5"
+version = "45.0.6"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "cryptography-45.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:101ee65078f6dd3e5a028d4f19c07ffa4dd22cce6a20eaa160f8b5219911e7d8"},
-    {file = "cryptography-45.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3a264aae5f7fbb089dbc01e0242d3b67dffe3e6292e1f5182122bdf58e65215d"},
-    {file = "cryptography-45.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e74d30ec9c7cb2f404af331d5b4099a9b322a8a6b25c4632755c8757345baac5"},
-    {file = "cryptography-45.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3af26738f2db354aafe492fb3869e955b12b2ef2e16908c8b9cb928128d42c57"},
-    {file = "cryptography-45.0.5-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e6c00130ed423201c5bc5544c23359141660b07999ad82e34e7bb8f882bb78e0"},
-    {file = "cryptography-45.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:dd420e577921c8c2d31289536c386aaa30140b473835e97f83bc71ea9d2baf2d"},
-    {file = "cryptography-45.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:d05a38884db2ba215218745f0781775806bde4f32e07b135348355fe8e4991d9"},
-    {file = "cryptography-45.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:ad0caded895a00261a5b4aa9af828baede54638754b51955a0ac75576b831b27"},
-    {file = "cryptography-45.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9024beb59aca9d31d36fcdc1604dd9bbeed0a55bface9f1908df19178e2f116e"},
-    {file = "cryptography-45.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:91098f02ca81579c85f66df8a588c78f331ca19089763d733e34ad359f474174"},
-    {file = "cryptography-45.0.5-cp311-abi3-win32.whl", hash = "sha256:926c3ea71a6043921050eaa639137e13dbe7b4ab25800932a8498364fc1abec9"},
-    {file = "cryptography-45.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:b85980d1e345fe769cfc57c57db2b59cff5464ee0c045d52c0df087e926fbe63"},
-    {file = "cryptography-45.0.5-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:f3562c2f23c612f2e4a6964a61d942f891d29ee320edb62ff48ffb99f3de9ae8"},
-    {file = "cryptography-45.0.5-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3fcfbefc4a7f332dece7272a88e410f611e79458fab97b5efe14e54fe476f4fd"},
-    {file = "cryptography-45.0.5-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:460f8c39ba66af7db0545a8c6f2eabcbc5a5528fc1cf6c3fa9a1e44cec33385e"},
-    {file = "cryptography-45.0.5-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9b4cf6318915dccfe218e69bbec417fdd7c7185aa7aab139a2c0beb7468c89f0"},
-    {file = "cryptography-45.0.5-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2089cc8f70a6e454601525e5bf2779e665d7865af002a5dec8d14e561002e135"},
-    {file = "cryptography-45.0.5-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0027d566d65a38497bc37e0dd7c2f8ceda73597d2ac9ba93810204f56f52ebc7"},
-    {file = "cryptography-45.0.5-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:be97d3a19c16a9be00edf79dca949c8fa7eff621763666a145f9f9535a5d7f42"},
-    {file = "cryptography-45.0.5-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:7760c1c2e1a7084153a0f68fab76e754083b126a47d0117c9ed15e69e2103492"},
-    {file = "cryptography-45.0.5-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6ff8728d8d890b3dda5765276d1bc6fb099252915a2cd3aff960c4c195745dd0"},
-    {file = "cryptography-45.0.5-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7259038202a47fdecee7e62e0fd0b0738b6daa335354396c6ddebdbe1206af2a"},
-    {file = "cryptography-45.0.5-cp37-abi3-win32.whl", hash = "sha256:1e1da5accc0c750056c556a93c3e9cb828970206c68867712ca5805e46dc806f"},
-    {file = "cryptography-45.0.5-cp37-abi3-win_amd64.whl", hash = "sha256:90cb0a7bb35959f37e23303b7eed0a32280510030daba3f7fdfbb65defde6a97"},
-    {file = "cryptography-45.0.5-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:206210d03c1193f4e1ff681d22885181d47efa1ab3018766a7b32a7b3d6e6afd"},
-    {file = "cryptography-45.0.5-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c648025b6840fe62e57107e0a25f604db740e728bd67da4f6f060f03017d5097"},
-    {file = "cryptography-45.0.5-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b8fa8b0a35a9982a3c60ec79905ba5bb090fc0b9addcfd3dc2dd04267e45f25e"},
-    {file = "cryptography-45.0.5-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:14d96584701a887763384f3c47f0ca7c1cce322aa1c31172680eb596b890ec30"},
-    {file = "cryptography-45.0.5-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:57c816dfbd1659a367831baca4b775b2a5b43c003daf52e9d57e1d30bc2e1b0e"},
-    {file = "cryptography-45.0.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:b9e38e0a83cd51e07f5a48ff9691cae95a79bea28fe4ded168a8e5c6c77e819d"},
-    {file = "cryptography-45.0.5-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:8c4a6ff8a30e9e3d38ac0539e9a9e02540ab3f827a3394f8852432f6b0ea152e"},
-    {file = "cryptography-45.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bd4c45986472694e5121084c6ebbd112aa919a25e783b87eb95953c9573906d6"},
-    {file = "cryptography-45.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:982518cd64c54fcada9d7e5cf28eabd3ee76bd03ab18e08a48cad7e8b6f31b18"},
-    {file = "cryptography-45.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:12e55281d993a793b0e883066f590c1ae1e802e3acb67f8b442e721e475e6463"},
-    {file = "cryptography-45.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:5aa1e32983d4443e310f726ee4b071ab7569f58eedfdd65e9675484a4eb67bd1"},
-    {file = "cryptography-45.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:e357286c1b76403dd384d938f93c46b2b058ed4dfcdce64a770f0537ed3feb6f"},
-    {file = "cryptography-45.0.5.tar.gz", hash = "sha256:72e76caa004ab63accdf26023fccd1d087f6d90ec6048ff33ad0445abf7f605a"},
+    {file = "cryptography-45.0.6-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:048e7ad9e08cf4c0ab07ff7f36cc3115924e22e2266e034450a890d9e312dd74"},
+    {file = "cryptography-45.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:44647c5d796f5fc042bbc6d61307d04bf29bccb74d188f18051b635f20a9c75f"},
+    {file = "cryptography-45.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e40b80ecf35ec265c452eea0ba94c9587ca763e739b8e559c128d23bff7ebbbf"},
+    {file = "cryptography-45.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:00e8724bdad672d75e6f069b27970883179bd472cd24a63f6e620ca7e41cc0c5"},
+    {file = "cryptography-45.0.6-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7a3085d1b319d35296176af31c90338eeb2ddac8104661df79f80e1d9787b8b2"},
+    {file = "cryptography-45.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1b7fa6a1c1188c7ee32e47590d16a5a0646270921f8020efc9a511648e1b2e08"},
+    {file = "cryptography-45.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:275ba5cc0d9e320cd70f8e7b96d9e59903c815ca579ab96c1e37278d231fc402"},
+    {file = "cryptography-45.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f4028f29a9f38a2025abedb2e409973709c660d44319c61762202206ed577c42"},
+    {file = "cryptography-45.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ee411a1b977f40bd075392c80c10b58025ee5c6b47a822a33c1198598a7a5f05"},
+    {file = "cryptography-45.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e2a21a8eda2d86bb604934b6b37691585bd095c1f788530c1fcefc53a82b3453"},
+    {file = "cryptography-45.0.6-cp311-abi3-win32.whl", hash = "sha256:d063341378d7ee9c91f9d23b431a3502fc8bfacd54ef0a27baa72a0843b29159"},
+    {file = "cryptography-45.0.6-cp311-abi3-win_amd64.whl", hash = "sha256:833dc32dfc1e39b7376a87b9a6a4288a10aae234631268486558920029b086ec"},
+    {file = "cryptography-45.0.6-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:3436128a60a5e5490603ab2adbabc8763613f638513ffa7d311c900a8349a2a0"},
+    {file = "cryptography-45.0.6-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0d9ef57b6768d9fa58e92f4947cea96ade1233c0e236db22ba44748ffedca394"},
+    {file = "cryptography-45.0.6-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea3c42f2016a5bbf71825537c2ad753f2870191134933196bee408aac397b3d9"},
+    {file = "cryptography-45.0.6-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:20ae4906a13716139d6d762ceb3e0e7e110f7955f3bc3876e3a07f5daadec5f3"},
+    {file = "cryptography-45.0.6-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dac5ec199038b8e131365e2324c03d20e97fe214af051d20c49db129844e8b3"},
+    {file = "cryptography-45.0.6-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:18f878a34b90d688982e43f4b700408b478102dd58b3e39de21b5ebf6509c301"},
+    {file = "cryptography-45.0.6-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5bd6020c80c5b2b2242d6c48487d7b85700f5e0038e67b29d706f98440d66eb5"},
+    {file = "cryptography-45.0.6-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:eccddbd986e43014263eda489abbddfbc287af5cddfd690477993dbb31e31016"},
+    {file = "cryptography-45.0.6-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:550ae02148206beb722cfe4ef0933f9352bab26b087af00e48fdfb9ade35c5b3"},
+    {file = "cryptography-45.0.6-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5b64e668fc3528e77efa51ca70fadcd6610e8ab231e3e06ae2bab3b31c2b8ed9"},
+    {file = "cryptography-45.0.6-cp37-abi3-win32.whl", hash = "sha256:780c40fb751c7d2b0c6786ceee6b6f871e86e8718a8ff4bc35073ac353c7cd02"},
+    {file = "cryptography-45.0.6-cp37-abi3-win_amd64.whl", hash = "sha256:20d15aed3ee522faac1a39fbfdfee25d17b1284bafd808e1640a74846d7c4d1b"},
+    {file = "cryptography-45.0.6-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:705bb7c7ecc3d79a50f236adda12ca331c8e7ecfbea51edd931ce5a7a7c4f012"},
+    {file = "cryptography-45.0.6-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:826b46dae41a1155a0c0e66fafba43d0ede1dc16570b95e40c4d83bfcf0a451d"},
+    {file = "cryptography-45.0.6-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:cc4d66f5dc4dc37b89cfef1bd5044387f7a1f6f0abb490815628501909332d5d"},
+    {file = "cryptography-45.0.6-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f68f833a9d445cc49f01097d95c83a850795921b3f7cc6488731e69bde3288da"},
+    {file = "cryptography-45.0.6-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3b5bf5267e98661b9b888a9250d05b063220dfa917a8203744454573c7eb79db"},
+    {file = "cryptography-45.0.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:2384f2ab18d9be88a6e4f8972923405e2dbb8d3e16c6b43f15ca491d7831bd18"},
+    {file = "cryptography-45.0.6-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:fc022c1fa5acff6def2fc6d7819bbbd31ccddfe67d075331a65d9cfb28a20983"},
+    {file = "cryptography-45.0.6-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:3de77e4df42ac8d4e4d6cdb342d989803ad37707cf8f3fbf7b088c9cbdd46427"},
+    {file = "cryptography-45.0.6-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:599c8d7df950aa68baa7e98f7b73f4f414c9f02d0e8104a30c0182a07732638b"},
+    {file = "cryptography-45.0.6-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:31a2b9a10530a1cb04ffd6aa1cd4d3be9ed49f7d77a4dafe198f3b382f41545c"},
+    {file = "cryptography-45.0.6-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:e5b3dda1b00fb41da3af4c5ef3f922a200e33ee5ba0f0bc9ecf0b0c173958385"},
+    {file = "cryptography-45.0.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:629127cfdcdc6806dfe234734d7cb8ac54edaf572148274fa377a7d3405b0043"},
+    {file = "cryptography-45.0.6.tar.gz", hash = "sha256:5c966c732cf6e4a276ce83b6e4c729edda2df6929083a952cc7da973c539c719"},
 ]
 markers = {main = "extra == \"server\""}
 
@@ -893,7 +904,7 @@ nox = ["nox (>=2024.4.15)", "nox[uv] (>=2024.3.2) ; python_full_version >= \"3.8
 pep8test = ["check-sdist ; python_full_version >= \"3.8.0\"", "click (>=8.0.1)", "mypy (>=1.4)", "ruff (>=0.3.6)"]
 sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi (>=2024)", "cryptography-vectors (==45.0.5)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==45.0.6)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
@@ -950,6 +961,21 @@ files = [
 packaging = "*"
 
 [[package]]
+name = "dirty-equals"
+version = "0.9.0"
+description = "Doing dirty (but extremely useful) things with equals."
+optional = false
+python-versions = ">=3.8"
+groups = ["test"]
+files = [
+    {file = "dirty_equals-0.9.0-py3-none-any.whl", hash = "sha256:ff4d027f5cfa1b69573af00f7ba9043ea652dbdce3fe5cbe828e478c7346db9c"},
+    {file = "dirty_equals-0.9.0.tar.gz", hash = "sha256:17f515970b04ed7900b733c95fd8091f4f85e52f1fb5f268757f25c858eb1f7b"},
+]
+
+[package.extras]
+pydantic = ["pydantic (>=2.4.2)"]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 description = "Distribution utilities"
@@ -994,15 +1020,15 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "faker"
-version = "37.4.2"
+version = "37.5.3"
 description = "Faker is a Python package that generates fake data for you."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"seed\""
 files = [
-    {file = "faker-37.4.2-py3-none-any.whl", hash = "sha256:b70ed1af57bfe988cbcd0afd95f4768c51eaf4e1ce8a30962e127ac5c139c93f"},
-    {file = "faker-37.4.2.tar.gz", hash = "sha256:8e281bbaea30e5658895b8bea21cc50d27aaf3a43db3f2694409ca5701c56b0a"},
+    {file = "faker-37.5.3-py3-none-any.whl", hash = "sha256:386fe9d5e6132a915984bf887fcebcc72d6366a25dd5952905b31b141a17016d"},
+    {file = "faker-37.5.3.tar.gz", hash = "sha256:8315d8ff4d6f4f588bd42ffe63abd599886c785073e26a44707e10eeba5713dc"},
 ]
 
 [package.dependencies]
@@ -3046,6 +3072,18 @@ shellingham = ">=1.3.0"
 typing-extensions = ">=3.7.4.3"
 
 [[package]]
+name = "types-cachetools"
+version = "6.1.0.20250717"
+description = "Typing stubs for cachetools"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "types_cachetools-6.1.0.20250717-py3-none-any.whl", hash = "sha256:bba4b8d42262460d24e570097d2d9040e60311934603caa642efd971f3658ed0"},
+    {file = "types_cachetools-6.1.0.20250717.tar.gz", hash = "sha256:4acc8e25de9f5f84dd176ea81dcffa7cb24393869bb2e59e692dfd0139a1e66f"},
+]
+
+[[package]]
 name = "types-jwcrypto"
 version = "1.5.0.20250516"
 description = "Typing stubs for jwcrypto"
@@ -3179,14 +3217,14 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 
 [[package]]
 name = "virtualenv"
-version = "20.32.0"
+version = "20.33.1"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-20.32.0-py3-none-any.whl", hash = "sha256:2c310aecb62e5aa1b06103ed7c2977b81e042695de2697d01017ff0f1034af56"},
-    {file = "virtualenv-20.32.0.tar.gz", hash = "sha256:886bf75cadfdc964674e6e33eb74d787dff31ca314ceace03ca5810620f4ecf0"},
+    {file = "virtualenv-20.33.1-py3-none-any.whl", hash = "sha256:07c19bc66c11acab6a5958b815cbcee30891cd1c2ccf53785a28651a0d8d8a67"},
+    {file = "virtualenv-20.33.1.tar.gz", hash = "sha256:1b44478d9e261b3fb8baa5e74a0ca3bc0e05f21aa36167bf9cbf850e542765b8"},
 ]
 
 [package.dependencies]
@@ -3395,12 +3433,12 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [extras]
 consumer = ["alembic", "coloredlogs", "cramjam", "faststream", "greenlet", "packaging", "pydantic-settings", "python-dateutil", "python-json-logger", "pyyaml", "sqlalchemy", "sqlalchemy-utils", "uuid6"]
 gssapi = ["gssapi"]
-http2kafka = ["asgi-correlation-id", "coloredlogs", "cramjam", "fastapi", "faststream", "packaging", "pydantic-settings", "python-json-logger", "pyyaml", "starlette", "starlette-exporter", "uuid6", "uvicorn"]
+http2kafka = ["asgi-correlation-id", "cachetools", "coloredlogs", "cramjam", "fastapi", "faststream", "packaging", "pydantic-settings", "python-json-logger", "pyyaml", "starlette", "starlette-exporter", "uuid6", "uvicorn"]
 postgres = ["asyncpg"]
 seed = ["faker"]
-server = ["alembic", "asgi-correlation-id", "coloredlogs", "fastapi", "greenlet", "itsdangerous", "packaging", "pydantic-settings", "pyjwt", "python-dateutil", "python-json-logger", "python-keycloak", "python-multipart", "pyyaml", "sqlalchemy", "sqlalchemy-utils", "starlette", "starlette-exporter", "uuid6", "uvicorn"]
+server = ["alembic", "asgi-correlation-id", "cachetools", "coloredlogs", "fastapi", "greenlet", "itsdangerous", "packaging", "pydantic-settings", "pyjwt", "python-dateutil", "python-json-logger", "python-keycloak", "python-multipart", "pyyaml", "sqlalchemy", "sqlalchemy-utils", "starlette", "starlette-exporter", "uuid6", "uvicorn"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "79fef6a072e4507e3b14c192801fb6883dc72e5d5eb80a7b0c2c7871049511df"
+content-hash = "fe94a33c89e8e28030db7d21af3546f73b4d96d0dc3909caac3d8ef7c0ca4671"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ python-multipart = {version = "^0.0.20", optional = true}
 python-keycloak = {version = "^5.6.0", optional = true}
 pyjwt = {version = "^2.10.1 ", optional = true}
 gssapi = {version = "^1.9.0", optional = true}
-faker = {version = "37.4.2", optional = true}
+faker = {version = "^37.4.2", optional = true}
+cachetools = {version="^6.1.0", optional = true}
 
 [tool.poetry.extras]
 server = [
@@ -94,6 +95,7 @@ server = [
   "itsdangerous",
   "python-multipart",
   "python-keycloak",
+  "cachetools",
 ]
 consumer = [
   "faststream",
@@ -124,6 +126,7 @@ http2kafka = [
   "packaging",
   "faststream",
   "cramjam",
+  "cachetools",
 ]
 postgres = [
   "asyncpg",
@@ -148,6 +151,7 @@ psycopg2-binary = "^2.9.10"
 gevent = "^25.5.1"
 deepdiff = "^8.5.0"
 respx = "^0.22.0"
+dirty_equals = "^0.9.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^4.2.0"
@@ -156,6 +160,7 @@ sqlalchemy = {extras = ["mypy"], version = "^2.0.41"}
 types-pyyaml = "^6.0.12"
 types-python-dateutil = "^2.9.0"
 types-jwcrypto = "^1.5.0"
+types-cachetools = "^6.1.0"
 
 [tool.poetry.group.docs.dependencies]
 autodoc-pydantic = "^2.2.0"
@@ -184,8 +189,9 @@ replace = 'ver = Version.parse("{new_version}")'
 [tool.pytest.ini_options]
 markers = [
     "server: tests for server (require running database)",
-    "consumer: tests for consumer (require running database)",
-    "db: tests for db",
+    "consumer: tests for consumer (require running database and kafka)",
+    "http2kafka: tests for consumer (require running database and kafka)",
+    "db: tests for db structure and migrations",
     "lineage: tests for lineage endpoints (require running database)"
 ]
 

--- a/tests/fixtures/mocks.py
+++ b/tests/fixtures/mocks.py
@@ -3,29 +3,32 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 import pytest
-import pytest_asyncio
 
-from data_rentgen.db.models import User
+from data_rentgen.db.models import PersonalToken, User
 from data_rentgen.server.settings import ServerApplicationSettings
 from data_rentgen.server.settings.auth.jwt import JWTSettings
-from data_rentgen.server.utils.jwt import sign_jwt
+from data_rentgen.server.settings.auth.personal_token import PersonalTokenSettings
+from data_rentgen.server.utils.jwt import decode_jwt, sign_jwt
 
 
 @dataclass
 class MockedUser:
     user: User
     access_token: str
+    personal_token: str
 
 
-@pytest_asyncio.fixture
-async def mocked_user(
+@pytest.fixture
+def mocked_user(
     user: User,
-    access_token_factory: Callable[[int], str],
+    personal_token: PersonalToken,
+    access_token_generator: Callable[[User], str],
+    personal_token_jwt_generator: Callable[[PersonalToken, User], str],
 ) -> MockedUser:
-    access_token = access_token_factory(user.id)
     return MockedUser(
         user=user,
-        access_token=access_token,
+        access_token=access_token_generator(user),
+        personal_token=personal_token_jwt_generator(personal_token, user),
     )
 
 
@@ -35,12 +38,33 @@ def access_token_settings(server_app_settings: ServerApplicationSettings) -> JWT
 
 
 @pytest.fixture
-def access_token_factory(access_token_settings: JWTSettings) -> Callable[[int], str]:
-    def _generate_access_token(user_id: int) -> str:
-        return sign_jwt(
-            {"user_id": user_id, "exp": time.time() + 1000},
+def access_token_generator(access_token_settings: JWTSettings) -> Callable[[User], str]:
+    def _generate_access_token(user: User, time_delta: int = 1000) -> str:
+        now = time.time()
+        jwt = sign_jwt(
+            {
+                "iss": "data-rentgen",
+                "sub_id": user.id,
+                "preferred_username": user.name,
+                "iat": 0,
+                "nbf": 0,
+                "exp": now + time_delta,
+            },
             access_token_settings.secret_key.get_secret_value(),
             access_token_settings.security_algorithm,
         )
+        return f"access_token_{jwt}"
 
     return _generate_access_token
+
+
+@pytest.fixture
+def access_token_jwt_decoder(access_token_settings: PersonalTokenSettings) -> Callable[[str], dict]:
+    def _decoder(jwt_string: str) -> dict:
+        return decode_jwt(
+            token=jwt_string.replace("access_token_", ""),
+            secret_key=access_token_settings.secret_key.get_secret_value(),
+            security_algorithm=access_token_settings.security_algorithm,
+        )
+
+    return _decoder

--- a/tests/test_http2kafka/test_openlineage_http.py
+++ b/tests/test_http2kafka/test_openlineage_http.py
@@ -6,10 +6,15 @@ from typing import Any
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from data_rentgen.openlineage.run_event import OpenLineageRunEvent
+from tests.fixtures.mocks import MockedUser
 
 pytestmark = [pytest.mark.http2kafka, pytest.mark.asyncio]
+
+RESOURCES_PATH = Path(__file__).parent.parent.joinpath("resources")
+AIRFLOW_JSONL_PATH = RESOURCES_PATH.joinpath("events_airflow.jsonl")
 
 
 @pytest.mark.parametrize(
@@ -28,12 +33,14 @@ pytestmark = [pytest.mark.http2kafka, pytest.mark.asyncio]
     ],
 )
 async def test_http2kafka_openlineage_run_event(
+    mocked_user: MockedUser,
     http2kafka_client: AsyncClient,
     http2kafka_handler_with_messages: Any,
     event_content_transformation: Callable[[str], str | bytes],
     headers: dict[str, str],
+    async_session: AsyncSession,
 ):
-    with Path(__file__).parent.parent.joinpath("resources/events_airflow.jsonl").open() as f:
+    with AIRFLOW_JSONL_PATH.open() as f:
         raw_events = f.readlines()
 
     for raw_event in raw_events:
@@ -42,7 +49,10 @@ async def test_http2kafka_openlineage_run_event(
         response = await http2kafka_client.post(
             "v1/openlineage",
             content=event_content_transformation(raw_event),
-            headers=headers,
+            headers={
+                **headers,
+                "Authorization": f"Bearer {mocked_user.personal_token}",
+            },
         )
 
         assert response.status_code == HTTPStatus.CREATED, response.text
@@ -68,16 +78,23 @@ async def test_http2kafka_openlineage_run_event(
                 "correlation_id",
                 response.headers["X-Request-ID"].encode("utf-8"),
             ),
+            (
+                "reported-by-user-name",
+                mocked_user.user.name.encode("utf-8"),
+            ),
         ]
 
 
 async def test_http2kafka_openlineage_malformed_event(
+    mocked_user: MockedUser,
     http2kafka_client: AsyncClient,
     http2kafka_handler_with_messages: Any,
+    async_session: AsyncSession,
 ):
     response = await http2kafka_client.post(
         "v1/openlineage",
         json={"not": "valid event"},
+        headers={"Authorization": f"Bearer {mocked_user.personal_token}"},
     )
 
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.text
@@ -120,3 +137,72 @@ async def test_http2kafka_openlineage_malformed_event(
 
     _, received = http2kafka_handler_with_messages
     assert not received
+
+
+async def test_http2kafka_openlineage_wrong_token(
+    mocked_user: MockedUser,
+    http2kafka_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    with AIRFLOW_JSONL_PATH.open() as f:
+        raw_event = f.readlines()[0]
+
+    response = await http2kafka_client.post(
+        "v1/openlineage",
+        content=raw_event,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {mocked_user.personal_token + 'invalid'}",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.text
+    assert response.json() == {
+        "error": {
+            "code": "unauthorized",
+            "message": "Invalid token",
+            "details": "Signature verification failed",
+        },
+    }
+
+    response = await http2kafka_client.post(
+        "v1/openlineage",
+        content=raw_event,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {mocked_user.access_token}",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.text
+    assert response.json() == {
+        "error": {
+            "code": "unauthorized",
+            "message": "Invalid token",
+            "details": "Access token was passed but PersonalToken was expected",
+        },
+    }
+
+
+async def test_http2kafka_openlineage_missing_token(
+    http2kafka_client: AsyncClient,
+):
+    with AIRFLOW_JSONL_PATH.open() as f:
+        raw_event = f.readlines()[0]
+
+    response = await http2kafka_client.post(
+        "v1/openlineage",
+        content=raw_event,
+        headers={
+            "Content-Type": "application/json",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.text
+    assert response.json() == {
+        "error": {
+            "code": "unauthorized",
+            "message": "Missing Authorization header",
+            "details": None,
+        },
+    }

--- a/tests/test_server/fixtures/factories/personal_token.py
+++ b/tests/test_server/fixtures/factories/personal_token.py
@@ -1,17 +1,28 @@
 from __future__ import annotations
 
+import time
 from datetime import UTC, datetime, timedelta
 from random import randint
 from typing import TYPE_CHECKING
 
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+
 from data_rentgen.db.models.personal_token import PersonalToken
+from data_rentgen.server.settings.auth.personal_token import PersonalTokenSettings
+from data_rentgen.server.utils.jwt import decode_jwt, sign_jwt
 from data_rentgen.utils.uuid import generate_new_uuid
 from tests.test_server.fixtures.factories.base import random_string
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Callable
+    from contextlib import AbstractAsyncContextManager
+
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from data_rentgen.db.models import User
+    from data_rentgen.server.settings import ServerApplicationSettings
 
 
 def personal_token_factory(**kwargs):
@@ -19,7 +30,7 @@ def personal_token_factory(**kwargs):
     token_id = generate_new_uuid(datetime.combine(since, datetime.min.time(), tzinfo=UTC))
     data = {
         "id": token_id,
-        "name": random_string(16),
+        "name": "personal-token-" + random_string(16),
         "user_id": randint(0, 10000000),
         "scopes": ["all:read", "all:write"],
         "since": since,
@@ -42,3 +53,69 @@ async def create_personal_token(
     await async_session.refresh(token)
 
     return token
+
+
+@pytest_asyncio.fixture(params=[{}])
+async def personal_token(
+    user: User,
+    request: pytest.FixtureRequest,
+    async_session_maker: Callable[[], AbstractAsyncContextManager[AsyncSession]],
+) -> AsyncGenerator[PersonalToken, None]:
+    params = request.param
+    async with async_session_maker() as async_session:
+        item = await create_personal_token(async_session, user, params)
+
+        await async_session.commit()
+        await async_session.refresh(item)
+
+        async_session.expunge_all()
+
+    yield item
+
+    delete_query = delete(PersonalToken).where(PersonalToken.id == item.id)
+    async with async_session_maker() as async_session:
+        await async_session.execute(delete_query)
+        await async_session.commit()
+
+
+@pytest.fixture
+def personal_token_settings(server_app_settings: ServerApplicationSettings) -> PersonalTokenSettings:
+    return PersonalTokenSettings.model_validate(server_app_settings.auth.personal_tokens)
+
+
+@pytest.fixture
+def personal_token_jwt_generator(
+    personal_token_settings: PersonalTokenSettings,
+) -> Callable[[PersonalToken, User], str]:
+    def _generate_personal_token(personal_token: PersonalToken, user: User, time_delta: int = 1000) -> str:
+        now = time.time()
+        jwt = sign_jwt(
+            {
+                "jti": str(personal_token.id),
+                "iss": "data-rentgen",
+                "token_name": personal_token.name,
+                "sub_id": user.id,
+                "preferred_username": user.name,
+                "scope": " ".join(personal_token.scopes),
+                "iat": 0,
+                "nbf": 0,
+                "exp": now + time_delta,
+            },
+            personal_token_settings.secret_key.get_secret_value(),  # type: ignore[union-attr]
+            personal_token_settings.security_algorithm,
+        )
+        return f"personal_token_{jwt}"
+
+    return _generate_personal_token
+
+
+@pytest.fixture
+def personal_token_jwt_decoder(personal_token_settings: PersonalTokenSettings) -> Callable[[str], dict]:
+    def _decoder(jwt_string: str) -> dict:
+        return decode_jwt(
+            token=jwt_string.replace("personal_token_", ""),
+            secret_key=personal_token_settings.secret_key.get_secret_value(),
+            security_algorithm=personal_token_settings.security_algorithm,
+        )
+
+    return _decoder

--- a/tests/test_server/test_auth/test_dummy_auth.py
+++ b/tests/test_server/test_auth/test_dummy_auth.py
@@ -1,15 +1,26 @@
-import time
+from collections.abc import Callable
 from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
 
 from data_rentgen.db.models import User
-from data_rentgen.server.settings.auth.jwt import JWTSettings
-from data_rentgen.server.utils.jwt import sign_jwt
 from tests.fixtures.mocks import MockedUser
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
+
+
+async def test_dummy_token_auth(
+    test_client: AsyncClient,
+    mocked_user: MockedUser,
+):
+    response = await test_client.get(
+        "v1/users/me",
+        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {"name": mocked_user.user.name}
 
 
 async def test_dummy_auth_invalid_token(
@@ -17,100 +28,76 @@ async def test_dummy_auth_invalid_token(
     mocked_user: MockedUser,
 ):
     response = await test_client.get(
-        "v1/datasets",
+        "v1/users/me",
         headers={"Authorization": f"Bearer {mocked_user.access_token + 'invalid'}"},
     )
-
     assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
     assert response.json() == {
-        "error": {"code": "unauthorized", "details": None, "message": "Invalid token"},
+        "error": {
+            "code": "unauthorized",
+            "message": "Invalid token",
+            "details": "Signature verification failed",
+        },
     }
 
 
 async def test_dummy_auth_expired_token(
     test_client: AsyncClient,
     user: User,
-    access_token_settings: JWTSettings,
+    access_token_generator: Callable[..., str],
 ):
-    token = sign_jwt(
-        {"user_id": user.id, "exp": time.time() - 10000},
-        access_token_settings.secret_key.get_secret_value(),
-        access_token_settings.security_algorithm,
-    )
+    token = access_token_generator(user, time_delta=-1000)
 
     response = await test_client.get(
-        "v1/datasets",
+        "v1/users/me",
         headers={"Authorization": f"Bearer {token}"},
     )
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
     assert response.json() == {
-        "error": {"code": "unauthorized", "details": None, "message": "Invalid token"},
-    }
-
-
-async def test_dummy_auth_unexisting_user(
-    test_client: AsyncClient,
-    user: User,
-    access_token_settings: JWTSettings,
-):
-    token = sign_jwt(
-        {"user_id": user.id + 666, "exp": time.time() + 100000},
-        access_token_settings.secret_key.get_secret_value(),
-        access_token_settings.security_algorithm,
-    )
-
-    response = await test_client.get(
-        "v1/datasets",
-        headers={"Authorization": f"Bearer {token}"},
-    )
-
-    assert response.status_code == HTTPStatus.NOT_FOUND, response.json()
-    assert response.json() == {
         "error": {
-            "code": "not_found",
-            "details": {"entity_type": "User", "field": "user_id", "value": user.id + 666},
-            "message": f"User with user_id={user.id + 666} not found",
+            "code": "unauthorized",
+            "message": "Invalid token",
+            "details": "Token has expired",
         },
     }
 
 
 async def test_dummy_auth_logout_not_implemented(
     test_client: AsyncClient,
-    user: User,
-    access_token_settings: JWTSettings,
+    mocked_user: MockedUser,
 ):
-    token = sign_jwt(
-        {"user_id": user.id, "exp": time.time() + 100000},
-        access_token_settings.secret_key.get_secret_value(),
-        access_token_settings.security_algorithm,
-    )
-
     response = await test_client.get(
         "v1/auth/logout",
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
     )
 
     assert response.status_code == HTTPStatus.NOT_IMPLEMENTED, response.json()
     assert response.json() == {
         "error": {
             "code": "not_implemented",
+            "message": "Logout method is not implemented for DummyAuthProvider",
             "details": None,
-            "message": "Logout method is not implemented for DummyAuthProvider.",
         },
     }
 
 
-async def test_dummy_auth_generate_valid_token(
+async def test_dummy_auth_login(
     test_client: AsyncClient,
+    access_token_jwt_decoder: Callable[[str], dict],
 ):
     response = await test_client.post("v1/auth/token", data={"username": "test", "password": "test"})
 
-    token = response.json()["access_token"]
+    data = response.json()
+    assert data["token_type"] == "bearer"
+    assert data["access_token"]
+    assert data["expires_at"]
 
-    response = await test_client.get(
-        "v1/datasets",
-        headers={"Authorization": f"Bearer {token}"},
-    )
-
-    assert response.status_code == HTTPStatus.OK, response.json()
+    claims = access_token_jwt_decoder(data["access_token"])
+    assert claims["iss"]
+    assert claims["preferred_username"] == "test"
+    assert claims["sub_id"]
+    assert claims["nbf"]
+    assert claims["iat"]
+    assert claims["exp"]
+    assert "jti" not in claims

--- a/tests/test_server/test_auth/test_personal_token_auth.py
+++ b/tests/test_server/test_auth/test_personal_token_auth.py
@@ -1,0 +1,125 @@
+from collections.abc import Callable
+from datetime import UTC, datetime
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from data_rentgen.db.models import PersonalToken, User
+from data_rentgen.server.settings import ServerApplicationSettings as Settings
+from tests.fixtures.mocks import MockedUser
+from tests.test_server.fixtures.factories.personal_token import create_personal_token
+
+pytestmark = [pytest.mark.server, pytest.mark.asyncio]
+
+
+async def test_personal_token_auth(
+    test_client: AsyncClient,
+    mocked_user: MockedUser,
+):
+    response = await test_client.get(
+        "v1/users/me",
+        headers={"Authorization": f"Bearer {mocked_user.personal_token}"},
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {"name": mocked_user.user.name}
+
+
+@pytest.mark.parametrize(
+    "server_app_settings",
+    [
+        {"auth": {"personal_tokens": {"enabled": False}}},
+    ],
+    indirect=True,
+)
+async def test_personal_token_auth_disabled(
+    test_client: AsyncClient,
+    mocked_user: MockedUser,
+    server_app_settings: Settings,
+):
+    response = await test_client.get(
+        "v1/users/me",
+        headers={"Authorization": f"Bearer {mocked_user.personal_token}"},
+    )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
+    assert response.json() == {
+        "error": {
+            "code": "unauthorized",
+            "message": "Authentication using PersonalTokens is disabled",
+            "details": None,
+        },
+    }
+
+
+async def test_personal_token_auth_invalid_token(
+    test_client: AsyncClient,
+    mocked_user: MockedUser,
+):
+    response = await test_client.get(
+        "v1/datasets",
+        headers={"Authorization": f"Bearer {mocked_user.personal_token + 'invalid'}"},
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
+    assert response.json() == {
+        "error": {
+            "code": "unauthorized",
+            "message": "Invalid token",
+            "details": "Signature verification failed",
+        },
+    }
+
+
+async def test_personal_token_auth_expired_token(
+    test_client: AsyncClient,
+    user: User,
+    personal_token: PersonalToken,
+    personal_token_jwt_generator: Callable[..., str],
+):
+    token = personal_token_jwt_generator(personal_token, user, time_delta=-1000)
+
+    response = await test_client.get(
+        "v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
+    assert response.json() == {
+        "error": {
+            "code": "unauthorized",
+            "message": "Invalid token",
+            "details": "Token has expired",
+        },
+    }
+
+
+async def test_personal_token_auth_revoked_token(
+    async_session: AsyncSession,
+    test_client: AsyncClient,
+    user: User,
+    personal_token: PersonalToken,
+    personal_token_jwt_generator: Callable[..., str],
+):
+    personal_token = await create_personal_token(
+        async_session,
+        user,
+        token_kwargs={
+            "revoked_at": datetime.now(tz=UTC).date(),
+        },
+    )
+    token = personal_token_jwt_generator(personal_token, user)
+    response = await test_client.get(
+        "v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
+    assert response.json() == {
+        "error": {
+            "code": "unauthorized",
+            "message": "Invalid token",
+            "details": f"PersonalToken name='{personal_token.name}', id={personal_token.id} is revoked",
+        },
+    }

--- a/tests/test_server/test_datasets/test_get_datasets.py
+++ b/tests/test_server/test_datasets/test_get_datasets.py
@@ -53,5 +53,21 @@ async def test_get_datasets_unauthorized(
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
     assert response.json() == {
-        "error": {"code": "unauthorized", "details": None, "message": "Missing auth credentials"},
+        "error": {
+            "code": "unauthorized",
+            "message": "Missing Authorization header",
+            "details": None,
+        },
     }
+
+
+async def test_get_datasets_via_personal_token_is_allowed(
+    test_client: AsyncClient,
+    mocked_user: MockedUser,
+):
+    response = await test_client.get(
+        "v1/datasets",
+        headers={"Authorization": f"Bearer {mocked_user.personal_token}"},
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()

--- a/tests/test_server/test_jobs/test_get_jobs.py
+++ b/tests/test_server/test_jobs/test_get_jobs.py
@@ -53,5 +53,21 @@ async def test_get_jobs_unauthorized(
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
     assert response.json() == {
-        "error": {"code": "unauthorized", "details": None, "message": "Missing auth credentials"},
+        "error": {
+            "code": "unauthorized",
+            "message": "Missing Authorization header",
+            "details": None,
+        },
     }
+
+
+async def test_get_jobs_via_personal_token_is_allowed(
+    test_client: AsyncClient,
+    mocked_user: MockedUser,
+):
+    response = await test_client.get(
+        "v1/jobs",
+        headers={"Authorization": f"Bearer {mocked_user.personal_token}"},
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()

--- a/tests/test_server/test_lineage/test_job_lineage.py
+++ b/tests/test_server/test_lineage/test_job_lineage.py
@@ -31,8 +31,29 @@ async def test_get_job_lineage_unauthorized(
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
     assert response.json() == {
-        "error": {"code": "unauthorized", "details": None, "message": "Missing auth credentials"},
+        "error": {
+            "code": "unauthorized",
+            "message": "Missing Authorization header",
+            "details": None,
+        },
     }
+
+
+async def test_get_job_lineage_via_personal_token_is_allowed(
+    test_client: AsyncClient,
+    job: Job,
+    mocked_user: MockedUser,
+):
+    response = await test_client.get(
+        "v1/jobs/lineage",
+        headers={"Authorization": f"Bearer {mocked_user.personal_token}"},
+        params={
+            "since": datetime.now(tz=timezone.utc).isoformat(),
+            "start_node_id": job.id,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
 
 
 async def test_get_job_lineage_no_runs(

--- a/tests/test_server/test_lineage/test_operation_lineage.py
+++ b/tests/test_server/test_lineage/test_operation_lineage.py
@@ -32,8 +32,29 @@ async def test_get_operation_lineage_unauthorized(
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
     assert response.json() == {
-        "error": {"code": "unauthorized", "details": None, "message": "Missing auth credentials"},
+        "error": {
+            "code": "unauthorized",
+            "message": "Missing Authorization header",
+            "details": None,
+        },
     }
+
+
+async def test_get_operation_lineage_via_personal_token_is_allowed(
+    test_client: AsyncClient,
+    operation: Operation,
+    mocked_user: MockedUser,
+):
+    response = await test_client.get(
+        "v1/operations/lineage",
+        headers={"Authorization": f"Bearer {mocked_user.personal_token}"},
+        params={
+            "since": operation.created_at.isoformat(),
+            "start_node_id": str(operation.id),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
 
 
 async def test_get_operation_lineage_no_inputs_outputs(

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -33,8 +33,29 @@ async def test_get_run_lineage_unauthorized(
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
     assert response.json() == {
-        "error": {"code": "unauthorized", "details": None, "message": "Missing auth credentials"},
+        "error": {
+            "code": "unauthorized",
+            "message": "Missing Authorization header",
+            "details": None,
+        },
     }
+
+
+async def test_get_run_lineage_via_personal_token_is_allowed(
+    test_client: AsyncClient,
+    run: Run,
+    mocked_user: MockedUser,
+):
+    response = await test_client.get(
+        "v1/runs/lineage",
+        headers={"Authorization": f"Bearer {mocked_user.personal_token}"},
+        params={
+            "since": run.created_at.isoformat(),
+            "start_node_id": str(run.id),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
 
 
 async def test_get_run_lineage_no_operations(

--- a/tests/test_server/test_locations/test_get_locations.py
+++ b/tests/test_server/test_locations/test_get_locations.py
@@ -107,5 +107,21 @@ async def test_get_locations_unauthorized(
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
     assert response.json() == {
-        "error": {"code": "unauthorized", "details": None, "message": "Missing auth credentials"},
+        "error": {
+            "code": "unauthorized",
+            "message": "Missing Authorization header",
+            "details": None,
+        },
     }
+
+
+async def test_get_locations_via_personal_token_is_allowed(
+    test_client: AsyncClient,
+    mocked_user: MockedUser,
+):
+    response = await test_client.get(
+        "v1/locations",
+        headers={"Authorization": f"Bearer {mocked_user.personal_token}"},
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()

--- a/tests/test_server/test_locations/test_patch_locations.py
+++ b/tests/test_server/test_locations/test_patch_locations.py
@@ -152,5 +152,9 @@ async def test_patch_location_without_auth(
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
     assert response.json() == {
-        "error": {"code": "unauthorized", "details": None, "message": "Missing auth credentials"},
+        "error": {
+            "code": "unauthorized",
+            "message": "Missing Authorization header",
+            "details": None,
+        },
     }

--- a/tests/test_server/test_operations/test_get_operations.py
+++ b/tests/test_server/test_operations/test_get_operations.py
@@ -83,5 +83,9 @@ async def test_get_operations_unauthorized(
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
     assert response.json() == {
-        "error": {"code": "unauthorized", "details": None, "message": "Missing auth credentials"},
+        "error": {
+            "code": "unauthorized",
+            "message": "Missing Authorization header",
+            "details": None,
+        },
     }

--- a/tests/test_server/test_operations/test_get_operations_by_id.py
+++ b/tests/test_server/test_operations/test_get_operations_by_id.py
@@ -258,3 +258,17 @@ async def test_get_operations_by_one_id_with_sql_query(
             },
         ],
     }
+
+
+async def test_get_operations_via_personal_token_is_allowed(
+    test_client: AsyncClient,
+    new_operation: Operation,
+    mocked_user: MockedUser,
+):
+    response = await test_client.get(
+        "v1/operations",
+        headers={"Authorization": f"Bearer {mocked_user.personal_token}"},
+        params={"operation_id": str(new_operation.id)},
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()

--- a/tests/test_server/test_personal_tokens/test_get_token.py
+++ b/tests/test_server/test_personal_tokens/test_get_token.py
@@ -107,19 +107,3 @@ async def test_get_personal_token_not_found(
             },
             "items": [],
         }
-
-
-async def test_get_personal_token_unauthorized(
-    test_client: AsyncClient,
-):
-    token = personal_token_factory()
-
-    response = await test_client.get(
-        "v1/personal-tokens",
-        params={"personal_token_id": str(token.id)},
-    )
-
-    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
-    assert response.json() == {
-        "error": {"code": "unauthorized", "details": None, "message": "Missing auth credentials"},
-    }

--- a/tests/test_server/test_personal_tokens/test_revoke_token.py
+++ b/tests/test_server/test_personal_tokens/test_revoke_token.py
@@ -61,7 +61,7 @@ async def test_revoke_personal_token(
 
     assert response.status_code == HTTPStatus.NO_CONTENT, response.json()
 
-    query = select(PersonalToken).where(PersonalToken.user_id == mocked_user.user.id)
+    query = select(PersonalToken).where(PersonalToken.user_id == mocked_user.user.id, PersonalToken.name == "test")
     personal_token_scalars = await async_session.scalars(query)
     personal_tokens = list(personal_token_scalars.all())
 
@@ -121,5 +121,29 @@ async def test_revoke_personal_token_unauthorized(
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
     assert response.json() == {
-        "error": {"code": "unauthorized", "details": None, "message": "Missing auth credentials"},
+        "error": {
+            "code": "unauthorized",
+            "message": "Missing Authorization header",
+            "details": None,
+        },
+    }
+
+
+async def test_revoke_personal_token_via_personal_token_not_allowed(
+    test_client: AsyncClient,
+    mocked_user: MockedUser,
+    personal_token: PersonalToken,
+):
+    response = await test_client.delete(
+        f"v1/personal-tokens/{personal_token.id}",
+        headers={"Authorization": f"Bearer {mocked_user.personal_token}"},
+    )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
+    assert response.json() == {
+        "error": {
+            "code": "unauthorized",
+            "message": "Invalid token",
+            "details": "PersonalToken was passed but access token was expected",
+        },
     }

--- a/tests/test_server/test_runs/test_get_runs.py
+++ b/tests/test_server/test_runs/test_get_runs.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from http import HTTPStatus
 
 import pytest
@@ -208,5 +208,24 @@ async def test_get_runs_unauthorized(
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
     assert response.json() == {
-        "error": {"code": "unauthorized", "details": None, "message": "Missing auth credentials"},
+        "error": {
+            "code": "unauthorized",
+            "message": "Missing Authorization header",
+            "details": None,
+        },
     }
+
+
+async def test_get_runs_via_personal_token_is_allowed(
+    test_client: AsyncClient,
+    mocked_user: MockedUser,
+):
+    response = await test_client.get(
+        "v1/runs",
+        headers={"Authorization": f"Bearer {mocked_user.personal_token}"},
+        params={
+            "since": datetime.now(tz=UTC).isoformat(),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

User may generate PersonalToken, and use it in `Authorization: Bearer ...` header for both server and http2kafka. Personal tokens have higher priority than regular auth providers. Also auth using personal tokens can be disabled via settings.

PersonalToken is JWT string containing all information about token + user id + user name. This allows us to validate token without fetching information from database.

As token can be revoked, to avoid fetching token from database for every request, a simple im-memory cache is implemented (using `cachetools`). First request checks if token is revoked or not. Second uses cached information. Active tokens are cached for small time (5 minutes), revoked tokens cached forever.

Documentation will be added in next PR.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [ ] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
