### PR TITLE
[DOP-26672] Relax filters on GET /v1/runs

### DIFF
--- a/data_rentgen/server/schemas/v1/run.py
+++ b/data_rentgen/server/schemas/v1/run.py
@@ -14,7 +14,6 @@ from pydantic import (
     ValidationInfo,
     field_serializer,
     field_validator,
-    model_validator,
 )
 
 from data_rentgen.server.schemas.v1.job_response import JobResponseV1
@@ -224,19 +223,3 @@ class RunsPaginateQueryV1(PaginateQueryV1):
             msg = "'since' should be less than 'until'"
             raise ValueError(msg)
         return value
-
-    @model_validator(mode="after")
-    def _check_fields(self):
-        if not any([self.since, self.run_id, self.job_id, self.parent_run_id, self.search_query]):
-            msg = "input should contain either 'since', 'run_id', 'job_id', 'parent_run_id' or 'search_query' field"
-            raise ValueError(msg)
-        if self.job_id and not self.since:
-            msg = "'job_id' can be passed only with 'since'"
-            raise ValueError(msg)
-        if self.parent_run_id and not self.since:
-            msg = "'parent_run_id' can be passed only with 'since'"
-            raise ValueError(msg)
-        if self.search_query and not self.since:
-            msg = "'search_query' can be passed only with 'since'"
-            raise ValueError(msg)
-        return self

--- a/mddocs/docs/changelog/next_release/495.improvement.md
+++ b/mddocs/docs/changelog/next_release/495.improvement.md
@@ -1,0 +1,1 @@
+Relax filters on ``GET /v1/runs`` endpoint - ``since`` is not mandatory anymore.

--- a/tests/test_server/test_runs/test_get_runs.py
+++ b/tests/test_server/test_runs/test_get_runs.py
@@ -14,42 +14,23 @@ from tests.test_server.utils.enrich import enrich_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
-
-async def test_get_runs_missing_fields(
-    test_client: AsyncClient,
-    mocked_user: MockedUser,
-):
-    response = await test_client.get(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
-    )
-
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
-    assert response.json() == {
-        "error": {
-            "code": "invalid_request",
-            "message": "Invalid request",
-            "details": [
-                {
-                    "location": ["query"],
-                    "code": "value_error",
-                    "message": "Value error, input should contain either 'since', 'run_id', 'job_id', 'parent_run_id' or 'search_query' field",
-                    "context": {},
-                    "input": {
-                        "job_id": [],
-                        "job_location_id": [],
-                        "job_type": [],
-                        "page_size": 20,
-                        "page": 1,
-                        "parent_run_id": [],
-                        "run_id": [],
-                        "started_by_user": [],
-                        "status": [],
-                    },
-                },
-            ],
-        },
-    }
+EMPTY_STATS = {
+    "inputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+    "outputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+    "operations": {
+        "total_operations": 0,
+    },
+}
 
 
 async def test_get_runs_by_run_id_until_less_than_since(
@@ -83,6 +64,107 @@ async def test_get_runs_by_run_id_until_less_than_since(
                 },
             ],
         },
