### PR TITLE
[DOP-38805] Ignore datasets with reserved names

### DIFF
--- a/data_rentgen/consumer/extractors/batch_extractor.py
+++ b/data_rentgen/consumer/extractors/batch_extractor.py
@@ -61,6 +61,8 @@ class BatchExtractor:
 
         for input_dataset in event.inputs:
             input_dto, symlink_groups = extractor.extract_input(operation, input_dataset, event)
+            if not input_dto:
+                continue
             self.result.add_input(input_dto)
 
             for symlink_group in symlink_groups:
@@ -68,6 +70,8 @@ class BatchExtractor:
 
         for output_dataset in event.outputs:
             output_dto, symlink_groups = extractor.extract_output(operation, output_dataset, event)
+            if not output_dto:
+                continue
             self.result.add_output(output_dto)
 
             for symlink_group in symlink_groups:

--- a/data_rentgen/consumer/extractors/generic/column_lineage.py
+++ b/data_rentgen/consumer/extractors/generic/column_lineage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import datetime
+from typing import cast
 
 from data_rentgen.dto import (
     ColumnLineageDTO,
@@ -45,10 +46,12 @@ TRANSFORMATION_SUBTYPE_MAP = {
     "CONDITIONAL": DatasetColumnRelationTypeDTO.CONDITIONAL,
 }
 
+MISSING = object()
+
 
 class ColumnLineageExtractorMixin(ABC):
     def __init__(self):
-        self._dataset_ref_to_dto_cache: dict[tuple[str, str], DatasetDTO] = {}
+        self._dataset_ref_to_dto_cache: dict[tuple[str, str], DatasetDTO | None] = {}
 
     @abstractmethod
     def extract_io_created_at(self, operation: OperationDTO, event: OpenLineageRunEvent) -> datetime:
@@ -58,20 +61,22 @@ class ColumnLineageExtractorMixin(ABC):
     def _extract_dataset_ref(
         self,
         dataset: OpenLineageDataset | OpenLineageColumnLineageDatasetFacetFieldRef | OpenLineageSymlinkIdentifier,
-    ) -> DatasetDTO:
+    ) -> DatasetDTO | None:
         pass
 
     def _resolve_dataset_ref(
         self,
         dataset_ref: OpenLineageDataset | OpenLineageColumnLineageDatasetFacetFieldRef | OpenLineageSymlinkIdentifier,
-    ) -> DatasetDTO:
+    ) -> DatasetDTO | None:
         """
         Column lineage has a lot of dataset references, so this is a hot path which requires caching.
         """
         dataset_cache_key = (dataset_ref.namespace, dataset_ref.name)
