### PR TITLE
[DOP-29593] Add more filters in GET /v1/runs endpoint

### DIFF
--- a/data_rentgen/server/api/v1/router/run.py
+++ b/data_rentgen/server/api/v1/router/run.py
@@ -40,7 +40,13 @@ async def runs(
         parent_run_id=query_args.parent_run_id,
         search_query=query_args.search_query,
         job_type=query_args.job_type,
+        job_location_id=query_args.job_location_id,
         status=query_args.status,
+        started_by_user=query_args.started_by_user,
+        started_since=query_args.started_since,
+        started_until=query_args.started_until,
+        ended_since=query_args.ended_since,
+        ended_until=query_args.ended_until,
     )
     return PageResponseV1[RunDetailedResponseV1].from_pagination(pagination)
 

--- a/data_rentgen/server/schemas/v1/run.py
+++ b/data_rentgen/server/schemas/v1/run.py
@@ -43,10 +43,19 @@ class RunStatusV1(IntEnum):
 
 class RunStatusForQueryV1(StrEnum):
     UNKNOWN = "UNKNOWN"
+    """No data about status"""
+
     STARTED = "STARTED"
+    """Received START event"""
+
     SUCCEEDED = "SUCCEEDED"
+    """Finished successfully"""
+
     FAILED = "FAILED"
+    """Internal failure"""
+
     KILLED = "KILLED"
+    """Killed externally, e.g. by user request or in case of OOM"""
 
 
 class RunResponseV1(BaseModel):
@@ -150,14 +159,52 @@ class RunsQueryV1(PaginateQueryV1):
     job_type: list[str] = Field(
         default_factory=list,
         description="Filter runs by type of a Job",
-        examples=["SPARK_APPLICATION", "AIRFLOW_TASK"],
+        examples=[["SPARK_APPLICATION", "AIRFLOW_TASK"]],
     )
-    status: list[RunStatusForQueryV1] = Field(default_factory=list, description="Filter runs by status")
+    job_location_id: int | None = Field(
+        default=None,
+        description="Filter runs by location of a Job",
+        examples=[123, 234],
+    )
+
+    status: list[RunStatusForQueryV1] = Field(
+        default_factory=list,
+        description="Filter runs by status",
+        examples=[["SUCCEEDED", "FAILED"]],
+    )
+
+    started_by_user: list[str] | None = Field(
+        default=None,
+        description="User who started the Run",
+        examples=[["someuser1", "someuser2"]],
+    )
 
     search_query: str | None = Field(
         default=None,
         min_length=3,
         description="Search query",
+    )
+
+    started_since: datetime | None = Field(
+        default=None,
+        description="Minimum value of Run 'started_at' field, in ISO 8601 format",
+        examples=["2008-09-15T15:53:00+05:00"],
+    )
+    started_until: datetime | None = Field(
+        default=None,
+        description="Maximum value of Run 'started_at' field, in ISO 8601 format",
+        examples=["2008-09-15T15:53:00+05:00"],
+    )
+
+    ended_since: datetime | None = Field(
+        default=None,
+        description="Minimum value of Run 'ended_at' field, in ISO 8601 format",
+        examples=["2008-09-15T15:53:00+05:00"],
+    )
+    ended_until: datetime | None = Field(
+        default=None,
+        description="Maximum value of Run 'ended_at' field, in ISO 8601 format",
+        examples=["2008-09-15T15:53:00+05:00"],
     )
 
     model_config = ConfigDict(extra="forbid")

--- a/data_rentgen/server/services/run.py
+++ b/data_rentgen/server/services/run.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from fastapi import Depends
 from sqlalchemy import Row
 
-from data_rentgen.db.models.run import Run
+from data_rentgen.db.models import Run, RunStatus
 from data_rentgen.dto.pagination import PaginationDTO
 from data_rentgen.services.uow import UnitOfWork
 
@@ -81,7 +81,13 @@ class RunService:
         parent_run_id: UUID | None,
         search_query: str | None,
         job_type: Collection[str],
+        job_location_id: int | None,
         status: Collection[str],
+        started_by_user: Collection[str] | None,
+        started_since: datetime | None,
+        started_until: datetime | None,
+        ended_since: datetime | None,
+        ended_until: datetime | None,
     ) -> RunServicePaginatedResult:
         pagination = await self._uow.run.paginate(
             page=page,
@@ -93,7 +99,13 @@ class RunService:
             parent_run_id=parent_run_id,
             search_query=search_query,
             job_type=job_type,
-            status=status,
+            job_location_id=job_location_id,
+            status=[RunStatus[s] for s in status],
+            started_by_user=started_by_user,
+            started_since=started_since,
+            started_until=started_until,
+            ended_since=ended_since,
+            ended_until=ended_until,
         )
         run_ids = [item.id for item in pagination.items]
         input_stats = await self._uow.input.get_stats_by_run_ids(run_ids)

--- a/docs/changelog/next_release/319.feature.rst
+++ b/docs/changelog/next_release/319.feature.rst
@@ -1,0 +1,5 @@
+Add new filters for ``GET /v1/jobs`` endpoint.
+- location_id: ``int``  id to filter by specific location
+- job_type: ``list[str]`` filter by job's type
+
+Add new endpoint GET ``/v1/jobs/types`` - to get distinct job types from DataRentgen.

--- a/docs/changelog/next_release/319.improvement.rst
+++ b/docs/changelog/next_release/319.improvement.rst
@@ -1,5 +1,0 @@
-Add new filters for ``/v1/jobs`` endpoint.
-- ``location_id: int``  id to filter by specific location
-- ``job_type: list[str]`` filter by job's type
-
-Add new endpoint GET ``/v1/jobs/types`` - to get distinct job types from DataRentgen.