+    }
+
+
+async def test_get_runs_no_filters(
+    test_client: AsyncClient,
+    runs: list[Run],
+    mocked_user: MockedUser,
+    async_session: AsyncSession,
+):
+    runs = await enrich_runs(runs, async_session)
+
+    response = await test_client.get(
+        "v1/runs",
+        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "meta": {
+            "page": 1,
+            "page_size": 20,
+            "total_count": len(runs),
+            "pages_count": 1,
+            "has_next": False,
+            "has_previous": False,
+            "next_page": None,
+            "previous_page": None,
+        },
+        "items": [
+            {
+                "id": str(run.id),
+                "data": run_to_json(run),
+                "job": job_to_json(run.job),
+                "statistics": EMPTY_STATS,
+            }
+            for run in sorted(runs, key=lambda x: (x.id, x.created_at), reverse=True)
+        ],
+    }
+
+    response = await test_client.get(
+        "v1/runs",
+        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
+        params={
+            "page": 1,
+            "page_size": 2,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "meta": {
+            "page": 1,
+            "page_size": 2,
+            "total_count": len(runs),
+            "pages_count": len(runs) // 2,
+            "has_next": True,
+            "has_previous": False,
+            "next_page": 2,
+            "previous_page": None,
+        },
+        "items": [
+            {
+                "id": str(run.id),
+                "data": run_to_json(run),
+                "job": job_to_json(run.job),
+                "statistics": EMPTY_STATS,
+            }
+            for run in sorted(runs, key=lambda x: (x.id, x.created_at), reverse=True)[:2]
+        ],
+    }
+
+    response = await test_client.get(
+        "v1/runs",
+        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
+        params={
+            "page": 2,
+            "page_size": 2,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "meta": {
+            "page": 2,
+            "page_size": 2,
+            "total_count": len(runs),
+            "pages_count": len(runs) // 2,
+            "has_next": True,
+            "has_previous": True,
+            "next_page": 3,
+            "previous_page": 1,
+        },
+        "items": [
+            {
+                "id": str(run.id),
+                "data": run_to_json(run),
+                "job": job_to_json(run.job),
+                "statistics": EMPTY_STATS,
+            }
+            for run in sorted(runs, key=lambda x: (x.id, x.created_at), reverse=True)[2:4]
+        ],
     }
 
 
@@ -120,25 +202,9 @@ async def test_get_runs_with_since(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
-            for run in sorted(runs, key=lambda x: (x.created_at, x.id), reverse=True)
+            for run in sorted(runs, key=lambda x: (x.id, x.created_at), reverse=True)
         ],
     }
 
@@ -152,14 +218,13 @@ async def test_get_runs_with_until(
     since = min(run.created_at for run in runs)
     until = since + timedelta(seconds=1)
 
-    selected_runs = [run for run in runs if since <= run.created_at <= until]
-    selected_runs = await enrich_runs(selected_runs, async_session)
+    selected_runs = [run for run in runs if run.created_at <= until]
+    runs = await enrich_runs(selected_runs, async_session)
 
     response = await test_client.get(
         "v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             "until": until.isoformat(),
         },
     )
@@ -169,7 +234,7 @@ async def test_get_runs_with_until(
         "meta": {
             "page": 1,
             "page_size": 20,
-            "total_count": len(selected_runs),
+            "total_count": len(runs),
             "pages_count": 1,
             "has_next": False,
             "has_previous": False,
@@ -181,25 +246,9 @@ async def test_get_runs_with_until(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
-            for run in sorted(selected_runs, key=lambda x: (x.created_at, x.id), reverse=True)
+            for run in sorted(runs, key=lambda x: (x.id, x.created_at), reverse=True)
         ],
     }
 
@@ -218,13 +267,11 @@ async def test_get_runs_with_job_type(
         ],
         async_session,
     )
-    since = min(run.created_at for run in runs)
 
     response = await test_client.get(
         "/v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             "job_type": "SPARK_APPLICATION",
         },
     )
@@ -239,30 +286,14 @@ async def test_get_runs_with_job_type(
             "page_size": 20,
             "pages_count": 1,
             "previous_page": None,
-            "total_count": 2,
+            "total_count": len(runs),
         },
         "items": [
             {
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
             for run in runs
         ],
@@ -272,7 +303,6 @@ async def test_get_runs_with_job_type(
         "/v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             "job_type": ["SPARK_APPLICATION"],
             # multiple filters
             "search_query": "0002",
@@ -296,23 +326,7 @@ async def test_get_runs_with_job_type(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
             for run in runs[:1]
         ],
@@ -333,13 +347,11 @@ async def test_get_runs_with_status(
         ],
         async_session,
     )
-    since = min(run.created_at for run in runs)
 
     response = await test_client.get(
         "/v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             "status": ["SUCCEEDED", "STARTED"],
         },
     )