-        if dataset_cache_key not in self._dataset_ref_to_dto_cache:
-            self._dataset_ref_to_dto_cache[dataset_cache_key] = self._extract_dataset_ref(dataset_ref)
-        return self._dataset_ref_to_dto_cache[dataset_cache_key]
+        result = self._dataset_ref_to_dto_cache.get(dataset_cache_key, MISSING)
+        if result is MISSING:
+            result = self._extract_dataset_ref(dataset_ref)
+            self._dataset_ref_to_dto_cache[dataset_cache_key] = result
+        return cast("DatasetDTO | None", result)
 
     def extract_column_lineage(
         self,
@@ -86,16 +91,20 @@ class ColumnLineageExtractorMixin(ABC):
             return []
 
         output_dataset_dto = self._resolve_dataset_ref(output_dataset)
-        created_at = self.extract_io_created_at(operation, event)
+        if not output_dataset_dto:
+            return []
 
         # Grouping column lineage by source+target dataset. This is unique combination within operation,
         # so we can use it to generate the same fingerprint for all dataset column relations
         result: dict[tuple, ColumnLineageDTO] = {}
+        created_at = self.extract_io_created_at(operation, event)
 
         # direct lineage (source_column -> target_column)
         for field, raw_column_lineage in output_dataset.facets.columnLineage.fields.items():
             for input_field in raw_column_lineage.inputFields:
                 input_dataset_dto = self._resolve_dataset_ref(input_field)
+                if not input_dataset_dto:
+                    continue
                 column_lineage = ColumnLineageDTO(
                     created_at=created_at,
                     operation=operation,
@@ -122,6 +131,8 @@ class ColumnLineageExtractorMixin(ABC):
         # added to OL since v1.23 and send only when columnLineage.datasetLineageEnabled=true
         for input_field in output_dataset.facets.columnLineage.dataset:
             input_dataset_dto = self._resolve_dataset_ref(input_field)
+            if not input_dataset_dto:
+                continue
             column_lineage = ColumnLineageDTO(
                 created_at=created_at,
                 operation=operation,

--- a/data_rentgen/consumer/extractors/generic/dataset.py
+++ b/data_rentgen/consumer/extractors/generic/dataset.py
@@ -25,11 +25,6 @@ from data_rentgen.openlineage.dataset_facets import (
 METASTORE = DatasetSymlinkTypeDTO.METASTORE
 WAREHOUSE = DatasetSymlinkTypeDTO.WAREHOUSE
 
-# https://github.com/OpenLineage/OpenLineage/issues/4496
-# https://github.com/OpenLineage/OpenLineage/issues/4497
-# Fixed in OpenLineage 1.47, but not all users upgraded their ETL scripts
-SCHEMALESS_DATABASES = {"clickhouse", "mysql"}
-
 # OpenLineage namespaces are not necessarily URLs:
 # https://openlineage.io/docs/spec/naming/
 # But Data.Rentgen expects them to be actual URLs.
@@ -43,6 +38,30 @@ LOCATION_REPLACEMENTS = {
     re.compile(r"^postgresql://"): "postgres://",
 }
 
+OPTIONAL_DATABASE_PATTERN = r"([\w\d_\-\.]+\.)?"
+RESERVED_DATASET_NAME_PATTERNS = [
+    r"information_schema\.[\w_.]+",  # common for all databases
+    r"pg_[\w_.]+",  # PostgreSQL
+    r"system\.[\w_.]+",  # Clickhouse
+    r"sys\.[\w_.]+",  # Oracle
+    "dual",
+    r"all_[\w_]+",
+    r"user_[\w_]+",
+    r"dba_[\w_]+",
+    r"v\$[\w_]+",
+    r"v_\$[\w_]+",
+    r"gv_\$[\w_]+",
+]
+RESERVED_DATASET_NAME_PATTERN = re.compile(
+    "^" + OPTIONAL_DATABASE_PATTERN + "(" + "|".join(RESERVED_DATASET_NAME_PATTERNS) + ")$",
+    re.IGNORECASE | re.ASCII,
+)
+
+# https://github.com/OpenLineage/OpenLineage/issues/4496
+# https://github.com/OpenLineage/OpenLineage/issues/4497
+# Fixed in OpenLineage 1.47, but not all users upgraded their ETL scripts
+SCHEMALESS_DATABASES = {"clickhouse", "mysql"}
+
 
 def _get_symlink_role(type_: OpenLineageSymlinkType) -> DatasetSymlinkTypeDTO:
     return METASTORE if type_ == OpenLineageSymlinkType.TABLE else WAREHOUSE
@@ -53,19 +72,23 @@ def _get_opposite_dataset_role(symlink_roles: list[DatasetSymlinkTypeDTO]) -> Da
 
 
 class DatasetExtractorMixin:
-    def extract_dataset(self, dataset: OpenLineageDataset) -> DatasetDTO:
+    def extract_dataset(self, dataset: OpenLineageDataset) -> DatasetDTO | None:
         """
         Extract DatasetDTO from input or output OpenLineageDataset
         """
         dataset_dto = self._extract_dataset_ref(dataset)
+        if not dataset_dto:
+            return None
         return self._enrich_dataset_tags(dataset_dto, dataset)
 
     def _extract_dataset_ref(
         self,
         dataset: OpenLineageDataset | OpenLineageColumnLineageDatasetFacetFieldRef | OpenLineageSymlinkIdentifier,
-    ) -> DatasetDTO:
+    ) -> DatasetDTO | None:
         location = self._extract_dataset_location(dataset)
         name = dataset.name
+        if RESERVED_DATASET_NAME_PATTERN.match(name):
+            return None
         if location.type in SCHEMALESS_DATABASES and name.count(".") == 2:  # noqa: PLR2004
             name = name.split(".", maxsplit=1)[1]
         return DatasetDTO(
@@ -97,7 +120,7 @@ class DatasetExtractorMixin:
     def extract_dataset_and_symlinks(
         self,
         dataset: OpenLineageDataset,
-    ) -> tuple[DatasetDTO, list[DatasetSymlinkGroupDTO]]:
+    ) -> tuple[DatasetDTO | None, list[DatasetSymlinkGroupDTO]]:
         symlink_identifiers = dataset.facets.symlinks.identifiers if dataset.facets.symlinks else []
         return self._extract_dataset_and_symlinks(dataset, symlink_identifiers)
 
@@ -105,11 +128,14 @@ class DatasetExtractorMixin:
         self,
         dataset: OpenLineageDataset,
         symlink_identifiers: list[OpenLineageSymlinkIdentifier],
-    ) -> tuple[DatasetDTO, list[DatasetSymlinkGroupDTO]]:
+    ) -> tuple[DatasetDTO | None, list[DatasetSymlinkGroupDTO]]:
         dataset_dto = self.extract_dataset(dataset)
+        if not dataset_dto:
+            return None, []
         symlinks = [
-            (self._extract_dataset_ref(symlink_identifier), symlink_identifier.type)
+            (symlink_dataset, symlink_identifier.type)
             for symlink_identifier in symlink_identifiers
+            if (symlink_dataset := self._extract_dataset_ref(symlink_identifier))
         ]
         return dataset_dto, [self._build_dataset_symlink_group(dataset_dto, symlinks)] if symlinks else []
 

--- a/data_rentgen/consumer/extractors/generic/io.py
+++ b/data_rentgen/consumer/extractors/generic/io.py
@@ -54,7 +54,7 @@ class IOExtractorMixin(ABC):
     def extract_dataset_and_symlinks(
         self,
         dataset: OpenLineageDataset,
-    ) -> tuple[DatasetDTO, list[DatasetSymlinkGroupDTO]]:
+    ) -> tuple[DatasetDTO | None, list[DatasetSymlinkGroupDTO]]:
         pass
 
     def extract_io_created_at(self, operation: OperationDTO, event: OpenLineageRunEvent) -> datetime:
@@ -110,13 +110,15 @@ class IOExtractorMixin(ABC):
         operation: OperationDTO,
         dataset: OpenLineageInputDataset,
         event: OpenLineageRunEvent,
-    ) -> tuple[InputDTO, list[DatasetSymlinkGroupDTO]]:
+    ) -> tuple[InputDTO | None, list[DatasetSymlinkGroupDTO]]:
         """
         Extract InputDTO with optional symlinks
         """
         resolved_dataset_dto, symlinks = self.extract_dataset_and_symlinks(dataset)
-        created_at = self.extract_io_created_at(operation, event)
+        if not resolved_dataset_dto:
+            return None, []
 
+        created_at = self.extract_io_created_at(operation, event)
         result = InputDTO(
             created_at=created_at,
             operation=operation,
@@ -134,13 +136,15 @@ class IOExtractorMixin(ABC):
         operation: OperationDTO,
         dataset: OpenLineageOutputDataset,
         event: OpenLineageRunEvent,
-    ) -> tuple[OutputDTO, list[DatasetSymlinkGroupDTO]]:
+    ) -> tuple[OutputDTO | None, list[DatasetSymlinkGroupDTO]]:
         """
         Extract OutputDTO with optional symlinks
         """
         resolved_dataset_dto, symlinks = self.extract_dataset_and_symlinks(dataset)
-        created_at = self.extract_io_created_at(operation, event)
+        if not resolved_dataset_dto:
+            return None, []
 
+        created_at = self.extract_io_created_at(operation, event)
         result = OutputDTO(
             created_at=created_at,
             operation=operation,

--- a/data_rentgen/consumer/extractors/impl/dbt.py
+++ b/data_rentgen/consumer/extractors/impl/dbt.py
@@ -44,17 +44,18 @@ class DbtExtractor(GenericExtractor):
     def _extract_dataset_ref(
         self,
         dataset: OpenLineageDataset | OpenLineageColumnLineageDatasetFacetFieldRef | OpenLineageSymlinkIdentifier,
-    ) -> DatasetDTO:
+    ) -> DatasetDTO | None:
         dataset_dto = super()._extract_dataset_ref(dataset)
