### PR TITLE
[DOP-35394] Make infer_from_lineage query non-recursive

### DIFF
--- a/data_rentgen/db/repositories/job.py
+++ b/data_rentgen/db/repositories/job.py
@@ -335,8 +335,8 @@ class JobRepository(Repository[Job]):
         if not job_ids:
             return []
         stmt = select(
-            ancestors_by_job_cte.c.parent_job_id,
-            ancestors_by_job_cte.c.child_job_id,
+            ancestors_by_job_cte.c.parent_job_id.cast(Integer),
+            ancestors_by_job_cte.c.child_job_id.cast(Integer),
         )
         result = await self._session.execute(
             stmt,
@@ -344,12 +344,12 @@ class JobRepository(Repository[Job]):
                 "job_ids": list(job_ids),
             },
         )
-        return list(result.fetchall())
+        return list(result.all())
 
     async def list_descendant_relations(self, job_ids: Collection[int]):
         stmt = select(
-            descendants_by_job_cte.c.parent_job_id,
-            descendants_by_job_cte.c.child_job_id,
+            descendants_by_job_cte.c.parent_job_id.cast(Integer),
+            descendants_by_job_cte.c.child_job_id.cast(Integer),
         )
         result = await self._session.execute(
             stmt,
@@ -357,4 +357,4 @@ class JobRepository(Repository[Job]):
                 "job_ids": list(job_ids),
             },
         )
-        return list(result.fetchall())
+        return list(result.all())

--- a/data_rentgen/db/repositories/job_dependency.py
+++ b/data_rentgen/db/repositories/job_dependency.py
@@ -75,33 +75,6 @@ class JobDependencyRepository(Repository[JobDependency]):
         await self._lock(job_dependency.from_job.id, job_dependency.to_job.id)
         return await self._get(job_dependency) or await self._create(job_dependency)
 
