### PR TITLE
[DOP-26672] Relax filters on GET /v1/operations

### DIFF
--- a/data_rentgen/server/schemas/v1/operation.py
+++ b/data_rentgen/server/schemas/v1/operation.py
@@ -137,7 +137,4 @@ class OperationQueryV1(PaginateQueryV1):
         if not any([self.operation_id, self.run_id]):
             msg = "input should contain either 'run_id' or 'operation_id' field"
             raise ValueError(msg)
-        if self.run_id and not self.since:
-            msg = "'run_id' can be passed only with 'since'"
-            raise ValueError(msg)
         return self

--- a/mddocs/docs/changelog/next_release/496.improvement.md
+++ b/mddocs/docs/changelog/next_release/496.improvement.md
@@ -1,0 +1,1 @@
+Allow passing `run_id` filter to `GET /v1/operations` endpoint without `since` filter.

--- a/tests/test_server/test_operations/test_get_operations.py
+++ b/tests/test_server/test_operations/test_get_operations.py
@@ -3,12 +3,27 @@ from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
-from uuid6 import uuid7
 
+from data_rentgen.db.models import Run
 from data_rentgen.utils.uuid import generate_new_uuid
 from tests.fixtures.mocks import MockedUser
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
+
+EMPTY_STATS = {
+    "inputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+    "outputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+}
 
 
 async def test_get_operations_missing_fields(test_client: AsyncClient, mocked_user: MockedUser):