-        # https://github.com/OpenLineage/OpenLineage/pull/3707
-        dataset_dto.name = dataset.name.replace("None.", "")
+        if dataset_dto:
+            # https://github.com/OpenLineage/OpenLineage/pull/3707
+            dataset_dto.name = dataset.name.replace("None.", "")
         return dataset_dto
 
     def _extract_output_type(
         self,
         operation: OperationDTO,
         dataset: OpenLineageOutputDataset,
-    ) -> OutputTypeDTO | None:
+    ) -> OutputTypeDTO:
         # by default, model is not materialized, and is either VIEW or INSERT INTO
         result = super()._extract_output_type(operation, dataset)
         return result or OutputTypeDTO.APPEND

--- a/data_rentgen/consumer/extractors/impl/flink.py
+++ b/data_rentgen/consumer/extractors/impl/flink.py
@@ -50,7 +50,7 @@ class FlinkExtractor(GenericExtractor):
         self,
         dataset: OpenLineageDataset,
         symlink_identifiers: list[OpenLineageSymlinkIdentifier],
-    ) -> tuple[DatasetDTO, list[DatasetSymlinkGroupDTO]]:
+    ) -> tuple[DatasetDTO | None, list[DatasetSymlinkGroupDTO]]:
         # Exclude Kafka fake symlinks produced by Flink 2.x integration.
         # See https://github.com/OpenLineage/OpenLineage/pull/3657
         symlink_identifiers = [

--- a/data_rentgen/consumer/extractors/impl/interface.py
+++ b/data_rentgen/consumer/extractors/impl/interface.py
@@ -43,14 +43,14 @@ class ExtractorInterface(Protocol):
         operation: OperationDTO,
         dataset: OpenLineageInputDataset,
         event: OpenLineageRunEvent,
-    ) -> tuple[InputDTO, list[DatasetSymlinkGroupDTO]]: ...
+    ) -> tuple[InputDTO | None, list[DatasetSymlinkGroupDTO]]: ...
 
     def extract_output(
         self,
         operation: OperationDTO,
         dataset: OpenLineageOutputDataset,
         event: OpenLineageRunEvent,
-    ) -> tuple[OutputDTO, list[DatasetSymlinkGroupDTO]]: ...
+    ) -> tuple[OutputDTO | None, list[DatasetSymlinkGroupDTO]]: ...
 
     def extract_column_lineage(
         self,

--- a/data_rentgen/consumer/extractors/impl/spark.py
+++ b/data_rentgen/consumer/extractors/impl/spark.py
@@ -84,11 +84,11 @@ class SparkExtractor(GenericExtractor):
     def _extract_dataset_ref(
         self,
         dataset: OpenLineageDataset | OpenLineageColumnLineageDatasetFacetFieldRef | OpenLineageSymlinkIdentifier,
-    ) -> DatasetDTO:
+    ) -> DatasetDTO | None:
         dataset_dto = super()._extract_dataset_ref(dataset)
 
         # convert /some/long/path/with=partition/another=abc to /some/long/path
-        if "=" in dataset_dto.name and "/" in dataset_dto.name:
+        if dataset_dto and "=" in dataset_dto.name and "/" in dataset_dto.name:
             name_with_partitions = PARTITION_PATH_PATTERN.match(dataset_dto.name)
             if name_with_partitions:
                 dataset_dto.name = name_with_partitions.group(1)
@@ -98,7 +98,7 @@ class SparkExtractor(GenericExtractor):
         self,
         dataset: OpenLineageDataset,
         symlink_identifiers: list[OpenLineageSymlinkIdentifier],
-    ) -> tuple[DatasetDTO, list[DatasetSymlinkGroupDTO]]:
+    ) -> tuple[DatasetDTO | None, list[DatasetSymlinkGroupDTO]]:
         table_symlinks = [
             identifier for identifier in symlink_identifiers if identifier.type == OpenLineageSymlinkType.TABLE
         ]
@@ -118,9 +118,14 @@ class SparkExtractor(GenericExtractor):
             )
 
         location_dataset_dto = self.extract_dataset(dataset)
-        table_dataset_dto = self._extract_dataset_ref(table_symlinks[0])
+        if not location_dataset_dto:
+            return None, []
 
         # Swap datasets in column lineage as well
