### PR TITLE
[DOP-38372] Use composite primary key for dataset column relations

### DIFF
--- a/data_rentgen/db/migrations/versions/2026-07-14_7d9f6a1c2b34_change_dataset_column_relation_primary_key.py
+++ b/data_rentgen/db/migrations/versions/2026-07-14_7d9f6a1c2b34_change_dataset_column_relation_primary_key.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025-present MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+"""Change dataset_column_relation primary key
+
+Revision ID: 7d9f6a1c2b34
+Revises: 65a6e6f1f11a
+Create Date: 2026-07-14 15:51:48.132317
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7d9f6a1c2b34"
+down_revision = "65a6e6f1f11a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE dataset_column_relation SET target_column = '' WHERE target_column IS NULL")
+    op.alter_column(
+        "dataset_column_relation",
+        "target_column",
+        existing_type=sa.String(length=255),
+        nullable=False,
+    )
+    op.drop_constraint(op.f("pk__dataset_column_relation"), "dataset_column_relation", type_="primary")
+    op.drop_column("dataset_column_relation", "id")
+    op.create_primary_key(
+        op.f("pk__dataset_column_relation"),
+        "dataset_column_relation",
+        ["fingerprint", "source_column", "target_column"],
+    )
+    op.drop_index(
+        op.f("ix__dataset_column_relation__fingerprint_source_column_target_column"),
+        table_name="dataset_column_relation",
+    )
+    op.execute("DROP SEQUENCE IF EXISTS dataset_column_relation_id_seq")
+
+
+def downgrade() -> None:
+    op.drop_constraint(op.f("pk__dataset_column_relation"), "dataset_column_relation", type_="primary")
+    op.execute("CREATE SEQUENCE IF NOT EXISTS dataset_column_relation_id_seq")
+    op.add_column("dataset_column_relation", sa.Column("id", sa.BigInteger(), nullable=True))
+    op.execute("ALTER SEQUENCE dataset_column_relation_id_seq OWNED BY dataset_column_relation.id")
+    op.execute("UPDATE dataset_column_relation SET id = nextval('dataset_column_relation_id_seq')")
+    op.alter_column(
+        "dataset_column_relation",
+        "id",
+        existing_type=sa.BigInteger(),
+        nullable=False,
+        server_default=sa.text("nextval('dataset_column_relation_id_seq')"),
+    )
+    op.create_primary_key(op.f("pk__dataset_column_relation"), "dataset_column_relation", ["id"])
+    op.create_index(
+        op.f("ix__dataset_column_relation__fingerprint_source_column_target_column"),
+        "dataset_column_relation",
+        ["fingerprint", "source_column", sa.text("coalesce(target_column, '')")],
+        unique=True,
+    )
+    op.alter_column(
+        "dataset_column_relation",
+        "target_column",
+        existing_type=sa.String(length=255),
+        nullable=True,
+    )
+    op.execute("UPDATE dataset_column_relation SET target_column = NULL WHERE target_column = ''")

--- a/data_rentgen/db/models/dataset_column_relation.py
+++ b/data_rentgen/db/models/dataset_column_relation.py
@@ -6,12 +6,8 @@ from uuid import UUID
 
 from sqlalchemy import UUID as SQL_UUID
 from sqlalchemy import (
-    BigInteger,
-    Column,
-    Index,
     SmallInteger,
     String,
-    func,
 )
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -42,21 +38,10 @@ class DatasetColumnRelationType(Flag):
 # no foreign keys to partitioned tables
 class DatasetColumnRelation(Base):
     __tablename__ = "dataset_column_relation"
-    __table_args__ = (
-        Index(
-            None,
-            Column("fingerprint"),
-            Column("source_column"),
-            # NULLs are distinct by default, we have to convert them to something else.
-            # This is mostly for compatibility with PG <15, there is no `NULLS NOT DISTINCT` option
-            func.coalesce(Column("target_column"), ""),
-            unique=True,
-        ),
-    )
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     fingerprint: Mapped[UUID] = mapped_column(
         SQL_UUID,
+        primary_key=True,
         index=False,
         nullable=False,
         doc="Schema SHA-1 digest based used for grouping relations together. Currently this is in form of UUID",
@@ -64,17 +49,20 @@ class DatasetColumnRelation(Base):
 
     source_column: Mapped[str] = mapped_column(
         String(length=255),
+        primary_key=True,
         index=False,
         nullable=False,
         doc="Source dataset column the data is originated from",
     )
 
-    target_column: Mapped[str | None] = mapped_column(
+    target_column: Mapped[str] = mapped_column(
         String(length=255),
+        primary_key=True,
         index=False,
-        nullable=True,
+        nullable=False,
         doc=(
-            "Target dataset column the data is saved to. NULL means the entire target dataset depends on source column"
+            "Target dataset column the data is saved to. Empty value means the entire target dataset depends on source "
+            "column"
         ),
     )
 

--- a/data_rentgen/db/repositories/column_lineage.py
+++ b/data_rentgen/db/repositories/column_lineage.py
@@ -21,7 +21,7 @@ class ColumnLineageRow(NamedTuple):
     source_dataset_id: int
     target_dataset_id: int
     source_column: str
-    target_column: str
+    target_column: str | None
     types_combined: int
     last_used_at: datetime
 
@@ -157,7 +157,7 @@ class ColumnLineageRepository(Repository[ColumnLineage]):
                 ColumnLineage.source_dataset_id,
                 ColumnLineage.target_dataset_id,
                 DatasetColumnRelation.source_column,
-                DatasetColumnRelation.target_column,
+                func.nullif(DatasetColumnRelation.target_column, "").label("target_column"),
                 func.bit_or(DatasetColumnRelation.type).label("types_combined"),
                 func.max(ColumnLineage.created_at).label("last_used_at"),
             )

--- a/data_rentgen/db/repositories/dataset_column_relation.py
+++ b/data_rentgen/db/repositories/dataset_column_relation.py
@@ -4,7 +4,7 @@
 from collections import defaultdict
 from uuid import UUID
 
-from sqlalchemy import any_, bindparam, select, text
+from sqlalchemy import any_, bindparam, select
 from sqlalchemy.dialects.postgresql import insert
 
 from data_rentgen.db.models import (
@@ -47,7 +47,7 @@ class DatasetColumnRelationRepository(Repository[DatasetColumnRelation]):
             index_elements=[
                 DatasetColumnRelation.fingerprint,
                 DatasetColumnRelation.source_column,
-                text("coalesce(target_column, '')"),
+                DatasetColumnRelation.target_column,
             ],
         )
 
@@ -62,10 +62,9 @@ class DatasetColumnRelationRepository(Repository[DatasetColumnRelation]):
             insert_statement,
             [
                 {
-                    # id is autoincremental
                     "fingerprint": fingerprint,
                     "source_column": relation.source_column,
-                    "target_column": relation.target_column,
+                    "target_column": relation.target_column or "",
                     "type": DatasetColumnRelationType(relation.type).value,
                 }
                 for (fingerprint, *_), relations in to_insert.items()

--- a/mddocs/docs/changelog/next_release/493.improvement.md
+++ b/mddocs/docs/changelog/next_release/493.improvement.md
@@ -1,0 +1,1 @@
+Reduced `dataset_column_relation` storage size and column lineage query time by using `(fingerprint, source_column, target_column)` as the primary key.

--- a/mddocs/docs/reference/database/structure.md
+++ b/mddocs/docs/reference/database/structure.md
@@ -122,10 +122,9 @@ erDiagram
     }
 
     dataset_column_relation {
-        bigint id UK
-        uuid(v5) fingerprint UK
-        varchar(255) source_column UK
-        varchar(255) target_column UK
+        uuid(v5) fingerprint PK
+        varchar(255) source_column PK
+        varchar(255) target_column PK
         smallint type
     }
 

--- a/tests/test_consumer/test_handlers/test_runs_handler_hive.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_hive.py
@@ -302,7 +302,7 @@ async def test_runs_handler_hive(
 
     # Indirect relation
     customer_id_indirect_relation = dataset_column_relation[3]
-    assert customer_id_indirect_relation.target_column is None
+    assert customer_id_indirect_relation.target_column == ""
     assert customer_id_indirect_relation.source_column == "customer_id"
     assert customer_id_indirect_relation.type == DatasetColumnRelationType.JOIN.value
     assert customer_id_indirect_relation.fingerprint is not None

--- a/tests/test_consumer/test_handlers/test_runs_handler_spark.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_spark.py
@@ -322,7 +322,7 @@ async def test_runs_handler_spark(
 
     # Indirect relation
     customer_id_indirect_relation = dataset_column_relation[6]
-    assert customer_id_indirect_relation.target_column is None
+    assert customer_id_indirect_relation.target_column == ""
     assert customer_id_indirect_relation.source_column == "customer_id"
     assert customer_id_indirect_relation.type == DatasetColumnRelationType.JOIN.value
     assert customer_id_indirect_relation.fingerprint is not None

--- a/tests/test_consumer/test_handlers/test_runs_handler_spark_unknown_with_parent.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_spark_unknown_with_parent.py
@@ -387,7 +387,7 @@ async def test_runs_handler_spark_unknown_with_parent(
 
     # Indirect relation
     customer_id_indirect_relation = dataset_column_relation[6]
-    assert customer_id_indirect_relation.target_column is None
+    assert customer_id_indirect_relation.target_column == ""
     assert customer_id_indirect_relation.source_column == "customer_id"
     assert customer_id_indirect_relation.type == DatasetColumnRelationType.JOIN.value
     assert customer_id_indirect_relation.fingerprint is not None

--- a/tests/test_consumer/test_handlers/test_runs_handler_unknown.py
+++ b/tests/test_consumer/test_handlers/test_runs_handler_unknown.py
@@ -287,7 +287,7 @@ async def test_runs_handler_unknown(
 
     # Indirect relation
     customer_id_indirect_relation = dataset_column_relation[6]
-    assert customer_id_indirect_relation.target_column is None
+    assert customer_id_indirect_relation.target_column == ""
     assert customer_id_indirect_relation.source_column == "customer_id"
     assert customer_id_indirect_relation.type == DatasetColumnRelationType.JOIN.value
 

--- a/tests/test_database/test_migration_change_dataset_column_relation_primary_key.py
+++ b/tests/test_database/test_migration_change_dataset_column_relation_primary_key.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2025-present MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
+
+from data_rentgen.db.models import Base
+from tests.test_database.fixtures.alembic import do_run_migrations
+
+if TYPE_CHECKING:
+    from alembic.config import Config as AlembicConfig
+
+pytestmark = [pytest.mark.db]
+
+PREV_REVISION = "65a6e6f1f11a"
+THIS_REVISION = "7d9f6a1c2b34"
+
+
+def test_migration_change_dataset_column_relation_primary_key(
+    empty_db_url: str,
+    alembic_config: AlembicConfig,
+):
+    do_run_migrations(alembic_config, Base.metadata, PREV_REVISION)
+
+    engine = create_engine(empty_db_url, poolclass=NullPool)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO dataset_column_relation
+                        (id, fingerprint, source_column, target_column, type)
+                    VALUES
+                        (7, '00000000-0000-0000-0000-000000000001', 'source1', 'target1', 2),
+                        (42, '00000000-0000-0000-0000-000000000001', 'source2', null, 128)
+                    """,
+                ),
+            )
+
+        do_run_migrations(alembic_config, Base.metadata, THIS_REVISION)
+
+        with engine.begin() as conn:
+            assert conn.execute(
+                text(
+                    """
+                    SELECT fingerprint::text, source_column, target_column, type
+                    FROM dataset_column_relation
+                    ORDER BY source_column
+                    """,
+                ),
+            ).fetchall() == [
+                ("00000000-0000-0000-0000-000000000001", "source1", "target1", 2),
+                ("00000000-0000-0000-0000-000000000001", "source2", "", 128),
+            ]
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO dataset_column_relation
+                        (fingerprint, source_column, target_column, type)
+                    VALUES ('00000000-0000-0000-0000-000000000002', 'source3', '', 64)
+                    """,
+                ),
+            )
+
+        do_run_migrations(alembic_config, Base.metadata, PREV_REVISION, "down")
+
+        with engine.begin() as conn:
+            assert conn.execute(
+                text(
+                    """
+                    SELECT fingerprint::text, source_column, target_column, type
+                    FROM dataset_column_relation
+                    ORDER BY source_column
+                    """,
+                ),
+            ).fetchall() == [
+                ("00000000-0000-0000-0000-000000000001", "source1", "target1", 2),
+                ("00000000-0000-0000-0000-000000000001", "source2", None, 128),
+                ("00000000-0000-0000-0000-000000000002", "source3", None, 64),
+            ]
+
+            inserted_id = conn.execute(
+                text(
+                    """
+                    INSERT INTO dataset_column_relation
+                        (fingerprint, source_column, target_column, type)
+                    VALUES ('00000000-0000-0000-0000-000000000003', 'source4', null, 512)
+                    RETURNING id
+                    """,
+                ),
+            ).scalar_one()
+            assert inserted_id is not None
+    finally:
+        engine.dispose()

--- a/tests/test_server/fixtures/factories/relations.py
+++ b/tests/test_server/fixtures/factories/relations.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
 
 def column_relation_factory(**kwargs) -> DatasetColumnRelation:
     data = {
-        "id": randint(0, 10000000),
         "source_column": random_string(10),
         "target_column": random_string(10),
         "type": choice(list(DatasetColumnRelationType)),
@@ -35,14 +34,18 @@ async def create_column_relation(
 ) -> DatasetColumnRelation:
     column_relation_kwargs = column_relation_kwargs or {}
     column_relation_kwargs["fingerprint"] = fingerprint
+    column_relation_kwargs["target_column"] = column_relation_kwargs.get("target_column") or ""
 
     column_relation = column_relation_factory(**column_relation_kwargs)
-    del column_relation.id
     async_session.add(column_relation)
     await async_session.commit()
 
-    query = select(DatasetColumnRelation).where(DatasetColumnRelation.id == column_relation.id)
-    return await async_session.scalar(query)
+    query = select(DatasetColumnRelation).where(
+        DatasetColumnRelation.fingerprint == column_relation.fingerprint,
+        DatasetColumnRelation.source_column == column_relation.source_column,
+        DatasetColumnRelation.target_column == column_relation.target_column,
+    )
+    return (await async_session.scalars(query)).one()
 
 
 def column_lineage_factory(**kwargs) -> ColumnLineage:


### PR DESCRIPTION
## Change Summary

* Changed the `dataset_column_relation` table to use `(fingerprint, source_column, target_column)` as a composite primary key.
* Removed the unused `id` column.
* Removed the redundant unique index.
* Nullable `target_column` values are now stored as empty strings and converted back to `null` in API responses.
* Reduced the total table size from 186 MB to 163 MB.
* Improved a representative fingerprint lookup from 0.821 ms to 0.033 ms, making it approximately 25х faster.


## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `mddocs/docs/changelog/next_release/<pull request or issue id>.<change type>.md` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
