### PR TITLE
[DOP-37944] Do not merge different jobs

### DIFF
--- a/data_rentgen/consumer/extractors/batch_extraction_result.py
+++ b/data_rentgen/consumer/extractors/batch_extraction_result.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from typing import TypeVar
 
 from data_rentgen.dto import (
+    DTO,
     ColumnLineageDTO,
     DatasetDTO,
     DatasetSymlinkDTO,
@@ -24,25 +25,7 @@ from data_rentgen.dto import (
     UserDTO,
 )
 
-T = TypeVar(
-    "T",
-    ColumnLineageDTO,
-    DatasetDTO,
-    DatasetSymlinkDTO,
-    InputDTO,
-    JobDependencyDTO,
-    JobDTO,
-    JobTypeDTO,
-    LocationDTO,
-    OperationDTO,
-    OutputDTO,
-    RunDTO,
-    SchemaDTO,
-    SQLQueryDTO,
-    TagDTO,
-    TagValueDTO,
-    UserDTO,
-)
+T = TypeVar("T", bound=DTO)
 
 
 class BatchExtractionResult:
@@ -106,17 +89,18 @@ class BatchExtractionResult:
     @staticmethod
     def _add(context: dict[tuple, T], new_item: T) -> T:
         key = new_item.unique_key
-        if key in context:
-            old_item = context[key]
-            if old_item is new_item:
-                return old_item
+        old_item = context.get(key)
+        if not old_item:
+            context[key] = new_item
+            return new_item
 
-            merged_item = old_item.merge(new_item)
-            context[key] = merged_item
-            return merged_item
+        if old_item is new_item:
+            # optimization
+            return old_item
 
-        context[key] = new_item
-        return new_item
+        merged_item = old_item.merge(new_item)
+        context[key] = merged_item
+        return merged_item
 
     def add_location(self, location: LocationDTO):
         return self._add(self._locations, location)

--- a/data_rentgen/dto/__init__.py
+++ b/data_rentgen/dto/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024-present MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
+from data_rentgen.dto.base import DTO
 from data_rentgen.dto.column_lineage import ColumnLineageDTO
 from data_rentgen.dto.dataset import DatasetDTO
 from data_rentgen.dto.dataset_column_relation import (
@@ -27,6 +28,7 @@ from data_rentgen.dto.tag import TagDTO, TagValueDTO
 from data_rentgen.dto.user import UserDTO
 
 __all__ = [
+    "DTO",
     "ColumnLineageDTO",
     "DatasetColumnRelationDTO",
     "DatasetColumnRelationTypeDTO",

--- a/data_rentgen/dto/base.py
+++ b/data_rentgen/dto/base.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025-present MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Protocol, Self
+
+
+class DTO(Protocol):
+    @property
+    def unique_key(self) -> tuple:
+        """Expected to return the same value for the same DTO object"""
+        ...
+
+    def merge(self, new: Self) -> Self:
+        """
+        Expected to update existing object with data from new object
+        (from different point in time).
+
+        unique_key should be exactly the same!
+        """
+        ...

--- a/data_rentgen/dto/input.py
+++ b/data_rentgen/dto/input.py
@@ -45,10 +45,11 @@ class InputDTO:
         self.operation.merge(new.operation)
         self.dataset.merge(new.dataset)
 
-        if self.schema and new.schema:
-            self.schema.merge(new.schema)
-        else:
-            self.schema = new.schema or self.schema
+        if new.schema:
+            if self.schema:
+                self.schema.merge(new.schema)
+            else:
+                self.schema = new.schema
 
         self.created_at = min([new.created_at, self.created_at])
         self.num_rows = max(filter(None, [new.num_rows, self.num_rows]), default=None)

--- a/data_rentgen/dto/job.py
+++ b/data_rentgen/dto/job.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from copy import copy
 from dataclasses import dataclass, field
 
 from data_rentgen.dto.job_type import JobTypeDTO
@@ -26,23 +25,20 @@ class JobDTO:
 
     def merge(self, new: JobDTO) -> JobDTO:
         self.id = new.id or self.id
-        self.location = self.location.merge(new.location)
-        if new.parent_job and self.parent_job:
-            self.parent_job = self.parent_job.merge(new.parent_job)
-        else:
-            self.parent_job = new.parent_job or self.parent_job
+        self.location.merge(new.location)
 
-        if new.type and self.type:
-            self.type = self.type.merge(new.type)
-        else:
-            self.type = new.type or self.type
+        # Workaround for https://github.com/OpenLineage/OpenLineage/issues/3846
+        if new.parent_job:
+            if self.parent_job and self.parent_job.unique_key == new.parent_job.unique_key:
+                self.parent_job.merge(new.parent_job)
+            else:
+                self.parent_job = new.parent_job
+
+        if new.type:
+            if self.type and self.type.unique_key == new.type.unique_key:
+                self.type.merge(new.type)
+            else:
+                self.type = new.type
 
         self.tag_values.update(new.tag_values)
-
-        if self.name == "unknown" and new.name != "unknown":
-            # Workaround for https://github.com/OpenLineage/OpenLineage/issues/3846
-            result = copy(self)
-            result.name = new.name
-            return result
-
         return self

--- a/data_rentgen/dto/job_dependency.py
+++ b/data_rentgen/dto/job_dependency.py
@@ -20,7 +20,7 @@ class JobDependencyDTO:
         return (self.from_job.unique_key, self.to_job.unique_key, self.type)
 
     def merge(self, new: JobDependencyDTO) -> JobDependencyDTO:
-        self.from_job = self.from_job.merge(new.from_job)
-        self.to_job = self.to_job.merge(new.to_job)
+        self.from_job.merge(new.from_job)
+        self.to_job.merge(new.to_job)
         self.id = new.id or self.id
         return self

--- a/data_rentgen/dto/job_type.py
+++ b/data_rentgen/dto/job_type.py
@@ -16,6 +16,5 @@ class JobTypeDTO:
         return (self.type,)
 
     def merge(self, new: JobTypeDTO) -> JobTypeDTO:
-        self.type = new.type
         self.id = new.id or self.id
         return self

--- a/data_rentgen/dto/operation.py
+++ b/data_rentgen/dto/operation.py
@@ -58,11 +58,12 @@ class OperationDTO:
         return (self.id,)
 
     def merge(self, new: OperationDTO) -> OperationDTO:
-        self.run = self.run.merge(new.run)
-        if self.sql_query and new.sql_query:
-            self.sql_query = self.sql_query.merge(new.sql_query)
-        else:
-            self.sql_query = new.sql_query or self.sql_query
+        self.run.merge(new.run)
+        if new.sql_query:
+            if self.sql_query:
+                self.sql_query.merge(new.sql_query)
+            else:
+                self.sql_query = new.sql_query
 
         self.name = new.name or self.name
         self.type = new.type or self.type

--- a/data_rentgen/dto/output.py
+++ b/data_rentgen/dto/output.py
@@ -63,13 +63,14 @@ class OutputDTO:
         return generate_incremental_uuid(self.created_at, ".".join(id_components))
 
     def merge(self, new: OutputDTO) -> OutputDTO:
-        self.operation = self.operation.merge(new.operation)
-        self.dataset = self.dataset.merge(new.dataset)
+        self.operation.merge(new.operation)
+        self.dataset.merge(new.dataset)
 
-        if self.schema and new.schema:
-            self.schema = self.schema.merge(new.schema)
-        else:
-            self.schema = new.schema or self.schema
+        if new.schema:
+            if self.schema:
+                self.schema.merge(new.schema)
+            else:
+                self.schema = new.schema
 
         if not new.type.value & self.type.value:
             # IntFlag.__or__ is slow, avoid calling it if not needed

--- a/data_rentgen/dto/run.py
+++ b/data_rentgen/dto/run.py
@@ -57,22 +57,32 @@ class RunDTO:
         return (self.id,)
 
     def merge(self, new: RunDTO) -> RunDTO:
-        self.job = self.job.merge(new.job)
-        if new.parent_run and self.parent_run:
-            self.parent_run = self.parent_run.merge(new.parent_run)
+        if new.job.unique_key == self.job.unique_key:
+            self.job.merge(new.job)
         else:
-            self.parent_run = new.parent_run or self.parent_run
+            # Workaround for https://github.com/OpenLineage/OpenLineage/issues/3846
+            self.job = new.job
 
-        if new.user and self.user:
-            self.user = self.user.merge(new.user)
-        else:
-            self.user = new.user or self.user
+        if new.parent_run:
+            if self.parent_run:
+                self.parent_run.merge(new.parent_run)
+                self.job.parent_job = self.parent_run.job
+            else:
+                self.parent_run = new.parent_run
+                self.job.parent_job = new.parent_run.job
+
+        if new.user:
+            if self.user:
+                self.user.merge(new.user)
+            else:
+                self.user = new.user
 
         existing_dependencies = {item.unique_key: item for item in self.job_dependencies}
         merged_dependencies = []
         for job_dependency in new.job_dependencies:
-            if job_dependency.unique_key in existing_dependencies:
-                merged_dependencies.append(existing_dependencies[job_dependency.unique_key].merge(job_dependency))
+            old_job_dependency = existing_dependencies.get(job_dependency.unique_key)
+            if old_job_dependency:
+                merged_dependencies.append(old_job_dependency.merge(job_dependency))
             else:
                 merged_dependencies.append(job_dependency)
         self.job_dependencies = merged_dependencies

--- a/docs/changelog/next_release/473.bugfix.rst
+++ b/docs/changelog/next_release/473.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed workaround for `OpenLineage issue #3846<https://github.com/OpenLineage/OpenLineage/issues/3846>`_ -
+previously DataRentgen may merge different jobs into one if they were a parent of Spark ``unknown`` app job.

--- a/tests/test_consumer/test_extractors/fixtures/airflow_dto.py
+++ b/tests/test_consumer/test_extractors/fixtures/airflow_dto.py
@@ -55,11 +55,11 @@ def extracted_airflow_dag_job(
 
 
 @pytest.fixture
-def extracted_airflow_task_job(
+def extracted_airflow_task1_job(
     extracted_airflow_location: LocationDTO,
 ) -> JobDTO:
     return JobDTO(
-        name="mydag.mytask",
+        name="mydag.mytask1",
         location=extracted_airflow_location,
         type=JobTypeDTO(type="AIRFLOW_TASK"),
         tag_values={
@@ -72,6 +72,16 @@ def extracted_airflow_task_job(
                 value="1.10.0",
             ),
         },
+    )
+
+
+@pytest.fixture
+def extracted_airflow_task1_job_as_parent(
+    extracted_airflow_location: LocationDTO,
+) -> JobDTO:
+    return JobDTO(
+        name="mydag.mytask1",
+        location=extracted_airflow_location,
     )
 
 
@@ -96,12 +106,12 @@ def extracted_airflow_dag_run(
 
 
 @pytest.fixture
-def extracted_airflow_task_run(
-    extracted_airflow_task_job: JobDTO,
+def extracted_airflow_task1_run(
+    extracted_airflow_task1_job: JobDTO,
 ) -> RunDTO:
     return RunDTO(
         id=UUID("01908223-0782-7fc0-9d69-b1df9dac2c60"),
-        job=extracted_airflow_task_job,
+        job=extracted_airflow_task1_job,
         status=RunStatusDTO.SUCCEEDED,
         started_at=datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc),
         start_reason=RunStartReasonDTO.MANUAL,
@@ -119,14 +129,24 @@ def extracted_airflow_task_run(
 
 
 @pytest.fixture
-def extracted_airflow_task_operation(
-    extracted_airflow_task_run: RunDTO,
+def extracted_airflow_task1_run_as_parent(
+    extracted_airflow_task1_job_as_parent: JobDTO,
+) -> RunDTO:
+    return RunDTO(
+        id=UUID("01908223-0782-7fc0-9d69-b1df9dac2c60"),
+        job=extracted_airflow_task1_job_as_parent,
+    )
+
+
+@pytest.fixture
+def extracted_airflow_task1_operation(
+    extracted_airflow_task1_run: RunDTO,
 ) -> OperationDTO:
     return OperationDTO(
         id=UUID("01908223-0782-7fc0-9d69-b1df9dac2c60"),
         name="mytask",
         description="BashOperator",
-        run=extracted_airflow_task_run,
+        run=extracted_airflow_task1_run,
         status=OperationStatusDTO.SUCCEEDED,
         type=OperationTypeDTO.BATCH,
         started_at=datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc),
@@ -136,13 +156,13 @@ def extracted_airflow_task_operation(
 
 @pytest.fixture
 def extracted_airflow_postgres_input(
-    extracted_airflow_task_operation: OperationDTO,
+    extracted_airflow_task1_operation: OperationDTO,
     extracted_postgres_dataset: DatasetDTO,
     extracted_dataset_schema: SchemaDTO,
 ) -> InputDTO:
     return InputDTO(
-        created_at=extracted_airflow_task_operation.created_at,
-        operation=extracted_airflow_task_operation,
+        created_at=extracted_airflow_task1_operation.created_at,
+        operation=extracted_airflow_task1_operation,
         dataset=extracted_postgres_dataset,
         schema=extracted_dataset_schema,
     )
@@ -150,16 +170,45 @@ def extracted_airflow_postgres_input(
 
 @pytest.fixture
 def extracted_airflow_hdfs_output(
-    extracted_airflow_task_operation: OperationDTO,
+    extracted_airflow_task1_operation: OperationDTO,
     extracted_hdfs_dataset1: DatasetDTO,
     extracted_dataset_schema: SchemaDTO,
 ) -> OutputDTO:
     return OutputDTO(
-        created_at=extracted_airflow_task_operation.created_at,
+        created_at=extracted_airflow_task1_operation.created_at,
         type=OutputTypeDTO.CREATE,
-        operation=extracted_airflow_task_operation,
+        operation=extracted_airflow_task1_operation,
         dataset=extracted_hdfs_dataset1,
         schema=extracted_dataset_schema,
         num_rows=1_000_000,
         num_bytes=1000 * 1024 * 1024,
+    )
+
+
+@pytest.fixture
+def extracted_another_airflow_location() -> LocationDTO:
+    return LocationDTO(
+        type="http",
+        name="another-airflow-host:8081",
+        addresses={"http://another-airflow-host:8081"},
+    )
+
+
+@pytest.fixture
+def extracted_airflow_task2_job(
+    extracted_another_airflow_location: LocationDTO,
+) -> JobDTO:
+    return JobDTO(
+        name="mydag.mytask2",
+        location=extracted_another_airflow_location,
+    )
+
+
+@pytest.fixture
+def extracted_airflow_task2_run(
+    extracted_airflow_task2_job: JobDTO,
+) -> RunDTO:
+    return RunDTO(
+        id=UUID("01908222-243b-7df2-a7ce-774296a65c3b"),
+        job=extracted_airflow_task2_job,
     )

--- a/tests/test_consumer/test_extractors/fixtures/airflow_raw.py
+++ b/tests/test_consumer/test_extractors/fixtures/airflow_raw.py
@@ -100,7 +100,7 @@ def airflow_dag_run_event_stop() -> OpenLineageRunEvent:
 
 
 @pytest.fixture
-def airflow_task_run_event_start() -> OpenLineageRunEvent:
+def airflow_task1_run_event_start() -> OpenLineageRunEvent:
     event_time = datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc)
     run_id = UUID("01908223-0782-7fc0-9d69-b1df9dac2c60")
     return OpenLineageRunEvent(
@@ -108,7 +108,7 @@ def airflow_task_run_event_start() -> OpenLineageRunEvent:
         eventTime=event_time,
         job=OpenLineageJob(
             namespace="http://airflow-host:8081",
-            name="mydag.mytask",
+            name="mydag.mytask1",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
                     processingType=OpenLineageJobProcessingType.BATCH,
@@ -150,7 +150,7 @@ def airflow_task_run_event_start() -> OpenLineageRunEvent:
 
 
 @pytest.fixture
-def airflow_task_run_event_stop() -> OpenLineageRunEvent:
+def airflow_task1_run_event_stop() -> OpenLineageRunEvent:
     event_time = datetime(2024, 7, 5, 9, 4, 13, 979349, tzinfo=timezone.utc)
     run_id = UUID("01908223-0782-7fc0-9d69-b1df9dac2c60")
     return OpenLineageRunEvent(
@@ -158,7 +158,7 @@ def airflow_task_run_event_stop() -> OpenLineageRunEvent:
         eventTime=event_time,
         job=OpenLineageJob(
             namespace="http://airflow-host:8081",
-            name="mydag.mytask",
+            name="mydag.mytask1",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
                     processingType=OpenLineageJobProcessingType.BATCH,

--- a/tests/test_consumer/test_extractors/fixtures/column_lineage_raw.py
+++ b/tests/test_consumer/test_extractors/fixtures/column_lineage_raw.py
@@ -335,7 +335,7 @@ def get_run_event_with_column_lineage(
         eventTime=event_time,
         job=OpenLineageJob(
             namespace="local://some.host.com",
-            name="mysession.execute_some_command",
+            name="mysession1.execute_some_command",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
                     processingType=OpenLineageJobProcessingType.BATCH,
@@ -350,7 +350,7 @@ def get_run_event_with_column_lineage(
                 parent=OpenLineageParentRunFacet(
                     job=OpenLineageParentJob(
                         namespace="local://some.host.com",
-                        name="mysession",
+                        name="mysession1",
                     ),
                     run=OpenLineageParentRun(
                         runId=run_id,

--- a/tests/test_consumer/test_extractors/fixtures/spark_dto.py
+++ b/tests/test_consumer/test_extractors/fixtures/spark_dto.py
@@ -35,9 +35,46 @@ def extracted_spark_app_job(
     extracted_spark_location: LocationDTO,
 ) -> JobDTO:
     return JobDTO(
-        name="mysession",
+        name="mysession1",
         location=extracted_spark_location,
         type=JobTypeDTO(type="SPARK_APPLICATION"),
+    )
+
+
+@pytest.fixture
+def extracted_spark_app_job_with_parent(
+    extracted_spark_location: LocationDTO,
+    extracted_airflow_task1_job_as_parent: JobDTO,
+) -> JobDTO:
+    return JobDTO(
+        name="mysession1",
+        location=extracted_spark_location,
+        type=JobTypeDTO(type="SPARK_APPLICATION"),
+        parent_job=extracted_airflow_task1_job_as_parent,
+    )
+
+
+@pytest.fixture
+def extracted_spark_another_app_job(
+    extracted_spark_location: LocationDTO,
+) -> JobDTO:
+    return JobDTO(
+        name="mysession2",
+        location=extracted_spark_location,
+        type=JobTypeDTO(type="SPARK_APPLICATION"),
+    )
+
+
+@pytest.fixture
+def extracted_spark_another_app_job_with_parent(
+    extracted_spark_location: LocationDTO,
+    extracted_airflow_task2_job: JobDTO,
+) -> JobDTO:
+    return JobDTO(
+        name="mysession2",
+        location=extracted_spark_location,
+        type=JobTypeDTO(type="SPARK_APPLICATION"),
+        parent_job=extracted_airflow_task2_job,
     )
 
 
@@ -70,6 +107,40 @@ def extracted_spark_app_run(
 
 
 @pytest.fixture
+def extracted_spark_app_run_with_parent(
+    extracted_spark_app_job_with_parent: JobDTO,
+    extracted_airflow_task1_run_as_parent: RunDTO,
+    extracted_user: UserDTO,
+) -> RunDTO:
+    return RunDTO(
+        id=UUID("01908224-8410-79a2-8de6-a769ad6944c9"),
+        job=extracted_spark_app_job_with_parent,
+        user=extracted_user,
+        status=RunStatusDTO.SUCCEEDED,
+        parent_run=extracted_airflow_task1_run_as_parent,
+        started_at=datetime(2024, 7, 5, 9, 4, 48, 794900, tzinfo=timezone.utc),
+        ended_at=datetime(2024, 7, 5, 9, 7, 15, 646000, tzinfo=timezone.utc),
+        external_id="local-1719136537510",
+        running_log_url="http://127.0.0.1:4040",
+    )
+
+
+@pytest.fixture
+def extracted_spark_another_app_run_with_parent(
+    extracted_spark_another_app_job_with_parent: JobDTO,
+    extracted_airflow_task2_run: RunDTO,
+) -> RunDTO:
+    return RunDTO(
+        id=UUID("01908222-84bb-7fdf-ac0b-36892235c3db"),
+        job=extracted_spark_another_app_job_with_parent,
+        status=RunStatusDTO.SUCCEEDED,
+        parent_run=extracted_airflow_task2_run,
+        started_at=datetime(2024, 7, 5, 9, 3, 38, 683800, tzinfo=timezone.utc),
+        ended_at=datetime(2024, 7, 5, 9, 6, 15, 646000, tzinfo=timezone.utc),
+    )
+
+
+@pytest.fixture
 def extracted_spark_operation(
     extracted_spark_app_run: RunDTO,
 ):
@@ -77,6 +148,21 @@ def extracted_spark_operation(
         id=UUID("01908225-1fd7-746b-910c-70d24f2898b1"),
         name="execute_some_command",
         run=extracted_spark_app_run,
+        status=OperationStatusDTO.SUCCEEDED,
+        type=OperationTypeDTO.BATCH,
+        started_at=datetime(2024, 7, 5, 9, 6, 29, 462000, tzinfo=timezone.utc),
+        ended_at=datetime(2024, 7, 5, 9, 7, 15, 642000, tzinfo=timezone.utc),
+    )
+
+
+@pytest.fixture
+def extracted_spark_operation_with_parent(
+    extracted_spark_app_run_with_parent: RunDTO,
+):
+    return OperationDTO(
+        id=UUID("01908225-1fd7-746b-910c-70d24f2898b1"),
+        name="execute_some_command",
+        run=extracted_spark_app_run_with_parent,
         status=OperationStatusDTO.SUCCEEDED,
         type=OperationTypeDTO.BATCH,
         started_at=datetime(2024, 7, 5, 9, 6, 29, 462000, tzinfo=timezone.utc),
@@ -121,7 +207,7 @@ def get_spark_operation_dto(operation_id: UUID) -> OperationDTO:
         run=RunDTO(
             id=UUID("01908224-8410-79a2-8de6-a769ad6944c9"),
             job=JobDTO(
-                name="mysession",
+                name="mysession1",
                 location=LocationDTO(
                     type="local",
                     name="some.host.com",

--- a/tests/test_consumer/test_extractors/fixtures/spark_raw.py
+++ b/tests/test_consumer/test_extractors/fixtures/spark_raw.py
@@ -165,7 +165,7 @@ def spark_app_run_event_start() -> OpenLineageRunEvent:
         eventTime=event_time,
         job=OpenLineageJob(
             namespace="local://some.host.com",
-            name="mysession",
+            name="mysession1",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
                     processingType=OpenLineageJobProcessingType.NONE,
@@ -214,6 +214,72 @@ def spark_app_run_event_start_with_unknown_name() -> OpenLineageRunEvent:
 
 
 @pytest.fixture
+def spark_app_run_event_start_with_unknown_name_and_parent() -> OpenLineageRunEvent:
+    event_time = datetime(2024, 7, 5, 9, 4, 48, 794900, tzinfo=timezone.utc)
+    run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
+    return OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.START,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="local://some.host.com",
+            name="unknown",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    processingType=OpenLineageJobProcessingType.NONE,
+                    integration="SPARK",
+                    jobType="APPLICATION",
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=run_id,
+            facets=OpenLineageRunFacets(
+                parent=OpenLineageParentRunFacet(
+                    job=OpenLineageParentJob(
+                        namespace="http://airflow-host:8081",
+                        name="mydag.mytask1",
+                    ),
+                    run=OpenLineageParentRun(runId=UUID("01908223-0782-7fc0-9d69-b1df9dac2c60")),
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def spark_another_app_run_event_start_with_unknown_name_and_different_parent() -> OpenLineageRunEvent:
+    event_time = datetime(2024, 7, 5, 9, 3, 38, 683800, tzinfo=timezone.utc)
+    run_id = UUID("01908222-84bb-7fdf-ac0b-36892235c3db")
+    return OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.START,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="local://some.host.com",
+            name="unknown",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    processingType=OpenLineageJobProcessingType.NONE,
+                    integration="SPARK",
+                    jobType="APPLICATION",
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=run_id,
+            facets=OpenLineageRunFacets(
+                parent=OpenLineageParentRunFacet(
+                    job=OpenLineageParentJob(
+                        namespace="http://another-airflow-host:8081",
+                        name="mydag.mytask2",
+                    ),
+                    run=OpenLineageParentRun(runId=UUID("01908222-243b-7df2-a7ce-774296a65c3b")),
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
 def spark_app_run_event_stop() -> OpenLineageRunEvent:
     event_time = datetime(2024, 7, 5, 9, 7, 15, 646000, tzinfo=timezone.utc)
     run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
@@ -222,7 +288,7 @@ def spark_app_run_event_stop() -> OpenLineageRunEvent:
         eventTime=event_time,
         job=OpenLineageJob(
             namespace="local://some.host.com",
-            name="mysession",
+            name="mysession1",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
                     processingType=OpenLineageJobProcessingType.NONE,
@@ -236,6 +302,72 @@ def spark_app_run_event_stop() -> OpenLineageRunEvent:
 
 
 @pytest.fixture
+def spark_app_run_event_stop_with_parent() -> OpenLineageRunEvent:
+    event_time = datetime(2024, 7, 5, 9, 7, 15, 646000, tzinfo=timezone.utc)
+    run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
+    return OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.COMPLETE,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="local://some.host.com",
+            name="mysession1",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    processingType=OpenLineageJobProcessingType.NONE,
+                    integration="SPARK",
+                    jobType="APPLICATION",
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=run_id,
+            facets=OpenLineageRunFacets(
+                parent=OpenLineageParentRunFacet(
+                    job=OpenLineageParentJob(
+                        namespace="http://airflow-host:8081",
+                        name="mydag.mytask1",
+                    ),
+                    run=OpenLineageParentRun(runId=UUID("01908223-0782-7fc0-9d69-b1df9dac2c60")),
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def spark_another_app_run_event_stop_with_another_parent() -> OpenLineageRunEvent:
+    event_time = datetime(2024, 7, 5, 9, 6, 15, 646000, tzinfo=timezone.utc)
+    run_id = UUID("01908222-84bb-7fdf-ac0b-36892235c3db")
+    return OpenLineageRunEvent(
+        eventType=OpenLineageRunEventType.COMPLETE,
+        eventTime=event_time,
+        job=OpenLineageJob(
+            namespace="local://some.host.com",
+            name="mysession2",
+            facets=OpenLineageJobFacets(
+                jobType=OpenLineageJobTypeJobFacet(
+                    processingType=OpenLineageJobProcessingType.NONE,
+                    integration="SPARK",
+                    jobType="APPLICATION",
+                ),
+            ),
+        ),
+        run=OpenLineageRun(
+            runId=run_id,
+            facets=OpenLineageRunFacets(
+                parent=OpenLineageParentRunFacet(
+                    job=OpenLineageParentJob(
+                        namespace="http://another-airflow-host:8081",
+                        name="mydag.mytask2",
+                    ),
+                    run=OpenLineageParentRun(runId=UUID("01908222-243b-7df2-a7ce-774296a65c3b")),
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
 def spark_operation_run_event_start() -> OpenLineageRunEvent:
     event_time = datetime(2024, 7, 5, 9, 6, 29, 462000, tzinfo=timezone.utc)
     run_id = UUID("01908224-8410-79a2-8de6-a769ad6944c9")
@@ -245,7 +377,7 @@ def spark_operation_run_event_start() -> OpenLineageRunEvent:
         eventTime=event_time,
         job=OpenLineageJob(
             namespace="local://some.host.com",
-            name="mysession.execute_some_command",
+            name="mysession1.execute_some_command",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
                     processingType=OpenLineageJobProcessingType.BATCH,
@@ -260,7 +392,7 @@ def spark_operation_run_event_start() -> OpenLineageRunEvent:
                 parent=OpenLineageParentRunFacet(
                     job=OpenLineageParentJob(
                         namespace="local://some.host.com",
-                        name="mysession",
+                        name="mysession1",
                     ),
                     run=OpenLineageParentRun(
                         runId=run_id,
@@ -290,7 +422,7 @@ def spark_operation_run_event_running() -> OpenLineageRunEvent:
         eventTime=event_time,
         job=OpenLineageJob(
             namespace="local://some.host.com",
-            name="mysession.execute_some_command",
+            name="mysession1.execute_some_command",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
                     processingType=OpenLineageJobProcessingType.BATCH,
@@ -305,7 +437,7 @@ def spark_operation_run_event_running() -> OpenLineageRunEvent:
                 parent=OpenLineageParentRunFacet(
                     job=OpenLineageParentJob(
                         namespace="local://some.host.com",
-                        name="mysession",
+                        name="mysession1",
                     ),
                     run=OpenLineageParentRun(
                         runId=run_id,
@@ -335,7 +467,7 @@ def spark_operation_run_event_stop() -> OpenLineageRunEvent:
         eventTime=event_time,
         job=OpenLineageJob(
             namespace="local://some.host.com",
-            name="mysession.execute_some_command",
+            name="mysession1.execute_some_command",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
                     processingType=OpenLineageJobProcessingType.BATCH,
@@ -350,7 +482,7 @@ def spark_operation_run_event_stop() -> OpenLineageRunEvent:
                 parent=OpenLineageParentRunFacet(
                     job=OpenLineageParentJob(
                         namespace="local://some.host.com",
-                        name="mysession",
+                        name="mysession1",
                     ),
                     run=OpenLineageParentRun(
                         runId=run_id,

--- a/tests/test_consumer/test_extractors/test_extractors_batch_airflow.py
+++ b/tests/test_consumer/test_extractors/test_extractors_batch_airflow.py
@@ -36,32 +36,32 @@ from data_rentgen.openlineage.run_event import (
 def test_extractors_extract_batch_airflow_without_lineage(
     airflow_dag_run_event_start: OpenLineageRunEvent,
     airflow_dag_run_event_stop: OpenLineageRunEvent,
-    airflow_task_run_event_start: OpenLineageRunEvent,
-    airflow_task_run_event_stop: OpenLineageRunEvent,
+    airflow_task1_run_event_start: OpenLineageRunEvent,
+    airflow_task1_run_event_stop: OpenLineageRunEvent,
     extracted_airflow_location: LocationDTO,
     extracted_airflow_dag_job: JobDTO,
-    extracted_airflow_task_job: JobDTO,
+    extracted_airflow_task1_job: JobDTO,
     extracted_airflow_dag_run: RunDTO,
-    extracted_airflow_task_run: RunDTO,
-    extracted_airflow_task_operation: OperationDTO,
+    extracted_airflow_task1_run: RunDTO,
+    extracted_airflow_task1_operation: OperationDTO,
     input_transformation,
 ):
     events = [
         airflow_dag_run_event_start,
-        airflow_task_run_event_start,
-        airflow_task_run_event_stop,
+        airflow_task1_run_event_start,
+        airflow_task1_run_event_stop,
         airflow_dag_run_event_stop,
     ]
 
     extracted = BatchExtractor().add_events(input_transformation(events))
 
     assert extracted.locations() == [extracted_airflow_location]
-    assert extracted.jobs() == [extracted_airflow_dag_job, extracted_airflow_task_job]
+    assert extracted.jobs() == [extracted_airflow_dag_job, extracted_airflow_task1_job]
     assert extracted.runs() == [
         extracted_airflow_dag_run,
-        extracted_airflow_task_run,
+        extracted_airflow_task1_run,
     ]
-    assert extracted.operations() == [extracted_airflow_task_operation]
+    assert extracted.operations() == [extracted_airflow_task1_operation]
 
     assert not extracted.datasets()
     assert not extracted.dataset_symlinks()
@@ -87,16 +87,16 @@ def test_extractors_extract_batch_airflow_without_lineage(
 def test_extractors_extract_batch_airflow_with_lineage(
     airflow_dag_run_event_start: OpenLineageRunEvent,
     airflow_dag_run_event_stop: OpenLineageRunEvent,
-    airflow_task_run_event_start: OpenLineageRunEvent,
-    airflow_task_run_event_stop: OpenLineageRunEvent,
+    airflow_task1_run_event_start: OpenLineageRunEvent,
+    airflow_task1_run_event_stop: OpenLineageRunEvent,
     postgres_input: OpenLineageInputDataset,
     hdfs_output: OpenLineageOutputDataset,
     hdfs_output_with_stats: OpenLineageOutputDataset,
     extracted_airflow_dag_job: JobDTO,
-    extracted_airflow_task_job: JobDTO,
+    extracted_airflow_task1_job: JobDTO,
     extracted_airflow_dag_run: RunDTO,
-    extracted_airflow_task_run: RunDTO,
-    extracted_airflow_task_operation: OperationDTO,
+    extracted_airflow_task1_run: RunDTO,
+    extracted_airflow_task1_operation: OperationDTO,
     extracted_airflow_location: LocationDTO,
     extracted_postgres_location: LocationDTO,
     extracted_hdfs_location: LocationDTO,
@@ -114,13 +114,13 @@ def test_extractors_extract_batch_airflow_with_lineage(
 ):
     events = [
         airflow_dag_run_event_start,
-        airflow_task_run_event_start.model_copy(
+        airflow_task1_run_event_start.model_copy(
             update={
                 "inputs": [postgres_input],
                 "outputs": [hdfs_output],
             },
         ),
-        airflow_task_run_event_stop.model_copy(
+        airflow_task1_run_event_stop.model_copy(
             update={
                 "inputs": [postgres_input],
                 "outputs": [hdfs_output_with_stats],
@@ -138,10 +138,10 @@ def test_extractors_extract_batch_airflow_with_lineage(
         extracted_postgres_location,
     ]
 
-    assert extracted.jobs() == [extracted_airflow_dag_job, extracted_airflow_task_job]
+    assert extracted.jobs() == [extracted_airflow_dag_job, extracted_airflow_task1_job]
     assert extracted.users() == [extracted_user]
-    assert extracted.runs() == [extracted_airflow_dag_run, extracted_airflow_task_run]
-    assert extracted.operations() == [extracted_airflow_task_operation]
+    assert extracted.runs() == [extracted_airflow_dag_run, extracted_airflow_task1_run]
+    assert extracted.operations() == [extracted_airflow_task1_operation]
 
     assert extracted.datasets() == [
         extracted_hdfs_dataset1,

--- a/tests/test_consumer/test_extractors/test_extractors_batch_spark.py
+++ b/tests/test_consumer/test_extractors/test_extractors_batch_spark.py
@@ -132,6 +132,73 @@ def test_extractors_extract_batch_spark_openlineage_emitted_unknown_name(
     assert not extracted.outputs()
 
 
+def test_extractors_extract_batch_spark_openlineage_emitted_unknown_name_no_job_mixing(
+    spark_another_app_run_event_start_with_unknown_name_and_different_parent: OpenLineageRunEvent,
+    spark_app_run_event_start_with_unknown_name_and_parent: OpenLineageRunEvent,
+    spark_app_run_event_stop_with_parent: OpenLineageRunEvent,
+    spark_another_app_run_event_stop_with_another_parent: OpenLineageRunEvent,
+    spark_operation_run_event_start: OpenLineageRunEvent,
+    spark_operation_run_event_running: OpenLineageRunEvent,
+    spark_operation_run_event_stop: OpenLineageRunEvent,
+    extracted_airflow_location: LocationDTO,
+    extracted_airflow_task1_job_as_parent: JobDTO,
+    extracted_airflow_task1_run_as_parent: RunDTO,
+    extracted_another_airflow_location: LocationDTO,
+    extracted_airflow_task2_job: JobDTO,
+    extracted_airflow_task2_run: RunDTO,
+    extracted_spark_location: LocationDTO,
+    extracted_spark_app_job_with_parent: JobDTO,
+    extracted_spark_another_app_job_with_parent: JobDTO,
+    extracted_spark_unknown_job: JobDTO,
+    extracted_user: UserDTO,
+    extracted_spark_app_run_with_parent: RunDTO,
+    extracted_spark_another_app_run_with_parent: RunDTO,
+    extracted_spark_operation_with_parent: OperationDTO,
+):
+    events = [
+        spark_another_app_run_event_start_with_unknown_name_and_different_parent,
+        spark_app_run_event_start_with_unknown_name_and_parent,
+        spark_operation_run_event_start,
+        spark_operation_run_event_running,
+        spark_operation_run_event_stop,
+        spark_another_app_run_event_stop_with_another_parent,
+        spark_app_run_event_stop_with_parent,
+    ]
+
+    extracted = BatchExtractor().add_events(events)
+
+    extracted_spark_unknown_job.parent_job = extracted_airflow_task1_job_as_parent
+
+    # the result is the same as above
+    assert extracted.locations() == [
+        extracted_airflow_location,
+        extracted_another_airflow_location,
+        extracted_spark_location,
+    ]
+
+    assert extracted.jobs() == [
+        extracted_airflow_task1_job_as_parent,
+        extracted_airflow_task2_job,
+        extracted_spark_app_job_with_parent,
+        extracted_spark_another_app_job_with_parent,
+        extracted_spark_unknown_job,
+    ]
+    assert extracted.users() == [extracted_user]
+    assert extracted.runs() == [
+        extracted_airflow_task2_run,
+        extracted_spark_another_app_run_with_parent,
+        extracted_airflow_task1_run_as_parent,
+        extracted_spark_app_run_with_parent,
+    ]
+    assert extracted.operations() == [extracted_spark_operation_with_parent]
+
+    assert not extracted.datasets()
+    assert not extracted.dataset_symlinks()
+    assert not extracted.schemas()
+    assert not extracted.inputs()
+    assert not extracted.outputs()
+
+
 @pytest.mark.parametrize(
     "input_transformation",
     [
@@ -239,7 +306,7 @@ def test_extractors_extract_batch_spark_strip_hdfs_partitions(extracted_hdfs_dat
         eventTime=event_time,
         job=OpenLineageJob(
             namespace="local://some.host.com",
-            name="mysession.execute_some_command",
+            name="mysession1.execute_some_command",
             facets=OpenLineageJobFacets(
                 jobType=OpenLineageJobTypeJobFacet(
                     processingType=OpenLineageJobProcessingType.BATCH,
@@ -254,7 +321,7 @@ def test_extractors_extract_batch_spark_strip_hdfs_partitions(extracted_hdfs_dat
                 parent=OpenLineageParentRunFacet(
                     job=OpenLineageParentJob(
                         namespace="local://some.host.com",
-                        name="mysession",
+                        name="mysession1",
                     ),
                     run=OpenLineageParentRun(
                         runId=run_id,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Calling `DTO.merge(new, old)` expected that new and old entities are the same entity but with different state in time (old extracted from STARTED event, new from RUNNING/SUCCESS/...).
But actually there is a case then the same run can have different jobs - https://github.com/OpenLineage/OpenLineage/issues/3846.

There was a workaround in `JobDTO.merge(new, old)` which returned new object instead of updating the old one. But it was not compatible with [BatchExtractionResult._add](https://github.com/MTSWebServices/data-rentgen/blob/develop/data_rentgen/consumer/extractors/batch_extraction_result.py#L118) logic - new element returned different `unique_key`, but old key was used to store object in dict, so in total different jobs were merged into one.

Now `DTO.merge(new, old)` method is expected to return object with the same `unique_key`. Workaround for RunDTO having different job during a lifecycle was moved into RunDTO itself. Added a proper test for this case.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
