### PR TITLE
[DOP-26806] Improve parent-child job recursive query

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ concurrency:
 env:
   DEFAULT_PYTHON: '3.14'
   MIN_COVERAGE: 92
+  COLUMNS: 120
 
 jobs:
   tests:

--- a/data_rentgen/db/repositories/job.py
+++ b/data_rentgen/db/repositories/job.py
@@ -11,7 +11,6 @@ from sqlalchemy import (
     Select,
     SQLColumnExpression,
     String,
-    and_,
     any_,
     asc,
     bindparam,
@@ -22,11 +21,12 @@ from sqlalchemy import (
     func,
     literal,
     select,
+    text,
     tuple_,
     union,
 )
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.orm import aliased, selectinload
+from sqlalchemy.orm import selectinload
 
 from data_rentgen.db.models import Address, Job, JobLastRun, JobTagValue, Location, TagValue
 from data_rentgen.db.repositories.base import Repository
@@ -90,84 +90,45 @@ delete_tag_value_query = delete(JobTagValue).where(
     ~(JobTagValue.c.tag_value_id == any_(bindparam("tag_value_ids"))),
 )
 
-child_job = aliased(Job, name="child")
-parent_job = aliased(Job, name="parent")
+ancestors_by_job_query = text(
+    """
+    WITH RECURSIVE ancestors_by_job AS (
+        SELECT job.parent_job_id AS parent_job_id, job.id AS child_job_id
+        FROM job
+        WHERE job.id = ANY(:job_ids) AND job.parent_job_id IS NOT NULL
 
-ancestors_by_job_base_part = (
-    select(
-        child_job.id.label("child_job_id"),
-        parent_job.id.label("parent_job_id"),
-    )
-    .select_from(child_job)
-    .join(
-        parent_job,
-        and_(
-            child_job.parent_job_id == parent_job.id,
-            child_job.id != parent_job.id,
-        ),
-    )
-    .where(
-        child_job.id == any_(bindparam("job_ids")),
-    )
-)
-ancestors_by_job_cte = ancestors_by_job_base_part.cte("ancestors_by_job", recursive=True)
+        UNION
 
-ancestors_by_job_recursive_part = (
-    select(
-        child_job.id.label("child_job_id"),
-        parent_job.id.label("parent_job_id"),
+        SELECT parent.parent_job_id, parent.id
+        FROM job AS parent
+        JOIN ancestors_by_job ON parent.id = ancestors_by_job.parent_job_id
+        WHERE parent.parent_job_id IS NOT NULL
     )
-    .select_from(child_job)
-    .join(
-        parent_job,
-        and_(
-            child_job.parent_job_id == parent_job.id,
-            child_job.id != parent_job.id,
-        ),
-    )
-    .where(
-        child_job.id == ancestors_by_job_cte.c.parent_job_id,
-    )
+    SELECT parent_job_id, child_job_id
+    FROM ancestors_by_job
+    ORDER BY parent_job_id, child_job_id
+    """
 )
-ancestors_by_job_cte = ancestors_by_job_cte.union(ancestors_by_job_recursive_part)
 
-descendants_by_job_base_part = (
-    select(
-        parent_job.id.label("parent_job_id"),
-        child_job.id.label("child_job_id"),
-    )
-    .select_from(parent_job)
-    .join(
-        child_job,
-        and_(
-            child_job.parent_job_id == parent_job.id,
-            child_job.id != parent_job.id,
-        ),
-    )
-    .where(
-        parent_job.id == any_(bindparam("job_ids")),
-    )
-)
-descendants_by_job_cte = descendants_by_job_base_part.cte("descendants_by_job", recursive=True)
 
-descendants_by_job_recursive_part = (
-    select(
-        parent_job.id.label("parent_job_id"),
-        child_job.id.label("child_job_id"),
+descendants_by_job_query = text(
+    """
+    WITH RECURSIVE descendants_by_job AS (
+        SELECT job.id AS child_job_id, job.parent_job_id AS parent_job_id
+        FROM job
+        WHERE job.parent_job_id = ANY(:job_ids)
+
+        UNION
+
+        SELECT child.id, child.parent_job_id
+        FROM job AS child
+        JOIN descendants_by_job ON child.parent_job_id = descendants_by_job.child_job_id
     )
-    .select_from(parent_job)
-    .join(
-        child_job,
-        and_(
-            child_job.parent_job_id == parent_job.id,
-            child_job.id != parent_job.id,
-        ),
-    )
-    .where(
-        parent_job.id == descendants_by_job_cte.c.child_job_id,
-    )
+    SELECT parent_job_id, child_job_id
+    FROM descendants_by_job
+    ORDER BY parent_job_id, child_job_id
+    """
 )
-descendants_by_job_cte = descendants_by_job_cte.union(descendants_by_job_recursive_part)
 
 
 class JobRepository(Repository[Job]):
@@ -357,27 +318,11 @@ class JobRepository(Repository[Job]):
     async def list_ancestor_relations(self, job_ids: Collection[int]):
         if not job_ids:
             return []
-        stmt = select(
-            ancestors_by_job_cte.c.parent_job_id.cast(Integer),
-            ancestors_by_job_cte.c.child_job_id.cast(Integer),
-        )
-        result = await self._session.execute(
-            stmt,
-            {
-                "job_ids": list(job_ids),
-            },
-        )
+        result = await self._session.execute(ancestors_by_job_query, {"job_ids": list(job_ids)})
         return list(result.all())
 
     async def list_descendant_relations(self, job_ids: Collection[int]):
-        stmt = select(
-            descendants_by_job_cte.c.parent_job_id.cast(Integer),
-            descendants_by_job_cte.c.child_job_id.cast(Integer),
-        )
-        result = await self._session.execute(
-            stmt,
-            {
-                "job_ids": list(job_ids),
-            },
-        )
+        if not job_ids:
+            return []
+        result = await self._session.execute(descendants_by_job_query, {"job_ids": list(job_ids)})
         return list(result.all())

--- a/data_rentgen/db/repositories/run.py
+++ b/data_rentgen/db/repositories/run.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     desc,
     func,
     select,
+    text,
     union,
 )
 from sqlalchemy.dialects.postgresql import insert
@@ -87,64 +88,53 @@ insert_statement = insert_statement.on_conflict_do_update(
 )
 
 
-child_run = aliased(Run, name="child")
-parent_run = aliased(Run, name="parent")
+ancestors_by_run_query = text(
+    """
+    WITH RECURSIVE ancestors_by_run AS (
+        SELECT run.parent_run_id AS parent_run_id, run.id AS child_run_id
+        FROM run
+        WHERE
+            run.id = ANY(:run_ids)
+        AND run.created_at >= :since
+        AND run.created_at <= :until
+        AND run.parent_run_id IS NOT NULL
 
-ancestors_by_run_base_part = (
-    select(
-        child_run.id.label("child_run_id"),
-        parent_run.id.label("parent_run_id"),
-    )
-    .select_from(child_run)
-    .join(parent_run, child_run.parent_run_id == parent_run.id)
-    .where(
-        child_run.id == any_(bindparam("run_ids")),
-        child_run.created_at >= bindparam("since"),
-        child_run.created_at <= bindparam("until"),
-    )
-)
-ancestors_by_run_cte = ancestors_by_run_base_part.cte("ancestors_by_run", recursive=True)
+        UNION
 
-ancestors_by_run_recursive_part = (
-    select(
-        child_run.id.label("child_run_id"),
-        parent_run.id.label("parent_run_id"),
+        SELECT parent.parent_run_id, parent.id
+        FROM run AS parent
+        JOIN ancestors_by_run ON parent.id = ancestors_by_run.parent_run_id
+        WHERE parent.parent_run_id IS NOT NULL
+        -- run ids (UUIDv7) are generated using host time, and parent/child runs may start on different hosts.
+        -- so parent run_id/created_at is not necessarily less than child run_id/created_at
     )
-    .select_from(child_run)
-    .join(parent_run, child_run.parent_run_id == parent_run.id)
-    .where(
-        child_run.id == ancestors_by_run_cte.c.parent_run_id,
-    )
+    SELECT parent_run_id, child_run_id
+    FROM ancestors_by_run
+    ORDER BY parent_run_id, child_run_id
+    """
 )
-ancestors_by_run_cte = ancestors_by_run_cte.union(ancestors_by_run_recursive_part)
 
-descendants_by_run_base_part = (
-    select(
-        parent_run.id.label("parent_run_id"),
-        child_run.id.label("child_run_id"),
-    )
-    .select_from(parent_run)
-    .join(child_run, child_run.parent_run_id == parent_run.id)
-    .where(
-        parent_run.id == any_(bindparam("run_ids")),
-        parent_run.created_at >= bindparam("since"),
-        parent_run.created_at <= bindparam("until"),
-    )
-)
-descendants_by_run_cte = descendants_by_run_base_part.cte("descendants_by_run", recursive=True)
 
-descendants_by_run_recursive_part = (
-    select(
-        parent_run.id.label("parent_run_id"),
-        child_run.id.label("child_run_id"),
+descendants_by_run_query = text(
+    """
+    WITH RECURSIVE descendants_by_run AS (
+        SELECT run.id AS child_run_id, run.parent_run_id AS parent_run_id
+        FROM run
+        WHERE run.parent_run_id = ANY(:run_ids)
+        -- run ids (UUIDv7) are generated using host time, and parent/child runs may start on different hosts.
+        -- so parent run_id/created_at is not necessarily less than child run_id/created_at
+
+        UNION
+
+        SELECT child.id, child.parent_run_id
+        FROM run AS child
+        JOIN descendants_by_run ON child.parent_run_id = descendants_by_run.child_run_id
     )
-    .select_from(parent_run)
-    .join(child_run, child_run.parent_run_id == parent_run.id)
-    .where(
-        parent_run.id == descendants_by_run_cte.c.child_run_id,
-    )
+    SELECT parent_run_id, child_run_id
+    FROM descendants_by_run
+    ORDER BY parent_run_id, child_run_id
+    """
 )
-descendants_by_run_cte = descendants_by_run_cte.union(descendants_by_run_recursive_part)
 
 
 class RunRepository(Repository[Run]):
@@ -410,31 +400,21 @@ class RunRepository(Repository[Run]):
     async def list_ancestor_relations(self, run_ids: Collection[UUID]):
         if not run_ids:
             return []
-        stmt = select(
-            ancestors_by_run_cte.c.parent_run_id,
-            ancestors_by_run_cte.c.child_run_id,
-        )
         result = await self._session.execute(
-            stmt,
+            ancestors_by_run_query,
             {
                 "since": extract_timestamp_from_uuid(min(run_ids)),
                 "until": extract_timestamp_from_uuid(max(run_ids)),
                 "run_ids": list(run_ids),
             },
         )
-        return list(result.fetchall())
+        return list(result.all())
 
     async def list_descendant_relations(self, run_ids: Collection[UUID]):
-        stmt = select(
-            descendants_by_run_cte.c.parent_run_id,
-            descendants_by_run_cte.c.child_run_id,
-        )
         result = await self._session.execute(
-            stmt,
+            descendants_by_run_query,
             {
-                "since": extract_timestamp_from_uuid(min(run_ids)),
-                "until": extract_timestamp_from_uuid(max(run_ids)),
                 "run_ids": list(run_ids),
             },
         )
-        return list(result.fetchall())
+        return list(result.all())

--- a/data_rentgen/server/services/job.py
+++ b/data_rentgen/server/services/job.py
@@ -145,8 +145,8 @@ class JobService:
         descendant_relations = await self._uow.job.list_descendant_relations(start_node_ids)
         job_ids = (
             start_node_ids
-            | {r.parent_job_id for r in ancestor_relations}
-            | {r.child_job_id for r in descendant_relations}
+            | {parent_job_id for parent_job_id, _ in ancestor_relations}
+            | {child_job_id for _, child_job_id in descendant_relations}
         )
         result = JobHierarchyResult()
         result.parents.update(ancestor_relations)

--- a/data_rentgen/server/services/lineage.py
+++ b/data_rentgen/server/services/lineage.py
@@ -334,7 +334,7 @@ class LineageService:
         # Include child runs
         if level == 0:
             run_relations = await self._uow.run.list_descendant_relations(start_node_ids)
-            child_runs_ids = {c_id for _, c_id in run_relations}
+            child_runs_ids = {child_run_id for _, child_run_id in run_relations}
             child_runs = await self._uow.run.list_by_ids(child_runs_ids)
             runs.extend(child_runs)
             child_runs_by_id = {run.id: run for run in child_runs}
@@ -1359,13 +1359,13 @@ class LineageService:
         match granularity:
             case "RUN" | "OPERATION":
                 run_relations = await self._uow.run.list_ancestor_relations(result.runs.keys())
-                job_relations = await self._uow.job.list_ancestor_relations(result.jobs.keys())
                 parents_run_ids = {p_id for p_id, _ in run_relations}
                 runs = await self._uow.run.list_by_ids(parents_run_ids)
                 runs_by_id = {run.id: run for run in runs}
                 job_ids = {run.job_id for run in runs}
                 jobs = await self._uow.job.list_by_ids(job_ids)
                 jobs_by_id = {job.id: job for job in jobs}
+                job_relations = await self._uow.job.list_ancestor_relations(result.jobs.keys() | job_ids)
                 return LineageServiceResult(
                     run_ancestor_relations={tuple(r) for r in run_relations},
                     job_ancestor_relations={tuple(r) for r in job_relations},

--- a/mddocs/docs/changelog/next_release/492.improvement.md
+++ b/mddocs/docs/changelog/next_release/492.improvement.md
@@ -1,0 +1,1 @@
+Improve SQL queries for fetching job/run ancestors or descendants - previously it contained cartesial join.

--- a/tests/test_server/fixtures/factories/run.py
+++ b/tests/test_server/fixtures/factories/run.py
@@ -51,7 +51,8 @@ async def create_run(
     async_session: AsyncSession,
     run_kwargs: dict | None = None,
 ) -> Run:
-    run_kwargs = run_kwargs or {}
+    run_kwargs = dict(run_kwargs or {})
+    run_kwargs.setdefault("parent_run_id", None)
     run = run_factory(**run_kwargs)
     async_session.add(run)
     await async_session.commit()

--- a/tests/test_server/test_jobs/test_get_jobs_by_parent_job_id.py
+++ b/tests/test_server/test_jobs/test_get_jobs_by_parent_job_id.py
@@ -14,7 +14,7 @@ pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
 async def test_get_jobs_by_parent_job_id_unknown(
     test_client: AsyncClient,
-    new_job: Job,
+    jobs_with_same_parent_job: list[Job],
     mocked_user: MockedUser,
 ) -> None:
 

--- a/tests/test_server/test_lineage/test_run_lineage.py
+++ b/tests/test_server/test_lineage/test_run_lineage.py
@@ -1219,7 +1219,7 @@ async def test_get_run_lineage_for_long_running_operations(
     }
 
 
-async def test_get_run_lineage_run_with_ancestor_relations(
+async def test_get_run_lineage_with_ancestor_relations(
     test_client: AsyncClient,
     async_session: AsyncSession,
     lineage_with_parent_run_relations: LineageResult,
@@ -1266,7 +1266,7 @@ async def test_get_run_lineage_run_with_ancestor_relations(
     }
 
 
-async def test_runs_with_granularity_operation_and_ancestor_relations(
+async def test_get_run_lineage_with_granularity_operation_and_ancestor_relations(
     test_client: AsyncClient,
     async_session: AsyncSession,
     lineage_with_parent_run_relations: LineageResult,

--- a/tests/test_server/test_runs/test_get_runs_by_parent_run_id.py
+++ b/tests/test_server/test_runs/test_get_runs_by_parent_run_id.py
@@ -57,6 +57,7 @@ async def test_get_runs_by_parent_run_id_missing_since(
 async def test_get_runs_by_parent_run_id_unknown(
     test_client: AsyncClient,
     new_run: Run,
+    runs_with_same_parent: list[Run],
     mocked_user: MockedUser,
 ) -> None:
     since = new_run.created_at


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Previous version of the query looks like:
```
WITH RECURSIVE ancestors_by_job(child_job_id, parent_job_id) AS
(
  SELECT child.id AS child_job_id, parent.id AS parent_job_id
  FROM job AS child
  JOIN job AS parent ON child.parent_job_id = parent.id
  WHERE child.id = ANY ($1)

  UNION

  SELECT child.id AS child_job_id, parent.id AS parent_job_id
  FROM job AS child
  JOIN job AS parent ON child.parent_job_id = parent.id,
       ancestors_by_job  -- CROSS JOIN
  WHERE child.id = ancestors_by_job.parent_job_id
)
SELECT ancestors_by_job.parent_job_id AS parent_job_id, ancestors_by_job.child_job_id AS child_job_id
FROM ancestors_by_job;
```

Cross join here is a mistake. Also we don't need joining child on parent.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `mddocs/docs/changelog/next_release/<pull request or issue id>.<change type>.md` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