@@ -354,30 +366,14 @@ async def test_get_runs_with_status(
             "page_size": 20,
             "pages_count": 1,
             "previous_page": None,
-            "total_count": 2,
+            "total_count": len(runs),
         },
         "items": [
             {
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
             for run in runs
         ],
@@ -387,7 +383,6 @@ async def test_get_runs_with_status(
         "/v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             "status": ["SUCCEEDED", "STARTED"],
             "search_query": "dag",
         },
@@ -410,23 +405,7 @@ async def test_get_runs_with_status(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
             for run in runs[:1]
         ],
@@ -453,7 +432,6 @@ async def test_get_runs_with_started_at(
         "/v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": runs[0].created_at.isoformat(),
             "started_since": runs[1].started_at.isoformat(),
             "started_until": runs[2].started_at.isoformat(),
         },
@@ -476,23 +454,7 @@ async def test_get_runs_with_started_at(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
             # runs sorted by id in descending order
             for run in [runs[2], runs[1]]
@@ -520,7 +482,6 @@ async def test_get_runs_with_ended_at(
         "/v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": runs[0].created_at.isoformat(),
             "ended_since": runs[1].ended_at.isoformat(),
             "ended_until": runs[3].ended_at.isoformat(),
         },
@@ -543,23 +504,7 @@ async def test_get_runs_with_ended_at(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
             # runs sorted by id in descending order
             for run in [runs[3], runs[1]]
@@ -581,14 +526,12 @@ async def test_get_runs_with_location_id(
         ],
         async_session,
     )
-    since = min(run.created_at for run in runs)
     job = runs[0].job
 
     response = await test_client.get(
         "/v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             "job_location_id": job.location_id,
         },
     )
@@ -603,30 +546,14 @@ async def test_get_runs_with_location_id(
             "page_size": 20,
             "pages_count": 1,
             "previous_page": None,
-            "total_count": 2,
+            "total_count": len(runs),
         },
         "items": [
             {
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
             for run in runs
         ],
@@ -636,7 +563,6 @@ async def test_get_runs_with_location_id(
         "/v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             "job_location_id": [job.location_id],
             # test multiple filters
             "search_query": "0002",
@@ -660,23 +586,7 @@ async def test_get_runs_with_location_id(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
             for run in runs[:1]
         ],
@@ -697,14 +607,12 @@ async def test_get_runs_with_started_by_user(
         ],
         async_session,
     )
-    since = min(run.created_at for run in runs)
     started_by_user = runs[0].started_by_user
 
     response = await test_client.get(
         "/v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             "started_by_user": started_by_user.name,
         },
     )
@@ -719,30 +627,14 @@ async def test_get_runs_with_started_by_user(
             "page_size": 20,
             "pages_count": 1,
             "previous_page": None,
-            "total_count": 2,
+            "total_count": len(runs),
         },
         "items": [
             {
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
             for run in runs
         ],
@@ -752,7 +644,6 @@ async def test_get_runs_with_started_by_user(
         "/v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             "started_by_user": [started_by_user.name],
             # test multiple filters
             "search_query": "0002",
@@ -776,23 +667,7 @@ async def test_get_runs_with_started_by_user(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
             for run in runs[:1]
         ],

--- a/tests/test_server/test_runs/test_get_runs_by_id.py
+++ b/tests/test_server/test_runs/test_get_runs_by_id.py
@@ -13,6 +13,24 @@ from tests.test_server.utils.lineage_result import LineageResult
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
+EMPTY_STATS = {
+    "inputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+    "outputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+    "operations": {
+        "total_operations": 0,
+    },
+}
+
 
 async def test_get_runs_by_unknown_id(
     test_client: AsyncClient,
@@ -72,23 +90,7 @@ async def test_get_runs_by_one_id(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             },
         ],
     }
@@ -126,23 +128,7 @@ async def test_get_runs_by_multiple_ids(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
             for run in sorted(selected_runs, key=lambda x: (x.created_at, x.id), reverse=True)
         ],

--- a/tests/test_server/test_runs/test_get_runs_by_job_id.py
+++ b/tests/test_server/test_runs/test_get_runs_by_job_id.py
@@ -12,58 +12,35 @@ from tests.test_server.utils.enrich import enrich_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
-
-async def test_get_runs_by_job_id_missing_since(
-    test_client: AsyncClient,
-    new_run: Run,
-    mocked_user: MockedUser,
-):
-    response = await test_client.get(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
-        params={
-            "job_id": new_run.job_id,
-        },
-    )
-
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
-    assert response.json() == {
-        "error": {
-            "code": "invalid_request",
-            "message": "Invalid request",
-            "details": [
-                {
-                    "location": ["query"],
-                    "code": "value_error",
-                    "message": "Value error, 'job_id' can be passed only with 'since'",
-                    "context": {},
-                    "input": {
-                        "job_id": [str(new_run.job_id)],
-                        "job_location_id": [],
-                        "job_type": [],
-                        "page_size": 20,
-                        "page": 1,
-                        "parent_run_id": [],
-                        "run_id": [],
-                        "started_by_user": [],
-                        "status": [],
-                    },
-                },
-            ],
-        },
-    }
+EMPTY_STATS = {
+    "inputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+    "outputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+    "operations": {
+        "total_operations": 0,
+    },
+}
 
 
 async def test_get_runs_by_unknown_job_id(
     test_client: AsyncClient,
     new_run: Run,
+    runs_with_same_parent: list[Run],
     mocked_user: MockedUser,
 ):
     response = await test_client.get(
         "v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": new_run.created_at.isoformat(),
             "job_id": new_run.job_id,
         },
     )
@@ -100,12 +77,10 @@ async def test_get_runs_by_job_id(
         async_session,
     )
 
-    since = min(run.created_at for run in selected_runs)
     response = await test_client.get(
         "v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             "job_id": selected_job.id,
         },
     )
