### PR TITLE
[DOP-37149] Add handling database VS schema for CH & MySQL

### DIFF
--- a/data_rentgen/consumer/extractors/generic/dataset.py
+++ b/data_rentgen/consumer/extractors/generic/dataset.py
@@ -24,6 +24,11 @@ from data_rentgen.openlineage.dataset_facets import (
 METASTORE = DatasetSymlinkTypeDTO.METASTORE
 WAREHOUSE = DatasetSymlinkTypeDTO.WAREHOUSE
 
+# https://github.com/OpenLineage/OpenLineage/issues/4496
+# https://github.com/OpenLineage/OpenLineage/issues/4497
+# Fixed in OpenLineage 1.47, but not all users upgraded their ETL scripts
+SCHEMALESS_LOCATION_TYPES = {"clickhouse", "mysql"}
+
 
 class DatasetExtractorMixin:
     def extract_dataset(self, dataset: OpenLineageDataset) -> DatasetDTO:
@@ -37,9 +42,13 @@ class DatasetExtractorMixin:
         self,
         dataset: OpenLineageDataset | OpenLineageColumnLineageDatasetFacetFieldRef | OpenLineageSymlinkIdentifier,
     ) -> DatasetDTO:
+        location = self._extract_dataset_location(dataset)
+        name = dataset.name
+        if location.type in SCHEMALESS_LOCATION_TYPES and name.count(".") == 2:  # noqa: PLR2004
+            name = name.split(".", maxsplit=1)[1]
         return DatasetDTO(
-            name=dataset.name,
-            location=self._extract_dataset_location(dataset),
+            name=name,
+            location=location,
         )
 
     def _extract_dataset_location(

--- a/data_rentgen/db/migrations/versions/2026-06-15_c3f8a2e1d749_fix_clickhouse_mysql_dataset_names.py
+++ b/data_rentgen/db/migrations/versions/2026-06-15_c3f8a2e1d749_fix_clickhouse_mysql_dataset_names.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: 2024-present MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+"""Fix ClickHouse/MySQL dataset names
+
+OpenLineage <1.47 incorrectly included the JDBC default database
+for ClickHouse and MySQL, producing 3-component names like
+``default.mydb.mytable`` instead of ``mydb.mytable``.
+
+https://github.com/OpenLineage/OpenLineage/issues/4494
+https://github.com/OpenLineage/OpenLineage/issues/4496
+https://github.com/OpenLineage/OpenLineage/issues/4497
+
+Revision ID: c3f8a2e1d749
+Revises: 947c82ba59ba
+Create Date: 2026-06-15 18:28:24.545123
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c3f8a2e1d749"
+down_revision = "947c82ba59ba"
+branch_labels = None
+depends_on = None
+
+SCHEMALESS_TYPES = ["clickhouse", "mysql"]
+
+
+def upgrade() -> None:
+    # Create a map old 3-component dataset id -> new 2-component dataset id
+    op.execute(sa.text("CREATE TEMP TABLE dataset_name_migration (old_id BIGINT, new_id BIGINT)"))
+
+    # Ensure 2-component dataset exists for each 3-component one
+    # The unique index ix__dataset__location_id__name_lower prevents duplicates
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO dataset (name, location_id)
+            SELECT DISTINCT
+                substring(d.name FROM position('.' IN d.name) + 1),
+                d.location_id
+            FROM dataset d
+            JOIN location l ON l.id = d.location_id
+            WHERE l.type = ANY(:types)
+              AND array_length(string_to_array(d.name, '.'), 1) = 3
+            ON CONFLICT DO NOTHING
+            """,
+        ).bindparams(sa.bindparam("types", value=SCHEMALESS_TYPES, type_=sa.ARRAY(sa.String()))),
+    )
+
+    # Fill mapping table
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO dataset_name_migration (old_id, new_id)
+            SELECT d_old.id, d_new.id
+            FROM dataset d_old
+            JOIN location l ON l.id = d_old.location_id
+            JOIN dataset d_new
+                ON d_new.location_id = d_old.location_id
+               AND lower(d_new.name) = lower(substring(d_old.name FROM position('.' IN d_old.name) + 1))
+               AND d_new.id <> d_old.id
+            WHERE l.type = ANY(:types)
+              AND array_length(string_to_array(d_old.name, '.'), 1) = 3
+            """,
+        ).bindparams(sa.bindparam("types", value=SCHEMALESS_TYPES, type_=sa.ARRAY(sa.String()))),
+    )
+
+    # Remap FK references to old datasets onto new datasets
+    op.execute(
+        sa.text(
+            """
+            UPDATE input i
+            SET dataset_id = dm.new_id
+            FROM dataset_name_migration dm
+            WHERE i.dataset_id = dm.old_id
+            """,
+        ),
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE output o
+            SET dataset_id = dm.new_id
+            FROM dataset_name_migration dm
+            WHERE o.dataset_id = dm.old_id
+            """,
+        ),
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE column_lineage cl
+            SET source_dataset_id = dm.new_id
+            FROM dataset_name_migration dm
+            WHERE cl.source_dataset_id = dm.old_id
+            """,
+        ),
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE column_lineage cl
+            SET target_dataset_id = dm.new_id
+            FROM dataset_name_migration dm
+            WHERE cl.target_dataset_id = dm.old_id
+            """,
+        ),
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE dataset_symlink ds
+            SET from_dataset_id = dm.new_id
+            FROM dataset_name_migration dm
+            WHERE ds.from_dataset_id = dm.old_id
+            """,
+        ),
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE dataset_symlink ds
+            SET to_dataset_id = dm.new_id
+            FROM dataset_name_migration dm
+            WHERE ds.to_dataset_id = dm.old_id
+            """,
+        ),
+    )
+    # dataset_tag_value has a composite PK (dataset_id, tag_value_id);
+    # insert new rows first, then delete the old ones.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO dataset_tag_value (dataset_id, tag_value_id)
+            SELECT dm.new_id, dtv.tag_value_id
+            FROM dataset_tag_value dtv
+            JOIN dataset_name_migration dm ON dm.old_id = dtv.dataset_id
+            ON CONFLICT DO NOTHING
+            """,
+        ),
+    )
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM dataset_tag_value
+            WHERE dataset_id IN (SELECT old_id FROM dataset_name_migration)
+            """,
+        ),
+    )
+
+    # Delete old 3-component datasets
+    # Since we remapped all references, ON DELETE CASCADE won't hurt
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM dataset
+            WHERE id IN (SELECT old_id FROM dataset_name_migration)
+            """,
+        ),
+    )
+
+
+def downgrade() -> None:
+    # This migration is irreversible
+    pass

--- a/docs/changelog/next_release/463.feature.rst
+++ b/docs/changelog/next_release/463.feature.rst
@@ -1,0 +1,1 @@
+Add handling database VS schema for ClickHouse & MySQL

--- a/tests/test_consumer/test_extractors/test_extractors_dataset.py
+++ b/tests/test_consumer/test_extractors/test_extractors_dataset.py
@@ -215,6 +215,62 @@ def test_extractors_extract_dataset_postgres():
     assert symlinks_dto == []
 
 
+def test_extractors_extract_dataset_clickhouse_three_components():
+    # OpenLineage <1.47 incorrectly included the JDBC default DB
+    dataset = OpenLineageDataset(
+        namespace="clickhouse://myhost:8123",
+        name="default.mydb.mytable",
+    )
+
+    dataset_dto, symlinks_dto = GenericExtractor().extract_dataset_and_symlinks(dataset)
+    assert dataset_dto == DatasetDTO(
+        location=LocationDTO(
+            type="clickhouse",
+            name="myhost:8123",
+            addresses={"clickhouse://myhost:8123"},
+        ),
+        name="mydb.mytable",
+    )
+    assert symlinks_dto == []
+
+
+def test_extractors_extract_dataset_clickhouse_two_components():
+    dataset = OpenLineageDataset(
+        namespace="clickhouse://myhost:8123",
+        name="mydb.mytable",
+    )
+
+    dataset_dto, symlinks_dto = GenericExtractor().extract_dataset_and_symlinks(dataset)
+    assert dataset_dto == DatasetDTO(
+        location=LocationDTO(
+            type="clickhouse",
+            name="myhost:8123",
+            addresses={"clickhouse://myhost:8123"},
+        ),
+        name="mydb.mytable",
+    )
+    assert symlinks_dto == []
+
+
+def test_extractors_extract_dataset_mysql_three_components():
+    # OpenLineage <1.47 incorrectly included the JDBC default DB
+    dataset = OpenLineageDataset(
+        namespace="mysql://myhost:3306",
+        name="mydb.mydb.mytable",
+    )
+
+    dataset_dto, symlinks_dto = GenericExtractor().extract_dataset_and_symlinks(dataset)
+    assert dataset_dto == DatasetDTO(
+        location=LocationDTO(
+            type="mysql",
+            name="myhost:3306",
+            addresses={"mysql://myhost:3306"},
+        ),
+        name="mydb.mytable",
+    )
+    assert symlinks_dto == []
+
+
 def test_extractors_extract_dataset_kafka():
     dataset = OpenLineageDataset(
         namespace="kafka://192.168.1.1:9092,192.168.1.2:9092",

--- a/tests/test_consumer/test_handlers/test_runs_handler_spark.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_spark.py
@@ -155,7 +155,7 @@ async def test_runs_handler_spark(
     hive_table = datasets[1]
     clickhouse_table = datasets[2]
 
-    assert clickhouse_table.name == "mydb.myschema.mytable"
+    assert clickhouse_table.name == "myschema.mytable"
     assert clickhouse_table.location.type == "clickhouse"
     assert clickhouse_table.location.name == "localhost:8123"
     assert len(clickhouse_table.location.addresses) == 1

--- a/tests/test_consumer/test_handlers/test_runs_handler_unknown.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_unknown.py
@@ -140,7 +140,7 @@ async def test_runs_handler_unknown(
     hive_table = datasets[0]
     clickhouse_table = datasets[1]
 
-    assert clickhouse_table.name == "mydb.myschema.mytable"
+    assert clickhouse_table.name == "myschema.mytable"
     assert clickhouse_table.location.type == "clickhouse"
     assert clickhouse_table.location.name == "localhost:8123"
     assert len(clickhouse_table.location.addresses) == 1

--- a/tests/test_database/test_migration_fix_clickhouse_mysql_dataset_names.py
+++ b/tests/test_database/test_migration_fix_clickhouse_mysql_dataset_names.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2024-present MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
+
+from data_rentgen.db.models import Base
+from tests.test_database.fixtures.alembic import do_run_migrations
+
+if TYPE_CHECKING:
+    from alembic.config import Config as AlembicConfig
+
+pytestmark = [pytest.mark.db]
+
+PREV_REVISION = "947c82ba59ba"
+THIS_REVISION = "c3f8a2e1d749"
+
+
+def test_migration_fix_clickhouse_mysql_dataset_names(empty_db_url: str, alembic_config: AlembicConfig):
+    do_run_migrations(alembic_config, Base.metadata, PREV_REVISION)
+
+    engine = create_engine(empty_db_url, poolclass=NullPool)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO location (id, type, name) VALUES
+                        (1, 'clickhouse', 'myhost:8123'),
+                        (2, 'mysql', 'myhost:3306')
+                    """,
+                ),
+            )
+
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO dataset (id, location_id, name) VALUES
+                        (10, 1, 'default.mydb.mytable'),
+                        (11, 2, 'mydb.mydb.mytable'),
+
+                        (12, 1, 'default.mydb.collision'),
+                        (13, 1, 'mydb.collision')
+                    """,
+                ),
+            )
+
+        do_run_migrations(alembic_config, Base.metadata, THIS_REVISION)
+
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text("SELECT location_id, name FROM dataset ORDER BY location_id, name"),
+            ).fetchall()
+
+        names_by_location = defaultdict(list)
+        for location_id, name in rows:
+            names_by_location[location_id].append(name)
+
+        assert names_by_location == {1: ["mydb.collision", "mydb.mytable"], 2: ["mydb.mytable"]}
+
+    finally:
+        engine.dispose()

--- a/tests/test_server/test_hierarchy/test_job_hierarchy.py
+++ b/tests/test_server/test_hierarchy/test_job_hierarchy.py
@@ -375,7 +375,9 @@ async def test_get_job_hierarchy_with_inferred_dependencies(
     )
 
     assert response.status_code == HTTPStatus.OK, response.json()
-    assert response.json() == {
+    response_json = response.json()
+    response_json["relations"]["parents"].sort(key=lambda x: (x["from"]["id"], x["to"]["id"]))
+    assert response_json == {
         "relations": {
             "parents": jobs_ancestors_to_json(expected_nodes),
             "dependencies": [


### PR DESCRIPTION
## Change Summary

OpenLineage < 1.47 incorrectly includes the default database as a schema component when generating dataset names for ClickHouse and MySQL, even though these databases only support the `database.table` naming model.

For example, with:

`jdbcUrl=jdbc:clickhouse://myhost:8123/default`
`SELECT * FROM mydb.mytable`

OpenLineage produces the dataset name `default.mydb.mytable` instead of the correct `mydb.mytable`.

Since many users are still running different versions, added a compatibility layer that detects corresponding datasets and removes the first component if name consists of three.

Added a migration that updates existing dataset names to the new format.

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