--- a/docs/changelog/next_release/322.feature.rst
+++ b/docs/changelog/next_release/322.feature.rst
@@ -1,4 +1,4 @@
-Add new query parameters for ``/api/v1/runs`` endpoint:
+Add new query parameters for ``GET /v1/runs`` endpoint:
 
 - job_type: ``list[str]`` - filter by corresponding job type. For example ``SPARK_APLICATION``. You can use ``/api/v1/jobs/types`` to get all job types.
-- status:``list[RunStatus]`` - filter by runs statuses.
+- status: ``list[RunStatus]`` - filter by runs statuses.

--- a/docs/changelog/next_release/323.feature.rst
+++ b/docs/changelog/next_release/323.feature.rst
@@ -1,0 +1,9 @@
+Add new query parameters for ``GET /v1/runs`` endpoint:
+
+- started_since: ``datetime | None``
+- started_until: ``datetime | None``
+- ended_since: ``datetime | None``
+- ended_until: ``datetime | None``
+- job_location_id: ``int | None``
+- started_by_user: ``list[str] | None``
+

--- a/tests/test_server/test_runs/test_search_runs.py
+++ b/tests/test_server/test_runs/test_search_runs.py
@@ -121,21 +121,18 @@ async def test_search_runs_by_job_name(
     runs_search: dict[str, Run],
     mocked_user: MockedUser,
 ) -> None:
-    runs = await enrich_runs(
+    [run] = await enrich_runs(
         [
-            # runs sorted by id in descending order
-            runs_search["extract_task_0002"],
-            runs_search["extract_task_0001"],
+            runs_search["dag_0001"],
         ],
         async_session,
     )
-    since = min(run.created_at for run in runs)
 
     response = await test_client.get(
         "/v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
+            "since": run.created_at.isoformat(),
             "search_query": "airflow_dag",
         },
     )
@@ -150,7 +147,7 @@ async def test_search_runs_by_job_name(
             "page_size": 20,
             "pages_count": 1,
             "previous_page": None,
-            "total_count": 2,
+            "total_count": 1,
         },
         "items": [
             {
@@ -173,135 +170,7 @@ async def test_search_runs_by_job_name(
                         "total_operations": 0,
                     },
                 },
-            }
-            for run in runs
-        ],
-    }
-
-
-async def test_search_runs_by_job_type(
-    test_client: AsyncClient,
-    async_session: AsyncSession,
-    runs_search: dict[str, Run],
-    mocked_user: MockedUser,
-) -> None:
-    runs = await enrich_runs(
-        [
-            # runs sorted by id in descending order
-            runs_search["application_1638922609021_0002"],
-            runs_search["application_1638922609021_0001"],
-        ],
-        async_session,
-    )
-    since = min(run.created_at for run in runs)
-
-    response = await test_client.get(
-        "/v1/runs",
-        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
-        params={
-            "since": since.isoformat(),
-            "job_type": ["SPARK_APPLICATION"],
-        },
-    )
-
-    assert response.status_code == HTTPStatus.OK, response.json()
-    assert response.json() == {
-        "meta": {
-            "has_next": False,
-            "has_previous": False,
-            "next_page": None,
-            "page": 1,
-            "page_size": 20,
-            "pages_count": 1,
-            "previous_page": None,
-            "total_count": 2,
-        },
-        "items": [
-            {
-                "id": str(run.id),
-                "data": run_to_json(run),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
-            }
-            for run in runs
-        ],
-    }
-
-
-async def test_search_runs_by_status(
-    test_client: AsyncClient,
-    async_session: AsyncSession,
-    runs_search: dict[str, Run],
-    mocked_user: MockedUser,
-) -> None:
-    runs = await enrich_runs(
-        [
-            runs_search["extract_task_0001"],
-            runs_search["application_1638922609021_0002"],
-        ],
-        async_session,
-    )
-    since = min(run.created_at for run in runs)
-
-    response = await test_client.get(
-        "/v1/runs",
-        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
-        params={
-            "since": since.isoformat(),
-            "status": ["SUCCEEDED", "STARTED"],
-        },
-    )
-
-    assert response.status_code == HTTPStatus.OK, response.json()
-    assert response.json() == {
-        "meta": {
-            "has_next": False,
-            "has_previous": False,
-            "next_page": None,
-            "page": 1,
-            "page_size": 20,
-            "pages_count": 1,
-            "previous_page": None,
-            "total_count": 2,
-        },
-        "items": [
-            {
-                "id": str(run.id),
-                "data": run_to_json(run),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
-            }
-            for run in runs
+            },
         ],
     }
 

--- a/tests/test_server/utils/enrich.py
+++ b/tests/test_server/utils/enrich.py
@@ -8,7 +8,14 @@ from data_rentgen.db.models.tag import Tag
 
 async def enrich_runs(runs: list[Run], async_session: AsyncSession) -> list[Run]:
     run_ids = [run.id for run in runs]
-    query = select(Run).where(Run.id.in_(run_ids)).options(selectinload(Run.started_by_user))
+    query = (
+        select(Run)
+        .where(Run.id.in_(run_ids))
+        .options(
+            selectinload(Run.job).selectinload(Job.location).selectinload(Location.addresses),
+            selectinload(Run.started_by_user),
+        )
+    )
     result = await async_session.scalars(query)
     runs_by_id = {run.id: run for run in result.all()}
     # preserve original order


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Filter by `ended_at` is quite effective is value range is small (e.g. 5-10 minutes), even if there is no index for this field in the table. Filter by `started_at` is added for symmetry.

Also added filters `job_location_id` and `started_by_user` to allows fetching only jobs started on specific cluster/host by specific users - this also reduces number of fetched runs.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