@@ -127,25 +102,53 @@ async def test_get_runs_by_job_id(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
-            for run in sorted(selected_runs, key=lambda x: (x.created_at, x.id), reverse=True)
+            for run in sorted(selected_runs, key=lambda x: (x.id, x.created_at), reverse=True)
+        ],
+    }
+
+
+async def test_get_runs_by_job_id_with_since(
+    test_client: AsyncClient,
+    runs_with_same_job: list[Run],
+    async_session: AsyncSession,
+    mocked_user: MockedUser,
+):
+    since = min(run.created_at for run in runs_with_same_job) + timedelta(seconds=1)
+
+    selected_runs = [run for run in runs_with_same_job if since <= run.created_at]
+    selected_runs = await enrich_runs(selected_runs, async_session)
+
+    response = await test_client.get(
+        "v1/runs",
+        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
+        params={
+            "job_id": selected_runs[0].job_id,
+            "since": since.isoformat(),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "meta": {
+            "page": 1,
+            "page_size": 20,
+            "total_count": len(selected_runs),
+            "pages_count": 1,
+            "has_next": False,
+            "has_previous": False,
+            "next_page": None,
+            "previous_page": None,
+        },
+        "items": [
+            {
+                "id": str(run.id),
+                "data": run_to_json(run),
+                "job": job_to_json(run.job),
+                "statistics": EMPTY_STATS,
+            }
+            for run in sorted(selected_runs, key=lambda x: (x.id, x.created_at), reverse=True)
         ],
     }
 
@@ -159,7 +162,7 @@ async def test_get_runs_by_job_id_with_until(
     since = min(run.created_at for run in runs_with_same_job)
     until = since + timedelta(seconds=1)
 
-    selected_runs = [run for run in runs_with_same_job if since <= run.created_at <= until]
+    selected_runs = [run for run in runs_with_same_job if run.created_at <= until]
     selected_runs = await enrich_runs(selected_runs, async_session)
 
     response = await test_client.get(
@@ -167,7 +170,6 @@ async def test_get_runs_by_job_id_with_until(
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
             "job_id": selected_runs[0].job_id,
-            "since": since.isoformat(),
             "until": until.isoformat(),
         },
     )
@@ -189,24 +191,8 @@ async def test_get_runs_by_job_id_with_until(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
-            for run in sorted(selected_runs, key=lambda x: (x.created_at, x.id), reverse=True)
+            for run in sorted(selected_runs, key=lambda x: (x.id, x.created_at), reverse=True)
         ],
     }

--- a/tests/test_server/test_runs/test_get_runs_by_parent_run_id.py
+++ b/tests/test_server/test_runs/test_get_runs_by_parent_run_id.py
@@ -12,46 +12,23 @@ from tests.test_server.utils.enrich import enrich_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
-
-async def test_get_runs_by_parent_run_id_missing_since(
-    test_client: AsyncClient,
-    new_run: Run,
-    mocked_user: MockedUser,
-):
-    response = await test_client.get(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
-        params={
-            "parent_run_id": str(new_run.parent_run_id),
-        },
-    )
-
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
-    assert response.json() == {
-        "error": {
-            "code": "invalid_request",
-            "message": "Invalid request",
-            "details": [
-                {
-                    "location": ["query"],
-                    "code": "value_error",
-                    "message": "Value error, 'parent_run_id' can be passed only with 'since'",
-                    "context": {},
-                    "input": {
-                        "job_id": [],
-                        "job_location_id": [],
-                        "job_type": [],
-                        "page_size": 20,
-                        "page": 1,
-                        "parent_run_id": [str(new_run.parent_run_id)],
-                        "run_id": [],
-                        "started_by_user": [],
-                        "status": [],
-                    },
-                },
-            ],
-        },
-    }
+EMPTY_STATS = {
+    "inputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+    "outputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+    "operations": {
+        "total_operations": 0,
+    },
+}
 
 
 async def test_get_runs_by_parent_run_id_unknown(
@@ -93,14 +70,12 @@ async def test_get_runs_by_parent_run_id(
     runs_with_same_parent: list[Run],
     mocked_user: MockedUser,
 ) -> None:
-    since = min(run.created_at for run in runs_with_same_parent)
     runs = await enrich_runs(runs_with_same_parent, async_session)
 
     response = await test_client.get(
         "v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             "parent_run_id": str(runs_with_same_parent[0].parent_run_id),
         },
     )
@@ -110,7 +85,7 @@ async def test_get_runs_by_parent_run_id(
         "meta": {
             "page": 1,
             "page_size": 20,
-            "total_count": 5,
+            "total_count": len(runs),
             "pages_count": 1,
             "has_next": False,
             "has_previous": False,
@@ -122,25 +97,53 @@ async def test_get_runs_by_parent_run_id(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
-            for run in sorted(runs, key=lambda x: (x.created_at, x.id), reverse=True)
+            for run in sorted(runs, key=lambda x: (x.id, x.created_at), reverse=True)
+        ],
+    }
+
+
+async def test_get_runs_by_parent_run_id_with_since(
+    test_client: AsyncClient,
+    async_session: AsyncSession,
+    runs_with_same_parent: list[Run],
+    mocked_user: MockedUser,
+) -> None:
+    since = min(run.created_at for run in runs_with_same_parent) + timedelta(seconds=1)
+
+    selected_runs = [run for run in runs_with_same_parent if since <= run.created_at]
+    runs = await enrich_runs(selected_runs, async_session)
+
+    response = await test_client.get(
+        "v1/runs",
+        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
+        params={
+            "since": since.isoformat(),
+            "parent_run_id": str(runs[0].parent_run_id),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "meta": {
+            "page": 1,
+            "page_size": 20,
+            "total_count": len(runs),
+            "pages_count": 1,
+            "has_next": False,
+            "has_previous": False,
+            "next_page": None,
+            "previous_page": None,
+        },
+        "items": [
+            {
+                "id": str(run.id),
+                "data": run_to_json(run),
+                "job": job_to_json(run.job),
+                "statistics": EMPTY_STATS,
+            }
+            for run in sorted(runs, key=lambda x: (x.id, x.created_at), reverse=True)
         ],
     }
 
@@ -154,16 +157,15 @@ async def test_get_runs_by_parent_run_id_with_until(
     since = min(run.created_at for run in runs_with_same_parent)
     until = since + timedelta(seconds=1)
 
-    selected_runs = [run for run in runs_with_same_parent if since <= run.created_at <= until]
+    selected_runs = [run for run in runs_with_same_parent if run.created_at <= until]
     runs = await enrich_runs(selected_runs, async_session)
 
     response = await test_client.get(
         "v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             "until": until.isoformat(),
-            "parent_run_id": str(runs_with_same_parent[0].parent_run_id),
+            "parent_run_id": str(runs[0].parent_run_id),
         },
     )
 
@@ -172,7 +174,7 @@ async def test_get_runs_by_parent_run_id_with_until(
         "meta": {
             "page": 1,
             "page_size": 20,
-            "total_count": 2,
+            "total_count": len(runs),
             "pages_count": 1,
             "has_next": False,
             "has_previous": False,
@@ -184,24 +186,8 @@ async def test_get_runs_by_parent_run_id_with_until(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
-            for run in sorted(runs, key=lambda x: (x.created_at, x.id), reverse=True)
+            for run in sorted(runs, key=lambda x: (x.id, x.created_at), reverse=True)
         ],
     }

--- a/tests/test_server/test_runs/test_search_runs.py
+++ b/tests/test_server/test_runs/test_search_runs.py
@@ -11,47 +11,23 @@ from tests.test_server.utils.enrich import enrich_runs
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
-
-async def test_search_runs_missing_since(
-    test_client: AsyncClient,
-    new_run: Run,
-    mocked_user: MockedUser,
-):
-    response = await test_client.get(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
-        params={
-            "search_query": new_run.external_id,
-        },
-    )
-
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
-    assert response.json() == {
-        "error": {
-            "code": "invalid_request",
-            "message": "Invalid request",
-            "details": [
-                {
-                    "location": ["query"],
-                    "code": "value_error",
-                    "message": "Value error, 'search_query' can be passed only with 'since'",
-                    "context": {},
-                    "input": {
-                        "job_id": [],
-                        "job_location_id": [],
-                        "job_type": [],
-                        "page_size": 20,
-                        "page": 1,
-                        "parent_run_id": [],
-                        "run_id": [],
-                        "search_query": new_run.external_id,
-                        "started_by_user": [],
-                        "status": [],
-                    },
-                },
-            ],
-        },
-    }
+EMPTY_STATS = {
+    "inputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+    "outputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+    "operations": {
+        "total_operations": 0,
+    },
+}
 
 
 async def test_search_runs_by_external_id(
@@ -68,13 +44,11 @@ async def test_search_runs_by_external_id(
         ],
         async_session,
     )
-    since = min(run.created_at for run in runs)
 
     response = await test_client.get(
         "/v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             # search by word prefix
             "search_query": "1638922",
         },
@@ -97,23 +71,7 @@ async def test_search_runs_by_external_id(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
             for run in runs
         ],
@@ -137,7 +95,6 @@ async def test_search_runs_by_job_name(
         "/v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": run.created_at.isoformat(),
             "search_query": "airflow_dag",
         },
     )
@@ -159,23 +116,7 @@ async def test_search_runs_by_job_name(
                 "id": str(run.id),
                 "data": run_to_json(run),
                 "job": job_to_json(run.job),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "operations": {
-                        "total_operations": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             },
         ],
     }
@@ -186,13 +127,10 @@ async def test_search_runs_no_results(
     runs_search: dict[str, Run],
     mocked_user: MockedUser,
 ) -> None:
-    since = min(run.created_at for run in runs_search.values())
-
     response = await test_client.get(
         "/v1/runs",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             "search_query": "not-found",
         },
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

`since` filter was required to avoid scanning all partitions. But PostgreSQL is smart enough to scan partitions in parallel, and all fields used in `GET /v1/runs` query are covered with index. So query time is usually a fraction of millisecond which is enough for our cases.

```
explain analyze select * from run order by id desc, created_at desc limit 10 offset 10;
                                                                                QUERY PLAN                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=5.23..6.61 rows=10 width=503) (actual time=0.121..0.136 rows=10 loops=1)
   ->  Merge Append  (cost=3.84..1044278.41 rows=7535829 width=503) (actual time=0.080..0.134 rows=20 loops=1)
         Sort Key: run.id DESC, run.created_at DESC
         ->  Index Scan Backward using run_y2020_pkey on run_y2020 run_1  (cost=0.12..2.47 rows=1 width=508) (actual time=0.006..0.006 rows=0 loops=1)
         ->  Index Scan Backward using run_y2021_pkey on run_y2021 run_2  (cost=0.12..2.40 rows=1 width=508) (actual time=0.002..0.002 rows=0 loops=1)
         ->  Index Scan Backward using run_y2022_pkey on run_y2022 run_3  (cost=0.12..2.64 rows=1 width=538) (actual time=0.001..0.001 rows=0 loops=1)
         ->  Index Scan Backward using run_y2023_pkey on run_y2023 run_4  (cost=0.12..2.37 rows=1 width=537) (actual time=0.001..0.001 rows=0 loops=1)
         ->  Index Scan Backward using run_y2024_pkey on run_y2024 run_5  (cost=0.12..2.31 rows=1 width=537) (actual time=0.002..0.002 rows=0 loops=1)
         ->  Index Scan Backward using run_y2025_pkey on run_y2025 run_6  (cost=0.14..6.24 rows=17 width=505) (actual time=0.010..0.010 rows=1 loops=1)
         ->  Index Scan Backward using run_y2026_m01_pkey on run_y2026_m01 run_7  (cost=0.12..3.01 rows=1 width=525) (actual time=0.001..0.001 rows=0 loops=1)
         ->  Index Scan Backward using run_y2026_m02_pkey on run_y2026_m02 run_8  (cost=0.43..119696.35 rows=1432845 width=493) (actual time=0.006..0.006 rows=1 loops=1)
         ->  Index Scan Backward using run_y2026_m03_pkey on run_y2026_m03 run_9  (cost=0.43..141754.45 rows=1315793 width=500) (actual time=0.009..0.009 rows=1 loops=1)
         ->  Index Scan Backward using run_y2026_m04_pkey on run_y2026_m04 run_10  (cost=0.43..199226.52 rows=1611314 width=492) (actual time=0.014..0.015 rows=1 loops=1)
         ->  Index Scan Backward using run_y2026_m05_pkey on run_y2026_m05 run_11  (cost=0.43..194949.68 rows=1487328 width=502) (actual time=0.006..0.006 rows=1 loops=1)
         ->  Index Scan Backward using run_y2026_m06_pkey on run_y2026_m06 run_12  (cost=0.43..153344.38 rows=1141267 width=526) (actual time=0.007..0.007 rows=1 loops=1)
         ->  Index Scan Backward using run_y2026_m07_pkey on run_y2026_m07 run_13  (cost=0.42..54145.16 rows=547258 width=522) (actual time=0.008..0.059 rows=20 loops=1)
         ->  Index Scan Backward using run_y2026_m08_pkey on run_y2026_m08 run_14  (cost=0.12..3.14 rows=1 width=478) (actual time=0.006..0.006 rows=0 loops=1)
 Planning Time: 0.584 ms
 Execution Time: 0.220 ms
```

```
explain analyze select * from run where job_id=162120 order by id desc, created_at desc limit 10;
                                                                             QUERY PLAN                                                                              
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=417.14..417.17 rows=10 width=505) (actual time=0.101..0.104 rows=6 loops=1)
   ->  Sort  (cost=417.14..417.85 rows=284 width=505) (actual time=0.100..0.102 rows=6 loops=1)
         Sort Key: run.id DESC, run.created_at DESC
         Sort Method: quicksort  Memory: 28kB
         ->  Append  (cost=0.00..411.01 rows=284 width=505) (actual time=0.017..0.093 rows=6 loops=1)
               ->  Seq Scan on run_y2020 run_1  (cost=0.00..0.00 rows=1 width=508) (actual time=0.005..0.005 rows=0 loops=1)
                     Filter: (job_id = 162120)
               ->  Seq Scan on run_y2021 run_2  (cost=0.00..0.00 rows=1 width=508) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (job_id = 162120)
               ->  Seq Scan on run_y2022 run_3  (cost=0.00..0.00 rows=1 width=538) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (job_id = 162120)
               ->  Seq Scan on run_y2023 run_4  (cost=0.00..0.00 rows=1 width=537) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (job_id = 162120)
               ->  Seq Scan on run_y2024 run_5  (cost=0.00..0.00 rows=1 width=537) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (job_id = 162120)
               ->  Seq Scan on run_y2025 run_6  (cost=0.00..2.21 rows=6 width=505) (actual time=0.006..0.011 rows=6 loops=1)
                     Filter: (job_id = 162120)
                     Rows Removed by Filter: 11
               ->  Seq Scan on run_y2026_m01 run_7  (cost=0.00..0.00 rows=1 width=525) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (job_id = 162120)
               ->  Index Scan using run_y2026_m02_job_id_idx on run_y2026_m02 run_8  (cost=0.43..69.66 rows=45 width=493) (actual time=0.017..0.017 rows=0 loops=1)
                     Index Cond: (job_id = 162120)
               ->  Index Scan using run_y2026_m03_job_id_idx on run_y2026_m03 run_9  (cost=0.43..69.68 rows=45 width=500) (actual time=0.007..0.007 rows=0 loops=1)
                     Index Cond: (job_id = 162120)
               ->  Index Scan using run_y2026_m04_job_id_idx on run_y2026_m04 run_10  (cost=0.43..73.20 rows=53 width=492) (actual time=0.006..0.006 rows=0 loops=1)
                     Index Cond: (job_id = 162120)
               ->  Index Scan using run_y2026_m05_job_id_idx on run_y2026_m05 run_11  (cost=0.43..72.88 rows=50 width=502) (actual time=0.018..0.018 rows=0 loops=1)
                     Index Cond: (job_id = 162120)
               ->  Index Scan using run_y2026_m06_job_id_idx on run_y2026_m06 run_12  (cost=0.43..80.67 rows=52 width=526) (actual time=0.009..0.009 rows=0 loops=1)
                     Index Cond: (job_id = 162120)
               ->  Index Scan using run_y2026_m07_job_id_idx on run_y2026_m07 run_13  (cost=0.42..41.28 rows=26 width=522) (actual time=0.009..0.009 rows=0 loops=1)
                     Index Cond: (job_id = 162120)
               ->  Seq Scan on run_y2026_m08 run_14  (cost=0.00..0.00 rows=1 width=478) (actual time=0.002..0.002 rows=0 loops=1)
                     Filter: (job_id = 162120)
 Planning Time: 0.609 ms
 Execution Time: 0.177 ms
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `mddocs/docs/changelog/next_release/<pull request or issue id>.<change type>.md` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