@@ -42,6 +57,7 @@ async def test_get_operations_missing_fields(test_client: AsyncClient, mocked_us
 
 async def test_get_operations_until_less_than_since(
     test_client: AsyncClient,
+    new_run: Run,
     mocked_user: MockedUser,
 ):
     since = datetime.now(tz=timezone.utc)
@@ -52,7 +68,7 @@ async def test_get_operations_until_less_than_since(
         params={
             "since": since.isoformat(),
             "until": until.isoformat(),
-            "run_id": str(uuid7()),
+            "run_id": str(new_run.id),
         },
     )
 

--- a/tests/test_server/test_operations/test_get_operations_by_id.py
+++ b/tests/test_server/test_operations/test_get_operations_by_id.py
@@ -11,6 +11,21 @@ from tests.test_server.utils.lineage_result import LineageResult
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
+EMPTY_STATS = {
+    "inputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+    "outputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+}
+
 
 async def test_get_operations_by_unknown_id(
     test_client: AsyncClient,
@@ -66,20 +81,7 @@ async def test_get_operations_by_one_id(
             {
                 "id": str(operation.id),
                 "data": operation_to_json(operation),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             },
         ],
     }
@@ -117,20 +119,7 @@ async def test_get_operations_by_multiple_ids(
             {
                 "id": str(operation.id),
                 "data": operation_to_json(operation),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
             for operation in sorted(selected_operations, key=lambda x: (x.created_at, x.id.int), reverse=True)
         ],
@@ -241,20 +230,7 @@ async def test_get_operations_by_one_id_with_sql_query(
             {
                 "id": str(operation_with_sql_query.id),
                 "data": operation_to_json(operation_with_sql_query),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             },
         ],
     }

--- a/tests/test_server/test_operations/test_get_operations_by_run_id.py
+++ b/tests/test_server/test_operations/test_get_operations_by_run_id.py
@@ -10,41 +10,20 @@ from tests.test_server.utils.convert_to_json import operation_to_json
 
 pytestmark = [pytest.mark.server, pytest.mark.asyncio]
 
-
-async def test_get_operations_missing_since(
-    test_client: AsyncClient,
-    new_operation: Operation,
-    mocked_user: MockedUser,
-):
-    response = await test_client.get(
-        "v1/operations",
-        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
-        params={
-            "run_id": str(new_operation.run_id),
-        },
-    )
-
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
-    assert response.json() == {
-        "error": {
-            "code": "invalid_request",
-            "message": "Invalid request",
-            "details": [
-                {
-                    "location": ["query"],
-                    "code": "value_error",
-                    "message": "Value error, 'run_id' can be passed only with 'since'",
-                    "context": {},
-                    "input": {
-                        "page": 1,
-                        "page_size": 20,
-                        "run_id": [str(new_operation.run_id)],
-                        "operation_id": [],
-                    },
-                },
-            ],
-        },
-    }
+EMPTY_STATS = {
+    "inputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+    "outputs": {
+        "total_datasets": 0,
+        "total_bytes": 0,
+        "total_rows": 0,
+        "total_files": 0,
+    },
+}
 
 
 async def test_get_operations_by_unknown_run_id(
@@ -89,12 +68,10 @@ async def test_get_operations_by_run_id(
 
     selected_operations = [operation for operation in operations if operation.run_id == selected_run.id]
 
-    since = min(operation.created_at for operation in selected_operations)
     response = await test_client.get(
         "v1/operations",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
-            "since": since.isoformat(),
             "run_id": str(selected_run.id),
         },
     )
@@ -115,20 +92,47 @@ async def test_get_operations_by_run_id(
             {
                 "id": str(operation.id),
                 "data": operation_to_json(operation),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
+            }
+            for operation in sorted(selected_operations, key=lambda x: (x.created_at, x.id), reverse=True)
+        ],
+    }
+
+
+async def test_get_operations_by_run_id_with_since(
+    test_client: AsyncClient,
+    operations_with_same_run: list[Operation],
+    mocked_user: MockedUser,
+):
+    since = min(operation.created_at for operation in operations_with_same_run) + timedelta(seconds=1)
+    selected_operations = [operation for operation in operations_with_same_run if since <= operation.created_at]
+
+    response = await test_client.get(
+        "v1/operations",
+        headers={"Authorization": f"Bearer {mocked_user.access_token}"},
+        params={
+            "run_id": str(operations_with_same_run[0].run_id),
+            "since": since.isoformat(),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {
+        "meta": {
+            "page": 1,
+            "page_size": 20,
+            "total_count": len(selected_operations),
+            "pages_count": 1,
+            "has_next": False,
+            "has_previous": False,
+            "next_page": None,
+            "previous_page": None,
+        },
+        "items": [
+            {
+                "id": str(operation.id),
+                "data": operation_to_json(operation),
+                "statistics": EMPTY_STATS,
             }
             for operation in sorted(selected_operations, key=lambda x: (x.created_at, x.id), reverse=True)
         ],
@@ -140,19 +144,14 @@ async def test_get_operations_by_run_id_with_until(
     operations_with_same_run: list[Operation],
     mocked_user: MockedUser,
 ):
-    since = operations_with_same_run[0].created_at
-    until = since + timedelta(seconds=1)
-
-    selected_operations = [
-        operation for operation in operations_with_same_run if since <= operation.created_at <= until
-    ]
+    until = min(operation.created_at for operation in operations_with_same_run) + timedelta(seconds=1)
+    selected_operations = [operation for operation in operations_with_same_run if operation.created_at <= until]
 
     response = await test_client.get(
         "v1/operations",
         headers={"Authorization": f"Bearer {mocked_user.access_token}"},
         params={
             "run_id": str(operations_with_same_run[0].run_id),
-            "since": since.isoformat(),
             "until": until.isoformat(),
         },
     )
@@ -173,20 +172,7 @@ async def test_get_operations_by_run_id_with_until(
             {
                 "id": str(operation.id),
                 "data": operation_to_json(operation),
-                "statistics": {
-                    "inputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                    "outputs": {
-                        "total_datasets": 0,
-                        "total_bytes": 0,
-                        "total_rows": 0,
-                        "total_files": 0,
-                    },
-                },
+                "statistics": EMPTY_STATS,
             }
             for operation in sorted(selected_operations, key=lambda x: (x.created_at, x.id), reverse=True)
         ],


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

`since` filter was required to avoid scanning all partitions. But PostgreSQL is smart enough to scan partitions in parallel, and all fields used in `GET /v1/operations` query are covered with index. So query time is usually a fraction of millisecond which is enough for our cases.

```
explain analyze select * from operation where run_id='019f658c-2641-75b5-8765-e7635c83edbd'::uuid order by id desc, created_at desc limit 10;
                                                                                       QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=173.50..173.53 rows=10 width=180) (actual time=0.166..0.170 rows=10 loops=1)
   ->  Sort  (cost=173.50..176.89 rows=1356 width=180) (actual time=0.164..0.168 rows=10 loops=1)
         Sort Key: operation.id DESC, operation.created_at DESC
         Sort Method: top-N heapsort  Memory: 28kB
         ->  Append  (cost=0.00..144.20 rows=1356 width=180) (actual time=0.107..0.137 rows=31 loops=1)
               ->  Seq Scan on operation_y2020 operation_1  (cost=0.00..0.00 rows=1 width=149) (actual time=0.009..0.009 rows=0 loops=1)
                     Filter: (run_id = '019f658c-2641-75b5-8765-e7635c83edbd'::uuid)
               ->  Seq Scan on operation_y2021 operation_2  (cost=0.00..0.00 rows=1 width=149) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (run_id = '019f658c-2641-75b5-8765-e7635c83edbd'::uuid)
               ->  Seq Scan on operation_y2022 operation_3  (cost=0.00..0.00 rows=1 width=145) (actual time=0.002..0.002 rows=0 loops=1)
                     Filter: (run_id = '019f658c-2641-75b5-8765-e7635c83edbd'::uuid)
               ->  Seq Scan on operation_y2023 operation_4  (cost=0.00..0.00 rows=1 width=145) (actual time=0.002..0.002 rows=0 loops=1)
                     Filter: (run_id = '019f658c-2641-75b5-8765-e7635c83edbd'::uuid)
               ->  Seq Scan on operation_y2024 operation_5  (cost=0.00..0.00 rows=1 width=145) (actual time=0.002..0.002 rows=0 loops=1)
                     Filter: (run_id = '019f658c-2641-75b5-8765-e7635c83edbd'::uuid)
               ->  Seq Scan on operation_y2025 operation_6  (cost=0.00..1.09 rows=1 width=142) (actual time=0.012..0.012 rows=0 loops=1)
                     Filter: (run_id = '019f658c-2641-75b5-8765-e7635c83edbd'::uuid)
                     Rows Removed by Filter: 9
               ->  Seq Scan on operation_y2026_m01 operation_7  (cost=0.00..0.00 rows=1 width=150) (actual time=0.002..0.002 rows=0 loops=1)
                     Filter: (run_id = '019f658c-2641-75b5-8765-e7635c83edbd'::uuid)
               ->  Index Scan using operation_y2026_m02_run_id_idx on operation_y2026_m02 operation_8  (cost=0.43..12.61 rows=201 width=176) (actual time=0.021..0.021 rows=0 loops=1)
                     Index Cond: (run_id = '019f658c-2641-75b5-8765-e7635c83edbd'::uuid)
               ->  Index Scan using operation_y2026_m03_run_id_idx on operation_y2026_m03 operation_9  (cost=0.43..13.41 rows=229 width=181) (actual time=0.013..0.013 rows=0 loops=1)
                     Index Cond: (run_id = '019f658c-2641-75b5-8765-e7635c83edbd'::uuid)
               ->  Index Scan using operation_y2026_m04_run_id_idx on operation_y2026_m04 operation_10  (cost=0.43..13.91 rows=234 width=175) (actual time=0.012..0.012 rows=0 loops=1)
                     Index Cond: (run_id = '019f658c-2641-75b5-8765-e7635c83edbd'::uuid)
               ->  Index Scan using operation_y2026_m05_run_id_idx on operation_y2026_m05 operation_11  (cost=0.43..26.59 rows=315 width=181) (actual time=0.008..0.008 rows=0 loops=1)
                     Index Cond: (run_id = '019f658c-2641-75b5-8765-e7635c83edbd'::uuid)
               ->  Index Scan using operation_y2026_m06_run_id_idx on operation_y2026_m06 operation_12  (cost=0.43..60.99 rows=235 width=186) (actual time=0.009..0.009 rows=0 loops=1)
                     Index Cond: (run_id = '019f658c-2641-75b5-8765-e7635c83edbd'::uuid)
               ->  Index Scan using operation_y2026_m07_run_id_idx on operation_y2026_m07 operation_13  (cost=0.43..8.82 rows=134 width=181) (actual time=0.013..0.034 rows=31 loops=1)
                     Index Cond: (run_id = '019f658c-2641-75b5-8765-e7635c83edbd'::uuid)
               ->  Seq Scan on operation_y2026_m08 operation_14  (cost=0.00..0.00 rows=1 width=248) (actual time=0.003..0.003 rows=0 loops=1)
                     Filter: (run_id = '019f658c-2641-75b5-8765-e7635c83edbd'::uuid)
 Planning Time: 0.654 ms
 Execution Time: 0.268 ms
```

```
explain analyze select * from operation where id='019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid order by id desc, created_at desc limit 10;
                                                                                       QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=22.64..22.66 rows=10 width=168) (actual time=0.080..0.082 rows=1 loops=1)
   ->  Sort  (cost=22.64..22.67 rows=14 width=168) (actual time=0.080..0.081 rows=1 loops=1)
         Sort Key: operation.created_at DESC
         Sort Method: quicksort  Memory: 25kB
         ->  Append  (cost=0.00..22.37 rows=14 width=168) (actual time=0.073..0.076 rows=1 loops=1)
               ->  Seq Scan on operation_y2020 operation_1  (cost=0.00..0.00 rows=1 width=149) (actual time=0.005..0.005 rows=0 loops=1)
                     Filter: (id = '019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid)
               ->  Seq Scan on operation_y2021 operation_2  (cost=0.00..0.00 rows=1 width=149) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (id = '019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid)
               ->  Seq Scan on operation_y2022 operation_3  (cost=0.00..0.00 rows=1 width=145) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (id = '019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid)
               ->  Seq Scan on operation_y2023 operation_4  (cost=0.00..0.00 rows=1 width=145) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (id = '019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid)
               ->  Seq Scan on operation_y2024 operation_5  (cost=0.00..0.00 rows=1 width=145) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (id = '019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid)
               ->  Seq Scan on operation_y2025 operation_6  (cost=0.00..1.09 rows=1 width=142) (actual time=0.007..0.007 rows=0 loops=1)
                     Filter: (id = '019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid)
                     Rows Removed by Filter: 9
               ->  Seq Scan on operation_y2026_m01 operation_7  (cost=0.00..0.00 rows=1 width=150) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (id = '019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid)
               ->  Index Scan Backward using operation_y2026_m02_pkey on operation_y2026_m02 operation_8  (cost=0.56..3.58 rows=1 width=176) (actual time=0.013..0.013 rows=0 loops=1)
                     Index Cond: (id = '019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid)
               ->  Index Scan Backward using operation_y2026_m03_pkey on operation_y2026_m03 operation_9  (cost=0.43..3.45 rows=1 width=181) (actual time=0.007..0.007 rows=0 loops=1)
                     Index Cond: (id = '019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid)
               ->  Index Scan Backward using operation_y2026_m04_pkey on operation_y2026_m04 operation_10  (cost=0.56..3.58 rows=1 width=175) (actual time=0.006..0.006 rows=0 loops=1)
                     Index Cond: (id = '019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid)
               ->  Index Scan Backward using operation_y2026_m05_pkey on operation_y2026_m05 operation_11  (cost=0.56..3.58 rows=1 width=181) (actual time=0.006..0.006 rows=0 loops=1)
                     Index Cond: (id = '019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid)
               ->  Index Scan Backward using operation_y2026_m06_pkey on operation_y2026_m06 operation_12  (cost=0.56..3.58 rows=1 width=186) (actual time=0.007..0.007 rows=0 loops=1)
                     Index Cond: (id = '019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid)
               ->  Index Scan Backward using operation_y2026_m07_pkey on operation_y2026_m07 operation_13  (cost=0.43..3.45 rows=1 width=181) (actual time=0.016..0.016 rows=1 loops=1)
                     Index Cond: (id = '019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid)
               ->  Seq Scan on operation_y2026_m08 operation_14  (cost=0.00..0.00 rows=1 width=248) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (id = '019f6597-f38d-733e-9db7-d6ba5f61737c'::uuid)
 Planning Time: 0.531 ms
 Execution Time: 0.157 ms
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `mddocs/docs/changelog/next_release/<pull request or issue id>.<change type>.md` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