-    async def get_dependencies(
-        self,
-        job_ids: list[int],
-        direction: Literal["UPSTREAM", "DOWNSTREAM"],
-        depth: int,
-        since: datetime | None = None,
-        until: datetime | None = None,
-        *,
-        infer_from_lineage: bool = False,
-    ) -> list[JobDependency]:
-        core_query = self._get_core_hierarchy_query(include_indirect=infer_from_lineage)
-
-        query: Select | CompoundSelect
-        match direction:
-            case "UPSTREAM":
-                query = self._get_upstream_hierarchy_query(core_query)
-            case "DOWNSTREAM":
-                query = self._get_downstream_hierarchy_query(core_query)
-
-        result = await self._session.execute(
-            query, {"job_ids": job_ids, "depth": depth, "since": since, "until": until}
-        )
-        return [
-            JobDependency(from_job_id=item.from_job_id, to_job_id=item.to_job_id, type=item.type)
-            for item in result.all()
-        ]
-
     async def _get(self, job_dependency: JobDependencyDTO) -> JobDependency | None:
         return await self._session.scalar(
             get_one_query,
@@ -120,6 +93,33 @@ class JobDependencyRepository(Repository[JobDependency]):
         self._session.add(result)
         await self._session.flush([result])
         return result
+
+    async def get_dependencies(
+        self,
+        job_ids: list[int],
+        direction: Literal["UPSTREAM", "DOWNSTREAM"],
+        since: datetime | None = None,
+        until: datetime | None = None,
+        *,
+        infer_from_lineage: bool = False,
+    ) -> list[JobDependency]:
+        core_query = self._get_core_hierarchy_query(include_indirect=infer_from_lineage)
+
+        query: Select | CompoundSelect
+        match direction:
+            case "UPSTREAM":
+                query = select(core_query).where(core_query.c.to_job_id == any_(bindparam("job_ids")))
+            case "DOWNSTREAM":
+                query = select(core_query).where(core_query.c.from_job_id == any_(bindparam("job_ids")))
+
+        result = await self._session.execute(
+            query,
+            {"job_ids": job_ids, "since": since, "until": until},
+        )
+        return [
+            JobDependency(from_job_id=item.from_job_id, to_job_id=item.to_job_id, type=item.type)
+            for item in result.all()
+        ]
 
     def _get_core_hierarchy_query(
         self,
@@ -142,15 +142,13 @@ class JobDependencyRepository(Repository[JobDependency]):
                 .distinct()
                 .join(
                     Input,
-                    and_(
-                        Output.dataset_id == Input.dataset_id,
-                        Output.job_id != Input.job_id,
-                    ),
+                    Output.dataset_id == Input.dataset_id,
                 )
                 .where(
                     Input.created_at >= bindparam("since"),
                     Output.created_at >= bindparam("since"),
                     Output.created_at >= Input.created_at,
+                    Output.job_id != Input.job_id,
                     or_(
                         bindparam("until", type_=DateTime(timezone=True)).is_(None),
                         and_(
@@ -161,65 +159,3 @@ class JobDependencyRepository(Repository[JobDependency]):
                 )
             )
         return query.cte("jobs_hierarchy_core_query").prefix_with("NOT MATERIALIZED", dialect="postgresql")
-
-    def _get_upstream_hierarchy_query(
-        self,
-        core_query: CTE,
-    ) -> Select:
-        base_part = select(
-            core_query.c.from_job_id.label("from_job_id"),
-            core_query.c.to_job_id.label("to_job_id"),
-            core_query.c.type.label("type"),
-            literal(1).label("depth"),
-        ).where(core_query.c.to_job_id == any_(bindparam("job_ids")))
-
-        base_query_cte = base_part.cte(name="upstream_jobs_query", recursive=True)
-
-        recursive_part = (
-            select(
-                core_query.c.from_job_id.label("from_job_id"),
-                core_query.c.to_job_id.label("to_job_id"),
-                core_query.c.type.label("type"),
-                (base_query_cte.c.depth + literal(1)).label("depth"),
-            )
-            .join(
-                core_query,
-                core_query.c.to_job_id == base_query_cte.c.from_job_id,
-            )
-            .where(
-                base_query_cte.c.depth < bindparam("depth"),
-            )
-        )
-
-        return select(base_query_cte.union(recursive_part))
-
-    def _get_downstream_hierarchy_query(
-        self,
-        core_query: CTE,
-    ) -> Select:
-        base_part = select(
-            core_query.c.from_job_id.label("from_job_id"),
-            core_query.c.to_job_id.label("to_job_id"),
-            core_query.c.type.label("type"),
-            literal(1).label("depth"),
-        ).where(core_query.c.from_job_id == any_(bindparam("job_ids")))
-
-        base_part_cte = base_part.cte(name="downstream_jobs_query", recursive=True)
-
-        recursive_part = (
-            select(
-                core_query.c.from_job_id.label("from_job_id"),
-                core_query.c.to_job_id.label("to_job_id"),
-                core_query.c.type.label("type"),
-                (base_part_cte.c.depth + literal(1)).label("depth"),
-            )
-            .join(
-                core_query,
-                core_query.c.from_job_id == base_part_cte.c.to_job_id,
-            )
-            .where(
-                base_part_cte.c.depth < bindparam("depth"),
-            )
-        )
-
-        return select(base_part_cte.union(recursive_part))

--- a/data_rentgen/server/services/job.py
+++ b/data_rentgen/server/services/job.py
@@ -125,15 +125,18 @@ class JobService:
         infer_from_lineage: bool = False,
         level: int = 0,
     ) -> JobHierarchyResult:
-        logger.info(
-            "Get jobs hierarchy with start at job with ids %s, direction %s, depth %s",
-            start_node_ids,
-            direction,
-            depth,
-        )
-
         if not start_node_ids:
             return JobHierarchyResult()
+
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(
+                "[Level %d] Get hierarchy by jobs %r, with direction %s, since %s, until %s",
+                level,
+                sorted(start_node_ids),
+                direction,
+                since,
+                until,
+            )
 
         # Add ancestors and descendants for current level
         ancestor_relations = await self._uow.job.list_ancestor_relations(start_node_ids)
@@ -154,7 +157,6 @@ class JobService:
                 await self._uow.job_dependency.get_dependencies(
                     job_ids=list(job_ids),
                     direction="UPSTREAM",
-                    depth=depth,
                     infer_from_lineage=infer_from_lineage,
                     since=since,
                     until=until,
@@ -166,12 +168,12 @@ class JobService:
                 await self._uow.job_dependency.get_dependencies(
                     job_ids=list(job_ids),
                     direction="DOWNSTREAM",
-                    depth=depth,
                     infer_from_lineage=infer_from_lineage,
                     since=since,
                     until=until,
                 )
             )
+
         result.dependencies.update(
             {(d.from_job_id, d.to_job_id, d.type) for d in upstream_dependecies}
             | {(d.from_job_id, d.to_job_id, d.type) for d in downstream_dependencies}
@@ -200,25 +202,35 @@ class JobService:
                     level=level + 1,
                 )
             )
-        else:
-            # Add parents for last dependencies
-            ids = {from_job_id for (from_job_id, _, _) in result.dependencies} | {
+
+        # After all recursive calls are merged
+        if level == 0:
+            # Add parents for all dependencies
+            dependency_job_ids = {from_job_id for (from_job_id, _, _) in result.dependencies} | {
                 to_job_id for (_, to_job_id, _) in result.dependencies
             }
-            result.parents.update(await self._uow.job.list_ancestor_relations(ids))
-            result.parents.update(await self._uow.job.list_descendant_relations(ids))
+            existing_parent_job_ids = {from_job_id for (from_job_id, _) in result.parents} | {
+                to_job_id for (_, to_job_id) in result.parents
+            }
+            fetch_parent_job_ids = dependency_job_ids - existing_parent_job_ids
+            result.parents.update(await self._uow.job.list_ancestor_relations(fetch_parent_job_ids))
+            result.parents.update(await self._uow.job.list_descendant_relations(fetch_parent_job_ids))
 
-        # Collect all job nodes once, after all recursive calls are merged.
-        if level == 0:
-            final_job_ids = (
+            # Collect all job nodes once
+            job_ids = (
                 start_node_ids
-                | {from_job_id for (from_job_id, _, _) in result.dependencies}
-                | {to_job_id for (_, to_job_id, _) in result.dependencies}
+                | dependency_job_ids
                 | {from_job_id for (from_job_id, _) in result.parents}
                 | {to_job_id for (_, to_job_id) in result.parents}
             )
-            result.jobs = [
-                JobServiceResult.from_orm(job) for job in await self._uow.job.list_by_ids(list(final_job_ids))
-            ]
+            result.jobs = [JobServiceResult.from_orm(job) for job in await self._uow.job.list_by_ids(job_ids)]
 
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(
+                "[Level %d] Found %d jobs, %d parents, %d dependencies",
+                level,
+                len(result.jobs),
+                len(result.parents),
+                len(result.dependencies),
+            )
         return result


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

We actually don't need recursive CTE anymore, as each depth level executes the same query with new input job_ids.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
