### PR TITLE
[DOP-22531] Add location_id filter for dataset

### DIFF
--- a/data_rentgen/db/repositories/dataset.py
+++ b/data_rentgen/db/repositories/dataset.py
@@ -44,11 +44,15 @@ class DatasetRepository(Repository[Dataset]):
         page_size: int,
         dataset_ids: Collection[int],
         tag_value_ids: Collection[int],
+        location_id: int | None,
         search_query: str | None,
     ) -> PaginationDTO[Dataset]:
         where = []
         if dataset_ids:
             where.append(Dataset.id == any_(list(dataset_ids)))  # type: ignore[arg-type]
+
+        if location_id:
+            where.append(Dataset.location_id == location_id)
 
         if tag_value_ids:
             tv_ids = list(tag_value_ids)

--- a/data_rentgen/server/api/v1/router/dataset.py
+++ b/data_rentgen/server/api/v1/router/dataset.py
@@ -29,7 +29,7 @@ router = APIRouter(
 
 @router.get("", summary="Paginated list of Datasets")
 async def paginate_datasets(
-    query_args: Annotated[DatasetPaginateQueryV1, Depends()],
+    query_args: Annotated[DatasetPaginateQueryV1, Query()],
     dataset_service: Annotated[DatasetService, Depends()],
     current_user: Annotated[User, Depends(get_user())],
 ) -> PageResponseV1[DatasetDetailedResponseV1]:
@@ -38,6 +38,7 @@ async def paginate_datasets(
         page_size=query_args.page_size,
         dataset_ids=query_args.dataset_id,
         tag_value_ids=query_args.tag_value_id,
+        location_id=query_args.location_id,
         search_query=query_args.search_query,
     )
     return PageResponseV1[DatasetDetailedResponseV1].from_pagination(pagination)

--- a/data_rentgen/server/api/v1/router/job.py
+++ b/data_rentgen/server/api/v1/router/job.py
@@ -27,7 +27,7 @@ router = APIRouter(
 
 @router.get("", summary="Paginated list of Jobs")
 async def paginate_jobs(
-    query_args: Annotated[JobPaginateQueryV1, Depends()],
+    query_args: Annotated[JobPaginateQueryV1, Query()],
     job_service: Annotated[JobService, Depends()],
     current_user: Annotated[User, Depends(get_user())],
 ) -> PageResponseV1[JobDetailedResponseV1]:

--- a/data_rentgen/server/api/v1/router/location.py
+++ b/data_rentgen/server/api/v1/router/location.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from data_rentgen.db.models import User
 from data_rentgen.server.errors import get_error_responses
@@ -28,7 +28,7 @@ router = APIRouter(
     responses=get_error_responses(include={NotAuthorizedSchema, NotAuthorizedRedirectSchema, InvalidRequestSchema}),
 )
 async def paginate_locations(
-    query_args: Annotated[LocationPaginateQueryV1, Depends()],
+    query_args: Annotated[LocationPaginateQueryV1, Query()],
     location_service: Annotated[LocationService, Depends()],
     current_user: Annotated[User, Depends(get_user())],
 ) -> PageResponseV1[LocationDetailedResponseV1]:

--- a/data_rentgen/server/api/v1/router/operation.py
+++ b/data_rentgen/server/api/v1/router/operation.py
@@ -27,7 +27,7 @@ router = APIRouter(
 
 @router.get("", summary="Paginated list of Operations")
 async def operations(
-    query_args: Annotated[OperationQueryV1, Depends()],
+    query_args: Annotated[OperationQueryV1, Query()],
     unit_of_work: Annotated[UnitOfWork, Depends()],
     operation_service: Annotated[OperationService, Depends()],
     current_user: Annotated[User, Depends(get_user())],

--- a/data_rentgen/server/api/v1/router/run.py
+++ b/data_rentgen/server/api/v1/router/run.py
@@ -26,7 +26,7 @@ router = APIRouter(
 
 @router.get("", summary="Paginated list of Runs")
 async def runs(
-    query_args: Annotated[RunsQueryV1, Depends()],
+    query_args: Annotated[RunsQueryV1, Query()],
     run_service: Annotated[RunService, Depends()],
     current_user: Annotated[User, Depends(get_user())],
 ) -> PageResponseV1[RunDetailedResponseV1]:

--- a/data_rentgen/server/api/v1/router/tag.py
+++ b/data_rentgen/server/api/v1/router/tag.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from data_rentgen.db.models.user import User
 from data_rentgen.server.errors import get_error_responses
@@ -24,7 +24,7 @@ router = APIRouter(
 
 @router.get("", summary="Paginated list of Tags")
 async def paginate_tags(
-    query_args: Annotated[TagPaginateQueryV1, Depends()],
+    query_args: Annotated[TagPaginateQueryV1, Query()],
     tag_service: Annotated[TagService, Depends()],
     current_user: Annotated[User, Depends(get_user())],
 ) -> PageResponseV1[TagDetailedResponseV1]:

--- a/data_rentgen/server/schemas/v1/dataset.py
+++ b/data_rentgen/server/schemas/v1/dataset.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Literal
 
-from fastapi import Query
 from pydantic import BaseModel, ConfigDict, Field
 
 from data_rentgen.server.schemas.v1.location import LocationResponseV1
@@ -56,14 +55,13 @@ class DatasetDetailedResponseV1(BaseModel):
 class DatasetPaginateQueryV1(PaginateQueryV1):
     """Query params for Dataset paginate request."""
 
-    dataset_id: list[int] = Field(Query(default_factory=list), description="Dataset id")
-    tag_value_id: list[int] = Field(Query(default_factory=list), description="Tag value id")
+    dataset_id: list[int] = Field(default_factory=list, description="Dataset id")
+    tag_value_id: list[int] = Field(default_factory=list, description="Tag value id")
+    location_id: int | None = Field(default=None, description="Location id to filter dataset")
     search_query: str | None = Field(
-        Query(
-            default=None,
-            min_length=3,
-            description="Search query",
-        ),
+        default=None,
+        min_length=3,
+        description="Search query",
     )
 
     model_config = ConfigDict(extra="forbid")

--- a/data_rentgen/server/schemas/v1/job.py
+++ b/data_rentgen/server/schemas/v1/job.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from fastapi import Query
 from pydantic import BaseModel, ConfigDict, Field
 
 from data_rentgen.server.schemas.v1.location import LocationResponseV1
@@ -30,13 +29,11 @@ class JobDetailedResponseV1(BaseModel):
 class JobPaginateQueryV1(PaginateQueryV1):
     """Query params for Jobs paginate request."""
 
-    job_id: list[int] = Field(Query(default_factory=list), description="Job id")
+    job_id: list[int] = Field(default_factory=list, description="Job id")
     search_query: str | None = Field(
-        Query(
-            default=None,
-            min_length=3,
-            description="Search query",
-        ),
+        default=None,
+        min_length=3,
+        description="Search query",
     )
 
     model_config = ConfigDict(extra="forbid")

--- a/data_rentgen/server/schemas/v1/location.py
+++ b/data_rentgen/server/schemas/v1/location.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from fastapi import Query
 from pydantic import BaseModel, ConfigDict, Field
 
 from data_rentgen.server.schemas.v1.address import AddressResponseV1
@@ -55,14 +54,12 @@ class LocationDetailedResponseV1(BaseModel):
 class LocationPaginateQueryV1(PaginateQueryV1):
     """Query params for Location paginate request."""
 
-    location_id: list[int] = Field(Query(default_factory=list), description="Location id")
-    location_type: str | None = Field(Query(default=None), description="Location type")
+    location_id: list[int] = Field(default_factory=list, description="Location id")
+    location_type: str | None = Field(default=None, description="Location type")
     search_query: str | None = Field(
-        Query(
-            default=None,
-            min_length=3,
-            description="Search query",
-        ),
+        default=None,
+        min_length=3,
+        description="Search query",
     )
 
     model_config = ConfigDict(extra="forbid")

--- a/data_rentgen/server/schemas/v1/operation.py
+++ b/data_rentgen/server/schemas/v1/operation.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from enum import IntEnum
 from uuid import UUID
 
-from fastapi import Query
 from pydantic import (
     UUID7,
     BaseModel,
@@ -102,30 +101,22 @@ class OperationQueryV1(PaginateQueryV1):
     """Query params for Operations paginate request."""
 
     since: datetime | None = Field(
-        Query(
-            default=None,
-            description="Minimum value of Operation 'created_at' field, in ISO 8601 format",
-            examples=["2008-09-15T15:53:00+05:00"],
-        ),
+        default=None,
+        description="Minimum value of Operation 'created_at' field, in ISO 8601 format",
+        examples=["2008-09-15T15:53:00+05:00"],
     )
     until: datetime | None = Field(
-        Query(
-            default=None,
-            description="Maximum value of Operation 'created_at' field, in ISO 8601 format",
-            examples=["2008-09-15T15:53:00+05:00"],
-        ),
+        default=None,
+        description="Maximum value of Operation 'created_at' field, in ISO 8601 format",
+        examples=["2008-09-15T15:53:00+05:00"],
     )
     operation_id: list[UUID7] = Field(
-        Query(
-            default_factory=list,
-            description="Operation ids, for exact match",
-        ),
+        default_factory=list,
+        description="Operation ids, for exact match",
     )
     run_id: UUID7 | None = Field(
-        Query(
-            default=None,
-            description="Run id, can be used only with 'since'",
-        ),
+        default=None,
+        description="Run id, can be used only with 'since'",
     )
 
     model_config = ConfigDict(extra="forbid")

--- a/data_rentgen/server/schemas/v1/run.py
+++ b/data_rentgen/server/schemas/v1/run.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from enum import IntEnum
 from uuid import UUID
 
-from fastapi import Query
 from pydantic import (
     UUID7,
     BaseModel,
@@ -116,46 +115,34 @@ class RunsQueryV1(PaginateQueryV1):
     """Query params for Runs paginate request."""
 
     since: datetime | None = Field(
-        Query(
-            default=None,
-            description="Minimum value of Run 'created_at' field, in ISO 8601 format",
-            examples=["2008-09-15T15:53:00+05:00"],
-        ),
+        default=None,
+        description="Minimum value of Run 'created_at' field, in ISO 8601 format",
+        examples=["2008-09-15T15:53:00+05:00"],
     )
     until: datetime | None = Field(
-        Query(
-            default=None,
-            description="Maximum value of Run 'created_at' field, in ISO 8601 format",
-            examples=["2008-09-15T15:53:00+05:00"],
-        ),
+        default=None,
+        description="Maximum value of Run 'created_at' field, in ISO 8601 format",
+        examples=["2008-09-15T15:53:00+05:00"],
     )
     run_id: list[UUID7] = Field(
-        Query(
-            default_factory=list,
-            description="Run ids, for exact match",
-        ),
+        default_factory=list,
+        description="Run ids, for exact match",
     )
     job_id: int | None = Field(
-        Query(
-            default=None,
-            description="Job id, can be used only with 'since'",
-        ),
+        default=None,
+        description="Job id, can be used only with 'since'",
     )
 
     parent_run_id: UUID7 | None = Field(
-        Query(
-            default=None,
-            description="Parent run id, can be used only with 'since' and 'until'",
-            examples=["01913217-b761-7b1a-bb52-489da9c8b9c8"],
-        ),
+        default=None,
+        description="Parent run id, can be used only with 'since' and 'until'",
+        examples=["01913217-b761-7b1a-bb52-489da9c8b9c8"],
     )
 
     search_query: str | None = Field(
-        Query(
-            default=None,
-            min_length=3,
-            description="Search query",
-        ),
+        default=None,
+        min_length=3,
+        description="Search query",
     )
 
     model_config = ConfigDict(extra="forbid")

--- a/data_rentgen/server/schemas/v1/tag.py
+++ b/data_rentgen/server/schemas/v1/tag.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2024-2025 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
-from fastapi import Query
 from pydantic import BaseModel, ConfigDict, Field
 
 from data_rentgen.server.schemas.v1.pagination import PaginateQueryV1
@@ -31,13 +30,11 @@ class TagDetailedResponseV1(BaseModel):
 class TagPaginateQueryV1(PaginateQueryV1):
     """Query params for Tag paginate request."""
 
-    tag_id: list[int] = Field(Query(default_factory=list), description="Tag id")
+    tag_id: list[int] = Field(default_factory=list, description="Tag id")
     search_query: str | None = Field(
-        Query(
-            default=None,
-            min_length=3,
-            description="Search query",
-        ),
+        default=None,
+        min_length=3,
+        description="Search query",
     )
 
     model_config = ConfigDict(extra="forbid")

--- a/data_rentgen/server/services/dataset.py
+++ b/data_rentgen/server/services/dataset.py
@@ -42,6 +42,7 @@ class DatasetService:
         page_size: int,
         dataset_ids: Collection[int],
         tag_value_ids: Collection[int],
+        location_id: int | None,
         search_query: str | None,
     ) -> DatasetServicePaginatedResult:
         pagination = await self._uow.dataset.paginate(
@@ -49,6 +50,7 @@ class DatasetService:
             page_size=page_size,
             dataset_ids=dataset_ids,
             tag_value_ids=tag_value_ids,
+            location_id=location_id,
             search_query=search_query,
         )
 

--- a/docs/changelog/next_release/294.improvement.rst
+++ b/docs/changelog/next_release/294.improvement.rst
@@ -1,0 +1,1 @@
+Add `location_id` for dataset paginate query. Now you can get all datasets which are related to specific location.

--- a/tests/test_server/test_operations/test_get_operations.py
+++ b/tests/test_server/test_operations/test_get_operations.py
@@ -24,17 +24,14 @@ async def test_get_operations_missing_fields(test_client: AsyncClient, mocked_us
             "message": "Invalid request",
             "details": [
                 {
-                    "location": [],
+                    "location": ["query"],
                     "code": "value_error",
                     "message": "Value error, input should contain either 'run_id' or 'operation_id' field",
                     "context": {},
                     "input": {
                         "page": 1,
                         "page_size": 20,
-                        "since": None,
-                        "until": None,
                         "operation_id": [],
-                        "run_id": None,
                     },
                 },
             ],
@@ -65,11 +62,11 @@ async def test_get_operations_until_less_than_since(
             "message": "Invalid request",
             "details": [
                 {
-                    "location": ["until"],
+                    "location": ["query", "until"],
                     "code": "value_error",
                     "message": "Value error, 'since' should be less than 'until'",
                     "context": {},
-                    "input": until.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                    "input": until.isoformat(),
                 },
             ],
         },

--- a/tests/test_server/test_operations/test_get_operations_by_run_id.py
+++ b/tests/test_server/test_operations/test_get_operations_by_run_id.py
@@ -31,7 +31,7 @@ async def test_get_operations_missing_since(
             "message": "Invalid request",
             "details": [
                 {
-                    "location": [],
+                    "location": ["query"],
                     "code": "value_error",
                     "message": "Value error, 'run_id' can be passed only with 'since'",
                     "context": {},
@@ -39,8 +39,6 @@ async def test_get_operations_missing_since(
                         "page": 1,
                         "page_size": 20,
                         "run_id": str(new_operation.run_id),
-                        "since": None,
-                        "until": None,
                         "operation_id": [],
                     },
                 },

--- a/tests/test_server/test_runs/test_get_runs.py
+++ b/tests/test_server/test_runs/test_get_runs.py
@@ -31,19 +31,14 @@ async def test_get_runs_missing_fields(
             "message": "Invalid request",
             "details": [
                 {
-                    "location": [],
+                    "location": ["query"],
                     "code": "value_error",
                     "message": "Value error, input should contain either 'since', 'run_id', 'job_id', 'parent_run_id' or 'search_query' field",
                     "context": {},
                     "input": {
                         "page": 1,
                         "page_size": 20,
-                        "since": None,
-                        "until": None,
                         "run_id": [],
-                        "parent_run_id": None,
-                        "job_id": None,
-                        "search_query": None,
                     },
                 },
             ],
@@ -74,11 +69,11 @@ async def test_get_runs_by_run_id_until_less_than_since(
             "message": "Invalid request",
             "details": [
                 {
-                    "location": ["until"],
+                    "location": ["query", "until"],
                     "code": "value_error",
                     "message": "Value error, 'since' should be less than 'until'",
                     "context": {},
-                    "input": until.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                    "input": until.isoformat(),
                 },
             ],
         },

--- a/tests/test_server/test_runs/test_get_runs_by_job_id.py
+++ b/tests/test_server/test_runs/test_get_runs_by_job_id.py
@@ -33,19 +33,15 @@ async def test_get_runs_by_job_id_missing_since(
             "message": "Invalid request",
             "details": [
                 {
-                    "location": [],
+                    "location": ["query"],
                     "code": "value_error",
                     "message": "Value error, 'job_id' can be passed only with 'since'",
                     "context": {},
                     "input": {
                         "page": 1,
                         "page_size": 20,
-                        "job_id": new_run.job_id,
-                        "since": None,
-                        "until": None,
-                        "parent_run_id": None,
+                        "job_id": str(new_run.job_id),
                         "run_id": [],
-                        "search_query": None,
                     },
                 },
             ],

--- a/tests/test_server/test_runs/test_get_runs_by_parent_run_id.py
+++ b/tests/test_server/test_runs/test_get_runs_by_parent_run_id.py
@@ -33,7 +33,7 @@ async def test_get_runs_by_job_id_missing_since(
             "message": "Invalid request",
             "details": [
                 {
-                    "location": [],
+                    "location": ["query"],
                     "code": "value_error",
                     "message": "Value error, 'parent_run_id' can be passed only with 'since'",
                     "context": {},
@@ -41,11 +41,7 @@ async def test_get_runs_by_job_id_missing_since(
                         "page": 1,
                         "page_size": 20,
                         "parent_run_id": str(new_run.parent_run_id),
-                        "since": None,
-                        "until": None,
-                        "job_id": None,
                         "run_id": [],
-                        "search_query": None,
                     },
                 },
             ],

--- a/tests/test_server/test_runs/test_search_runs.py
+++ b/tests/test_server/test_runs/test_search_runs.py
@@ -32,17 +32,13 @@ async def test_search_runs_missing_since(
             "message": "Invalid request",
             "details": [
                 {
-                    "location": [],
+                    "location": ["query"],
                     "code": "value_error",
                     "message": "Value error, 'search_query' can be passed only with 'since'",
                     "context": {},
                     "input": {
                         "page": 1,
                         "page_size": 20,
-                        "job_id": None,
-                        "since": None,
-                        "until": None,
-                        "parent_run_id": None,
                         "run_id": [],
                         "search_query": new_run.external_id,
                     },


### PR DESCRIPTION
## Change Summary

- Add filter 'location_id' for dataset pagination query
- Change type of `DatasetPaginationQuery` from `Depends()` to `Query()`. With `Depends` the `model_config = {'extra': 'forbiden'}` doesn't work. Same fix for all entities (`Job`, `Run`, ....)

## Related issue number

[DOP-22531]

## Checklist

* [ ] Commit message and PR title is comprehensive
* [ ] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [ ] My PR is ready to review.