+        table_dataset_dto = self._extract_dataset_ref(table_symlinks[0])
+        if not table_dataset_dto:
+            return None, []
+
         dataset_cache_key = (dataset.namespace, dataset.name)
         self._dataset_ref_to_dto_cache[dataset_cache_key] = table_dataset_dto
 

--- a/data_rentgen/db/migrations/versions/2026-07-08_9579bc0e1b35_delete_datasets_with_reserved_names.py
+++ b/data_rentgen/db/migrations/versions/2026-07-08_9579bc0e1b35_delete_datasets_with_reserved_names.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2024-present MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+"""Delete datasets with reserved names
+
+Revision ID: 9579bc0e1b35
+Revises: 96fd9a096682
+Create Date: 2026-07-08 11:52:15.440901
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9579bc0e1b35"
+down_revision = "96fd9a096682"
+branch_labels = None
+depends_on = None
+
+OPTIONAL_DATABASE_PATTERN = r"([\w\d_\-\.]+\.)?"
+RESERVED_DATASET_NAME_PATTERNS = [
+    r"information_schema\.[\w_.]+",  # common for all databases
+    r"pg_[\w_.]+",  # PostgreSQL
+    r"system\.[\w_.]+",  # Clickhouse
+    r"sys\.[\w_.]+",  # Oracle
+    "dual",
+    r"all_[\w_]+",
+    r"user_[\w_]+",
+    r"dba_[\w_]+",
+    r"v\$[\w_]+",
+    r"v_\$[\w_]+",
+    r"gv_\$[\w_]+",
+]
+RESERVED_DATASET_NAME_PATTERN = "^" + OPTIONAL_DATABASE_PATTERN + "(" + "|".join(RESERVED_DATASET_NAME_PATTERNS) + ")$"
+
+
+def upgrade() -> None:
+    op.execute(sa.text("CREATE TEMP TABLE datasets_to_delete (id BIGINT)"))
+
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO datasets_to_delete (id)
+            SELECT dataset.id
+            FROM dataset
+            WHERE name ~* :pattern
+            """,
+        ).bindparams(sa.bindparam("pattern", value=RESERVED_DATASET_NAME_PATTERN, type_=sa.String())),
+    )
+
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM input
+            WHERE dataset_id IN (SELECT id FROM datasets_to_delete)
+            """,
+        ),
+    )
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM output
+            WHERE dataset_id IN (SELECT id FROM datasets_to_delete)
+            """,
+        ),
+    )
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM column_lineage
+            WHERE source_dataset_id IN (SELECT id FROM datasets_to_delete)
+            """,
+        ),
+    )
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM column_lineage
+            WHERE target_dataset_id IN (SELECT id FROM datasets_to_delete)
+            """,
+        ),
+    )
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM dataset_symlink_group
+            WHERE fingerprint IN (
+                SELECT fingerprint
+                FROM dataset_symlink_group
+                WHERE dataset_id IN (SELECT id FROM datasets_to_delete)
+            )
+            """,
+        ),
+    )
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM dataset
+            WHERE id IN (SELECT id FROM datasets_to_delete)
+            """,
+        ),
+    )
+
+
+def downgrade() -> None:
+    # this migration is irreversible
+    pass

--- a/mddocs/docs/changelog/next_release/483.improvement.md
+++ b/mddocs/docs/changelog/next_release/483.improvement.md
@@ -1,0 +1,1 @@
+Ignore datasets with reserved names like `information_schema.tables`, `all_tables`, `dual` and so on.

--- a/tests/test_consumer/test_extractors/test_extractors_dataset.py
+++ b/tests/test_consumer/test_extractors/test_extractors_dataset.py
@@ -451,6 +451,35 @@ def test_extractors_extract_dataset_unknown():
     assert symlinks_dto == []
 
 
