### PR TITLE
[DOP-29593] Add indexes for run.started_at and run.ended_at

### DIFF
--- a/data_rentgen/db/migrations/versions/2026-07-15_484cee706cc2_add_index_for_run_started_at_and_run_.py
+++ b/data_rentgen/db/migrations/versions/2026-07-15_484cee706cc2_add_index_for_run_started_at_and_run_.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2024-present MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+"""Add index for run.started_at and run.ended_at
+
+Revision ID: 484cee706cc2
+Revises: 6e24232c427b
+Create Date: 2026-07-15 13:28:23.888562
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "484cee706cc2"
+down_revision = "6e24232c427b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix__run__ended_at",
+        "run",
+        ["ended_at"],
+        unique=False,
+        postgresql_where="ended_at IS NOT NULL",
+        postgresql_using="brin",
+    )
+    op.create_index(
+        "ix__run__started_at",
+        "run",
+        ["started_at"],
+        unique=False,
+        postgresql_where="started_at IS NOT NULL",
+        postgresql_using="brin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix__run__started_at", table_name="run")
+    op.drop_index("ix__run__ended_at", table_name="run")

--- a/data_rentgen/db/models/run.py
+++ b/data_rentgen/db/models/run.py
@@ -59,6 +59,8 @@ class Run(Base):
         PrimaryKeyConstraint("id", "created_at"),
         Index("ix__run__search_vector", "search_vector", postgresql_using="gin"),
         Index("ix__run__parent_run_id", "parent_run_id", postgresql_where="parent_run_id IS NOT NULL"),
+        Index("ix__run__started_at", "started_at", postgresql_where="started_at IS NOT NULL", postgresql_using="brin"),
+        Index("ix__run__ended_at", "ended_at", postgresql_where="ended_at IS NOT NULL", postgresql_using="brin"),
         Index("ix__run__started_by_user_id", "started_by_user_id", postgresql_where="started_by_user_id IS NOT NULL"),
         {"postgresql_partition_by": "RANGE (created_at)"},
     )

--- a/mddocs/docs/changelog/next_release/494.improvement.md
+++ b/mddocs/docs/changelog/next_release/494.improvement.md
@@ -1,0 +1,1 @@
+Add lightweight ``BRIN`` index over ``run.started_at`` and ``run.ended_at`` columns.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,7 @@ docstring_style = "sphinx"
 
 [tool.codespell]
 exclude-file="uv.lock"
-ignore-words-list = "selectin"
+ignore-words-list = "selectin, brin"
 
 [tool.towncrier]
 name = "Data.Rentgen"

--- a/tests/test_server/fixtures/factories/run.py
+++ b/tests/test_server/fixtures/factories/run.py
@@ -8,7 +8,7 @@ import pytest_asyncio
 
 from data_rentgen.db.models import Job, Run, RunStartReason, RunStatus, User
 from data_rentgen.utils.uuid import extract_timestamp_from_uuid, generate_new_uuid
-from tests.test_server.fixtures.factories.base import random_datetime, random_string
+from tests.test_server.fixtures.factories.base import random_string
 from tests.test_server.fixtures.factories.job import create_job
 from tests.test_server.fixtures.factories.job_type import create_job_type
 from tests.test_server.fixtures.factories.location import create_location
@@ -26,8 +26,9 @@ if TYPE_CHECKING:
 def run_factory(**kwargs):
     created_at = kwargs.pop("created_at", None)
     run_id = generate_new_uuid(created_at)
+    created_at = extract_timestamp_from_uuid(run_id)
     data = {
-        "created_at": extract_timestamp_from_uuid(run_id),
+        "created_at": created_at,
         "id": run_id,
         "job_id": randint(0, 10000000),
         "parent_run_id": generate_new_uuid(),
@@ -36,12 +37,13 @@ def run_factory(**kwargs):
         "attempt": random_string(16),
         "persistent_log_url": random_string(32),
         "running_log_url": random_string(32),
-        "started_at": random_datetime(),
+        "started_at": created_at + timedelta(seconds=randint(1, 10)),
         "started_by_user_id": None,
         "start_reason": choice(list(RunStartReason)),
-        "ended_at": random_datetime(),
+        "ended_at": created_at + timedelta(seconds=randint(10, 3600)),
         "end_reason": random_string(8),
-        "expected_start_at": random_datetime(),
+        "expected_start_at": created_at,
+        "expected_end_at": created_at + timedelta(seconds=10),
     }
     data.update(kwargs)
     return Run(**data)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Add [BRIN](https://www.postgresql.org/docs/current/brin.html) indexes over `run.started_at` and `run.ended_at` columns, as values here are mostly increasing, and index is very lightweight (just 48kb for 500k rows).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `mddocs/docs/changelog/next_release/<pull request or issue id>.<change type>.md` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
