### PR TITLE
[DOP-38585] Use composite primary key for job_dependency

### DIFF
--- a/data_rentgen/consumer/saver.py
+++ b/data_rentgen/consumer/saver.py
@@ -112,12 +112,8 @@ class DatabaseSaver:
 
     async def create_job_dependencies(self, data: BatchExtractionResult):
         self.logger.debug("Creating job dependencies")
-        job_dependency_pairs = await self.unit_of_work.job_dependency.fetch_bulk(data.job_dependencies())
-        for job_dependency_dto, job_dependency in job_dependency_pairs:
-            if not job_dependency:
-                async with self.unit_of_work:
-                    job_dependency = await self.unit_of_work.job_dependency.create(job_dependency_dto)  # noqa: PLW2901
-            job_dependency_dto.id = job_dependency.id
+        async with self.unit_of_work:
+            await self.unit_of_work.job_dependency.create_bulk(data.job_dependencies())
 
     async def create_users(self, data: BatchExtractionResult):
         self.logger.debug("Creating users")

--- a/data_rentgen/db/migrations/versions/2026-07-09_65a6e6f1f11a_change_job_dependency_primary_key.py
+++ b/data_rentgen/db/migrations/versions/2026-07-09_65a6e6f1f11a_change_job_dependency_primary_key.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2024-present MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+"""Change job_dependency primary key
+
+Revision ID: 65a6e6f1f11a
+Revises: bff610745bac
+Create Date: 2026-07-09 16:37:02.215531
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "65a6e6f1f11a"
+down_revision = "bff610745bac"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index(op.f("ix__job_dependency__from_job_id"), table_name="job_dependency")
+    op.drop_constraint(op.f("pk__job_dependency"), "job_dependency", type_="primary")
+    op.drop_constraint(op.f("uq__job_dependency__from_job_id_to_job_id"), "job_dependency", type_="unique")
+    op.drop_column("job_dependency", "id")
+    op.create_primary_key(op.f("pk__job_dependency"), "job_dependency", ["from_job_id", "to_job_id"])
+    op.execute("DROP SEQUENCE IF EXISTS job_dependency_id_seq")
+
+
+def downgrade() -> None:
+    op.drop_constraint(op.f("pk__job_dependency"), "job_dependency", type_="primary")
+    op.execute("CREATE SEQUENCE IF NOT EXISTS job_dependency_id_seq")
+    op.add_column("job_dependency", sa.Column("id", sa.BigInteger(), nullable=True))
+    op.execute("ALTER SEQUENCE job_dependency_id_seq OWNED BY job_dependency.id")
+    op.execute("UPDATE job_dependency SET id = nextval('job_dependency_id_seq')")
+    op.alter_column(
+        "job_dependency",
+        "id",
+        existing_type=sa.BigInteger(),
+        nullable=False,
+        server_default=sa.text("nextval('job_dependency_id_seq')"),
+    )
+    op.create_primary_key(op.f("pk__job_dependency"), "job_dependency", ["id"])
+    op.create_unique_constraint(
+        op.f("uq__job_dependency__from_job_id_to_job_id"),
+        "job_dependency",
+        ["from_job_id", "to_job_id"],
+    )
+    op.create_index(op.f("ix__job_dependency__from_job_id"), "job_dependency", ["from_job_id"], unique=False)

--- a/data_rentgen/db/models/job_dependency.py
+++ b/data_rentgen/db/models/job_dependency.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from sqlalchemy import BigInteger, ForeignKey, String, UniqueConstraint
+from sqlalchemy import BigInteger, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from data_rentgen.db.models.base import Base
@@ -11,13 +11,11 @@ from data_rentgen.db.models.job import Job
 
 class JobDependency(Base):
     __tablename__ = "job_dependency"
-    __table_args__ = (UniqueConstraint("from_job_id", "to_job_id"),)
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     from_job_id: Mapped[int] = mapped_column(
         BigInteger,
         ForeignKey("job.id", ondelete="CASCADE"),
-        index=True,
+        primary_key=True,
         nullable=False,
         doc="From job id",
     )
@@ -30,6 +28,7 @@ class JobDependency(Base):
     to_job_id: Mapped[int] = mapped_column(
         BigInteger,
         ForeignKey("job.id", ondelete="CASCADE"),
+        primary_key=True,
         index=True,
         nullable=False,
         doc="To job id",

--- a/data_rentgen/db/repositories/job_dependency.py
+++ b/data_rentgen/db/repositories/job_dependency.py
@@ -4,21 +4,17 @@ from datetime import datetime
 from typing import Literal
 
 from sqlalchemy import (
-    ARRAY,
     CompoundSelect,
     DateTime,
-    Integer,
     Select,
     and_,
     any_,
     bindparam,
-    cast,
-    func,
     literal,
     or_,
     select,
-    tuple_,
 )
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import aliased
 
 from data_rentgen.db.models.dataset_symlink_group import DatasetSymlinkGroup
@@ -60,76 +56,28 @@ def _symlink_connected_cte():
     return cte.union(recursive_part)
 
 
-fetch_bulk_query = select(JobDependency).where(
-    tuple_(JobDependency.from_job_id, JobDependency.to_job_id).in_(
-        select(
-            func.unnest(
-                cast(bindparam("from_job_ids"), ARRAY(Integer())),
-                cast(bindparam("to_job_ids"), ARRAY(Integer())),
-            )
-            .table_valued("from_job_ids", "to_job_ids")
-            .render_derived(),
-        ),
-    ),
-)
-
-get_one_query = (
-    select(JobDependency)
-    .where(
-        JobDependency.from_job_id == bindparam("from_job_id"),
-        JobDependency.to_job_id == bindparam("to_job_id"),
-    )
-    .limit(literal(1, literal_execute=True))
+insert_statement = insert(JobDependency).on_conflict_do_nothing(
+    index_elements=[JobDependency.from_job_id, JobDependency.to_job_id],
 )
 
 
 class JobDependencyRepository(Repository[JobDependency]):
-    async def fetch_bulk(
-        self,
-        job_dependencies_dto: list[JobDependencyDTO],
-    ) -> list[tuple[JobDependencyDTO, JobDependency | None]]:
-        if not job_dependencies_dto:
-            return []
+    async def create_bulk(self, job_dependencies: list[JobDependencyDTO]) -> None:
+        if not job_dependencies:
+            return
 
-        scalars = await self._session.scalars(
-            fetch_bulk_query,
-            {
-                "from_job_ids": [item.from_job.id for item in job_dependencies_dto],
-                "to_job_ids": [item.to_job.id for item in job_dependencies_dto],
-            },
+        type_by_key: dict[tuple[int, int], str | None] = {}
+        for item in job_dependencies:
+            key = (item.from_job.id, item.to_job.id)
+            if key not in type_by_key:
+                type_by_key[key] = item.type  # type: ignore[index]
+        await self._session.execute(
+            insert_statement,
+            [
+                {"from_job_id": from_job_id, "to_job_id": to_job_id, "type": dependency_type}
+                for (from_job_id, to_job_id), dependency_type in sorted(type_by_key.items())  # avoid deadlocks
+            ],
         )
-        existing = {(item.from_job_id, item.to_job_id): item for item in scalars.all()}
-        return [
-            (
-                dto,
-                existing.get((dto.from_job.id, dto.to_job.id)),  # type: ignore[arg-type]
-            )
-            for dto in job_dependencies_dto
-        ]
-
-    async def create(self, job_dependency: JobDependencyDTO) -> JobDependency:
-        # if another worker already created the same row, just use it. if not - create with holding the lock.
-        await self._lock(job_dependency.from_job.id, job_dependency.to_job.id)
-        return await self._get(job_dependency) or await self._create(job_dependency)
-
-    async def _get(self, job_dependency: JobDependencyDTO) -> JobDependency | None:
-        return await self._session.scalar(
-            get_one_query,
-            {
-                "from_job_id": job_dependency.from_job.id,
-                "to_job_id": job_dependency.to_job.id,
-            },
-        )
-
-    async def _create(self, job_dependency: JobDependencyDTO) -> JobDependency:
-        result = JobDependency(
-            from_job_id=job_dependency.from_job.id,
-            to_job_id=job_dependency.to_job.id,
-            type=job_dependency.type,
-        )
-        self._session.add(result)
-        await self._session.flush([result])
-        return result
 
     async def get_dependencies(
         self,

--- a/data_rentgen/dto/job_dependency.py
+++ b/data_rentgen/dto/job_dependency.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from data_rentgen.dto.job import JobDTO
 
@@ -13,7 +13,6 @@ class JobDependencyDTO:
     from_job: JobDTO
     to_job: JobDTO
     type: str | None = None
-    id: int | None = field(default=None, compare=False)
 
     @property
     def unique_key(self) -> tuple:
@@ -22,5 +21,4 @@ class JobDependencyDTO:
     def merge(self, new: JobDependencyDTO) -> JobDependencyDTO:
         self.from_job.merge(new.from_job)
         self.to_job.merge(new.to_job)
-        self.id = new.id or self.id
         return self

--- a/mddocs/docs/changelog/next_release/489.improvement.md
+++ b/mddocs/docs/changelog/next_release/489.improvement.md
@@ -1,0 +1,1 @@
+Reduced `job_dependency` storage size and consumer database load by using `(from_job_id, to_job_id)` as the primary key and inserting dependencies in bulk.

--- a/tests/test_consumer/test_handlers/test_runs_handler_dbt.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_dbt.py
@@ -89,7 +89,7 @@ async def test_runs_handler_dbt(
         "openlineage_adapter.version": "1.34.0",
     }
 
-    job_dependency_query = select(JobDependency).order_by(JobDependency.id)
+    job_dependency_query = select(JobDependency).order_by(JobDependency.from_job_id, JobDependency.to_job_id)
     job_dependency_scalars = await async_session.scalars(job_dependency_query)
     job_dependencies = job_dependency_scalars.all()
     assert not job_dependencies

--- a/tests/test_consumer/test_handlers/test_runs_handler_flink.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_flink.py
@@ -86,7 +86,7 @@ async def test_runs_handler_flink(
         "openlineage_adapter.version": "1.34.0",
     }
 
-    job_dependency_query = select(JobDependency).order_by(JobDependency.id)
+    job_dependency_query = select(JobDependency).order_by(JobDependency.from_job_id, JobDependency.to_job_id)
     job_dependency_scalars = await async_session.scalars(job_dependency_query)
     job_dependencies = job_dependency_scalars.all()
     assert not job_dependencies

--- a/tests/test_consumer/test_handlers/test_runs_handler_hive.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_hive.py
@@ -89,7 +89,7 @@ async def test_runs_handler_hive(
         "openlineage_adapter.version": "1.35.0",
     }
 
-    job_dependency_query = select(JobDependency).order_by(JobDependency.id)
+    job_dependency_query = select(JobDependency).order_by(JobDependency.from_job_id, JobDependency.to_job_id)
     job_dependency_scalars = await async_session.scalars(job_dependency_query)
     job_dependencies = job_dependency_scalars.all()
     assert not job_dependencies

--- a/tests/test_consumer/test_handlers/test_runs_handler_spark.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_spark.py
@@ -89,7 +89,7 @@ async def test_runs_handler_spark(
         "openlineage_adapter.version": "1.19.0",
     }
 
-    job_dependency_query = select(JobDependency).order_by(JobDependency.id)
+    job_dependency_query = select(JobDependency).order_by(JobDependency.from_job_id, JobDependency.to_job_id)
     job_dependency_scalars = await async_session.scalars(job_dependency_query)
     job_dependencies = job_dependency_scalars.all()
     assert not job_dependencies

--- a/tests/test_consumer/test_handlers/test_runs_handler_spark_unknown_with_parent.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_spark_unknown_with_parent.py
@@ -116,7 +116,7 @@ async def test_runs_handler_spark_unknown_with_parent(
     assert jobs[4].location.addresses[0].url == "local://some.host.name"
     assert not jobs[0].tag_values
 
-    job_dependency_query = select(JobDependency).order_by(JobDependency.id)
+    job_dependency_query = select(JobDependency).order_by(JobDependency.from_job_id, JobDependency.to_job_id)
     job_dependency_scalars = await async_session.scalars(job_dependency_query)
     job_dependencies = job_dependency_scalars.all()
     assert not job_dependencies

--- a/tests/test_consumer/test_handlers/test_runs_handler_starrocks.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_starrocks.py
@@ -84,7 +84,7 @@ async def test_runs_handler_starrocks(
     assert jobs[0].location.addresses[0].url == "starrocks://some-starrocks:9030"
     assert not jobs[0].tag_values
 
-    job_dependency_query = select(JobDependency).order_by(JobDependency.id)
+    job_dependency_query = select(JobDependency).order_by(JobDependency.from_job_id, JobDependency.to_job_id)
     job_dependency_scalars = await async_session.scalars(job_dependency_query)
     job_dependencies = job_dependency_scalars.all()
     assert not job_dependencies

--- a/tests/test_consumer/test_handlers/test_runs_handler_unknown.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_unknown.py
@@ -86,7 +86,7 @@ async def test_runs_handler_unknown(
     assert job.location.addresses[0].url == "unknown://unknown"
     assert {tv.tag.name: tv.value for tv in jobs[0].tag_values} == {}
 
-    job_dependency_query = select(JobDependency).order_by(JobDependency.id)
+    job_dependency_query = select(JobDependency).order_by(JobDependency.from_job_id, JobDependency.to_job_id)
     job_dependency_scalars = await async_session.scalars(job_dependency_query)
     job_dependencies = job_dependency_scalars.all()
     assert not job_dependencies

--- a/tests/test_database/test_migration_change_job_dependency_primary_key.py
+++ b/tests/test_database/test_migration_change_job_dependency_primary_key.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2024-present MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
+
+from data_rentgen.db.models import Base
+from tests.test_database.fixtures.alembic import do_run_migrations
+
+if TYPE_CHECKING:
+    from alembic.config import Config as AlembicConfig
+
+pytestmark = [pytest.mark.db]
+
+PREV_REVISION = "bff610745bac"
+THIS_REVISION = "65a6e6f1f11a"
+
+
+def test_migration_change_job_dependency_primary_key(empty_db_url: str, alembic_config: AlembicConfig):
+    do_run_migrations(alembic_config, Base.metadata, PREV_REVISION)
+
+    engine = create_engine(empty_db_url, poolclass=NullPool)
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("INSERT INTO location (id, type, name) VALUES (1, 'local', 'somehost')"))
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO job (id, location_id, name, type_id, parent_job_id) VALUES
+                        (1, 1, 'task1', 3, null),
+                        (2, 1, 'task2', 3, null),
+                        (3, 1, 'task3', 3, null)
+                    """,
+                ),
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO job_dependency (id, from_job_id, to_job_id, type) VALUES
+                        (7, 1, 2, 'DIRECT_DEPENDENCY'),
+                        (42, 2, 3, null)
+                    """,
+                ),
+            )
+
+        do_run_migrations(alembic_config, Base.metadata, THIS_REVISION)
+
+        with engine.connect() as conn:
+            assert conn.execute(
+                text("SELECT from_job_id, to_job_id, type FROM job_dependency ORDER BY from_job_id, to_job_id"),
+            ).fetchall() == [
+                (1, 2, "DIRECT_DEPENDENCY"),
+                (2, 3, None),
+            ]
+
+        do_run_migrations(alembic_config, Base.metadata, PREV_REVISION, "down")
+
+        with engine.begin() as conn:
+            rows = conn.execute(
+                text("SELECT id, from_job_id, to_job_id, type FROM job_dependency ORDER BY from_job_id, to_job_id"),
+            ).fetchall()
+            assert [(row.from_job_id, row.to_job_id, row.type) for row in rows] == [
+                (1, 2, "DIRECT_DEPENDENCY"),
+                (2, 3, None),
+            ]
+
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO job (id, location_id, name, type_id, parent_job_id)
+                    VALUES (4, 1, 'task4', 3, null)
+                    """,
+                ),
+            )
+            inserted_id = conn.execute(
+                text(
+                    """
+                    INSERT INTO job_dependency (from_job_id, to_job_id, type)
+                    VALUES (3, 4, 'DIRECT_DEPENDENCY')
+                    RETURNING id
+                    """,
+                ),
+            ).scalar_one()
+            assert inserted_id is not None
+
+    finally:
+        engine.dispose()


### PR DESCRIPTION
## Change Summary

Changed the `job_dependency` table to use `(from_job_id, to_job_id)` as its composite primary key, removed the unused `id` column and redundant `from_job_id `index. Replaced row-by-row dependency creation and advisory locking with conflict-safe bulk inserts, reducing database storage usage and consumer load without significantly affecting query performance.

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `mddocs/docs/changelog/next_release/<pull request or issue id>.<change type>.md` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