+@pytest.mark.parametrize(
+    ["namespace", "name"],
+    [
+        ("postgres://myhost:5432", "mydb.information_schema.tables"),
+        ("postgres://myhost:5432", "mydb.pg_catalog.pg_tables"),
+        ("sqlserver://myhost:1433", "mydb.information_schema.tables"),
+        ("mysql://myhost:3306", "information_schema.tables"),
+        ("clickhouse://myhost:8123", "information_schema.tables"),
+        ("clickhouse://myhost:8123", "system.tables"),
+        ("oracle://myhost:1521", "mydb.dual"),
+        ("oracle://myhost:1521", "mydb.sys.all_tables"),
+        ("oracle://myhost:1521", "mydb.all_tables"),
+        ("oracle://myhost:1521", "mydb.user_tables"),
+        ("oracle://myhost:1521", "mydb.dba_tables"),
+        ("oracle://myhost:1521", "mydb.v$session"),
+        ("oracle://myhost:1521", "mydb.v_$session"),
+        ("oracle://myhost:1521", "mydb.gv_$session"),
+    ],
+)
+def test_extractors_extract_dataset_prohibited_name(namespace: str, name: str):
+    dataset = OpenLineageDataset(
+        namespace=namespace,
+        name=name,
+    )
+    dataset_dto, symlinks_dto = GenericExtractor().extract_dataset_and_symlinks(dataset)
+    assert dataset_dto is None
+    assert symlinks_dto == []
+
+
 def test_extractors_extract_dataset_with_tags():
     dataset = OpenLineageDataset(
         namespace="postgres://192.168.1.1:5432",

--- a/tests/test_database/test_migration_delete_datasets_with_reserved_names.py
+++ b/tests/test_database/test_migration_delete_datasets_with_reserved_names.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2024-present MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
+
+from data_rentgen.db.models import Base
+from tests.test_database.fixtures.alembic import do_run_migrations
+
+if TYPE_CHECKING:
+    from alembic.config import Config as AlembicConfig
+
+pytestmark = [pytest.mark.db]
+
+PREV_REVISION = "96fd9a096682"
+THIS_REVISION = "9579bc0e1b35"
+
+
+def test_migration_delete_datasets_with_reserved_names(empty_db_url: str, alembic_config: AlembicConfig):
+    do_run_migrations(alembic_config, Base.metadata, PREV_REVISION)
+
+    engine = create_engine(empty_db_url, poolclass=NullPool)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO location (id, type, name) VALUES
+                        (1, 'clickhouse', 'myhost:8123'),
+                        (2, 'mysql', 'myhost:3306'),
+                        (3, 'sqlserver', 'myhost:1433'),
+                        (4, 'postgres', 'myhost:5432'),
+                        (5, 'oracle', 'myhost:1521')
+                    """,
+                ),
+            )
+
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO dataset (location_id, name) VALUES
+                        (1, 'default.mytable'),
+                        (2, 'mydb.mytable'),
+                        (3, 'mydb.myschema.mytable'),
+                        (4, 'mydb.myschema.mytable'),
+                        (5, 'mydb.myschema.mytable'),
+
+                        (1, 'system.tables'),
+                        (2, 'information_schema.tables'),
+
+                        (3, 'mydb.information_schema.tables'),
+
+                        (4, 'mydb.information_schema.tables'),
+                        (4, 'mydb.pg_catalog.pg_database'),
+                        (4, 'mydb.pg_database'),
+
+                        (5, 'mydb.information_schema.tables'),
+                        (5, 'mydb.sys.all_tables'),
+                        (5, 'mydb.all_tables'),
+                        (5, 'mydb.user_tables'),
+                        (5, 'mydb.dba_tables'),
+                        (5, 'mydb.dual'),
+                        (5, 'mydb.v$session'),
+                        (5, 'mydb.v_$session'),
+                        (5, 'mydb.gv_$session')
+                    """,
+                ),
+            )
+
+        do_run_migrations(alembic_config, Base.metadata, THIS_REVISION)
+
+        with engine.connect() as conn:
+            assert conn.execute(
+                text("SELECT location_id, name FROM dataset ORDER BY location_id, name"),
+            ).fetchall() == [
+                (1, "default.mytable"),
+                (2, "mydb.mytable"),
+                (3, "mydb.myschema.mytable"),
+                (4, "mydb.myschema.mytable"),
+                (5, "mydb.myschema.mytable"),
+            ]
+
+    finally:
+        engine.dispose()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Datasets with reserved names like `information_schema.tables`, `all_tables`, `dual` are provided by database, and should be ignored by consumer. Added migration to drop them from database as well.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `mddocs/docs/changelog/next_release/<pull request or issue id>.<change type>.md` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [ ] My PR is ready to review.
