### PR TITLE
[DOP-26672] Hint number of rows returned by fetch_bulk queries

### DIFF
--- a/data_rentgen/db/repositories/dataset.py
+++ b/data_rentgen/db/repositories/dataset.py
@@ -32,17 +32,21 @@ from data_rentgen.db.repositories.base import Repository
 from data_rentgen.db.utils.search import make_tsquery, ts_match, ts_rank
 from data_rentgen.dto import DatasetDTO, PaginationDTO
 
-fetch_bulk_query = select(Dataset).where(
-    tuple_(Dataset.location_id, Dataset.name_lower).in_(
-        select(
-            func.unnest(
-                cast(bindparam("location_ids"), ARRAY(Integer())),
-                cast(bindparam("names_lower"), ARRAY(String())),
-            )
-            .table_valued("location_id", "name_lower")
-            .render_derived(),
+fetch_bulk_query = (
+    select(Dataset)
+    .where(
+        tuple_(Dataset.location_id, Dataset.name_lower).in_(
+            select(
+                func.unnest(
+                    cast(bindparam("location_ids"), ARRAY(Integer())),
+                    cast(bindparam("names_lower"), ARRAY(String())),
+                )
+                .table_valued("location_id", "name_lower")
+                .render_derived(),
+            ),
         ),
-    ),
+    )
+    .limit(bindparam("limit"))
 )
 
 get_list_query = (
@@ -94,6 +98,7 @@ class DatasetRepository(Repository[Dataset]):
             {
                 "location_ids": [item.location.id for item in datasets_dto],
                 "names_lower": [item.name.lower() for item in datasets_dto],
+                "limit": len(datasets_dto),
             },
         )
         existing = {(dataset.location_id, dataset.name.lower()): dataset for dataset in scalars.all()}

--- a/data_rentgen/db/repositories/dataset_column_relation.py
+++ b/data_rentgen/db/repositories/dataset_column_relation.py
@@ -14,8 +14,10 @@ from data_rentgen.db.models import (
 from data_rentgen.db.repositories.base import Repository
 from data_rentgen.dto import ColumnLineageDTO
 
-get_fingerprints_query = select(DatasetColumnRelation.fingerprint.distinct()).where(
-    DatasetColumnRelation.fingerprint == any_(bindparam("fingerprints"))
+get_fingerprints_query = (
+    select(DatasetColumnRelation.fingerprint.distinct())
+    .where(DatasetColumnRelation.fingerprint == any_(bindparam("fingerprints")))
+    .limit(bindparam("limit"))
 )
 
 
@@ -27,18 +29,18 @@ class DatasetColumnRelationRepository(Repository[DatasetColumnRelation]):
         # small optimization to avoid creating the same relations over and over.
         # although we're using ON CONFLICT DO NOTHING, PG still has to perform index scans
         # and to get next sequence value for each row
-        fingerprints_to_create = await self._get_missing_fingerprints([item.fingerprint for item in items])
+        fingerprints_to_create = await self._get_missing_fingerprints({item.fingerprint for item in items})
         relations_to_create = [item for item in items if item.fingerprint in fingerprints_to_create]
 
         if relations_to_create:
             await self._create_dataset_column_relations_bulk(relations_to_create)
 
-    async def _get_missing_fingerprints(self, fingerprints: list[UUID]) -> set[UUID]:
-        existing = await self._session.execute(
+    async def _get_missing_fingerprints(self, fingerprints: set[UUID]) -> set[UUID]:
+        existing = await self._session.scalars(
             get_fingerprints_query,
-            {"fingerprints": fingerprints},
+            {"fingerprints": list(fingerprints), "limit": len(fingerprints)},
         )
-        return set(fingerprints) - set(existing.scalars().all())
+        return fingerprints - set(existing.all())
 
     async def _create_dataset_column_relations_bulk(self, items: list[ColumnLineageDTO]):
         # we don't have to return anything, so there is no need to use on_conflict_update.

--- a/data_rentgen/db/repositories/dataset_symlink.py
+++ b/data_rentgen/db/repositories/dataset_symlink.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Collection
+from uuid import UUID
 
 from sqlalchemy import ARRAY, BigInteger, and_, any_, bindparam, func, select
 from sqlalchemy.dialects.postgresql import insert
@@ -12,8 +13,12 @@ from data_rentgen.db.models.dataset_symlink_group import DatasetSymlinkGroup
 from data_rentgen.db.repositories.base import Repository
 from data_rentgen.dto import DatasetSymlinkGroupDTO
 
-fetch_bulk_query = select(DatasetSymlinkGroup.fingerprint).where(
-    DatasetSymlinkGroup.fingerprint == any_(bindparam("fingerprints")),
+get_fingerprints_query = (
+    select(DatasetSymlinkGroup.fingerprint.distinct())
+    .where(
+        DatasetSymlinkGroup.fingerprint == any_(bindparam("fingerprints")),
+    )
+    .limit(bindparam("limit"))
 )
 
 insert_group_query = insert(DatasetSymlinkGroup).on_conflict_do_nothing(
@@ -53,14 +58,8 @@ class DatasetSymlinkRepository(Repository[DatasetSymlinkGroup]):
             return
 
         # skip inserting existing symlink groups
-        existing = await self._session.execute(
-            fetch_bulk_query,
-            {
-                "fingerprints": [item.fingerprint for item in items],
-            },
-        )
-        known_fingerprints = {item.fingerprint for item in existing.all()}
-        to_insert = [item for item in items if item.fingerprint not in known_fingerprints]
+        missing_fingerprints = await self._get_missing_fingerprints({item.fingerprint for item in items})
+        to_insert = [item for item in items if item.fingerprint in missing_fingerprints]
         if not to_insert:
             return
 
@@ -76,6 +75,13 @@ class DatasetSymlinkRepository(Repository[DatasetSymlinkGroup]):
                 for dataset, type_ in item.members
             ],
         )
+
+    async def _get_missing_fingerprints(self, fingerprints: set[UUID]) -> set[UUID]:
+        existing = await self._session.scalars(
+            get_fingerprints_query,
+            {"fingerprints": list(fingerprints), "limit": len(fingerprints)},
+        )
+        return fingerprints - set(existing.all())
 
     async def get_symlink_groups(self, dataset_ids: Collection[int]) -> list[DatasetSymlinkGroup]:
         if not dataset_ids:

--- a/data_rentgen/db/repositories/job.py
+++ b/data_rentgen/db/repositories/job.py
@@ -33,17 +33,21 @@ from data_rentgen.db.repositories.base import Repository
 from data_rentgen.db.utils.search import make_tsquery, ts_match, ts_rank
 from data_rentgen.dto import JobDTO, JobTypeDTO, PaginationDTO
 
-fetch_bulk_query = select(Job).where(
-    tuple_(Job.location_id, Job.name_lower).in_(
-        select(
-            func.unnest(
-                cast(bindparam("location_ids"), ARRAY(Integer())),
-                cast(bindparam("names_lower"), ARRAY(String())),
-            )
-            .table_valued("location_id", "name_lower")
-            .render_derived(),
+fetch_bulk_query = (
+    select(Job)
+    .where(
+        tuple_(Job.location_id, Job.name_lower).in_(
+            select(
+                func.unnest(
+                    cast(bindparam("location_ids"), ARRAY(Integer())),
+                    cast(bindparam("names_lower"), ARRAY(String())),
+                )
+                .table_valued("location_id", "name_lower")
+                .render_derived(),
+            ),
         ),
-    ),
+    )
+    .limit(bindparam("limit"))
 )
 
 get_one_query = (
@@ -267,6 +271,7 @@ class JobRepository(Repository[Job]):
             {
                 "location_ids": [item.location.id for item in jobs_dto],
                 "names_lower": [item.name.lower() for item in jobs_dto],
+                "limit": len(jobs_dto),
             },
         )
         existing = {(job.location_id, job.name.lower()): job for job in scalars.all()}

--- a/data_rentgen/db/repositories/job_type.py
+++ b/data_rentgen/db/repositories/job_type.py
@@ -14,8 +14,12 @@ from data_rentgen.db.models import JobType
 from data_rentgen.db.repositories.base import Repository
 from data_rentgen.dto import JobTypeDTO
 
-fetch_bulk_query = select(JobType).where(
-    JobType.type == any_(bindparam("types")),
+fetch_bulk_query = (
+    select(JobType)
+    .where(
+        JobType.type == any_(bindparam("types")),
+    )
+    .limit(bindparam("limit"))
 )
 
 get_one_query = (
@@ -39,6 +43,7 @@ class JobTypeRepository(Repository[JobType]):
             fetch_bulk_query,
             {
                 "types": [job_type_dto.type for job_type_dto in job_types_dto],
+                "limit": len(job_types_dto),
             },
         )
         existing = {job.type: job for job in scalars.all()}

--- a/data_rentgen/db/repositories/operation.py
+++ b/data_rentgen/db/repositories/operation.py
@@ -19,10 +19,14 @@ update_statement = update(Operation)
 # Do not use `tuple_(Operation.id, Operation.created_at).in_(...),
 # as this is too complex filter for Postgres to make an optimal query plan.
 # Primary key starts with id already, and created_at filter is used to select specific partitions
-get_list_by_ids = select(Operation).where(
-    Operation.created_at >= bindparam("since"),
-    Operation.created_at <= bindparam("until"),
-    Operation.id == any_(bindparam("operation_ids")),
+get_list_by_ids = (
+    select(Operation)
+    .where(
+        Operation.created_at >= bindparam("since"),
+        Operation.created_at <= bindparam("until"),
+        Operation.id == any_(bindparam("operation_ids")),
+    )
+    .limit(bindparam("limit"))
 )
 
 get_stats_by_run_ids = (
@@ -157,6 +161,7 @@ class OperationRepository(Repository[Operation]):
                 "since": extract_timestamp_from_uuid(min(operation_ids)),
                 "until": extract_timestamp_from_uuid(max(operation_ids)),
                 "operation_ids": list(operation_ids),
+                "limit": len(operation_ids),
             },
         )
         return list(result.all())

--- a/data_rentgen/db/repositories/run.py
+++ b/data_rentgen/db/repositories/run.py
@@ -33,6 +33,7 @@ get_list_by_id_query = (
         Run.created_at <= bindparam("until"),
         Run.id == any_(bindparam("run_ids")),
     )
+    .limit(bindparam("limit"))
     .options(selectinload(Run.job).joinedload(Job.location).selectinload(Location.addresses))
     .options(selectinload(Run.started_by_user))
 )
@@ -48,9 +49,14 @@ get_list_by_job_ids_query = (
     .options(selectinload(Run.started_by_user))
 )
 
-fetch_bulk_query = select(Run).where(
-    Run.created_at >= bindparam("since"),
-    Run.id == any_(bindparam("run_ids")),
+fetch_bulk_query = (
+    select(Run)
+    .where(
+        Run.created_at >= bindparam("since"),
+        Run.created_at <= bindparam("until"),
+        Run.id == any_(bindparam("run_ids")),
+    )
+    .limit(bindparam("limit"))
 )
 
 insert_statement = insert(Run).values(
@@ -277,6 +283,7 @@ class RunRepository(Repository[Run]):
                 "since": extract_timestamp_from_uuid(min(run_ids)),
                 "until": extract_timestamp_from_uuid(max(run_ids)),
                 "run_ids": list(run_ids),
+                "limit": len(run_ids),
             },
         )
         return list(result.all())
@@ -309,7 +316,9 @@ class RunRepository(Repository[Run]):
             fetch_bulk_query,
             {
                 "since": extract_timestamp_from_uuid(min(ids)),
+                "until": extract_timestamp_from_uuid(max(ids)),
                 "run_ids": ids,
+                "limit": len(ids),
             },
         )
         existing = {run.id: run for run in scalars.all()}

--- a/data_rentgen/db/repositories/schema.py
+++ b/data_rentgen/db/repositories/schema.py
@@ -10,11 +10,15 @@ from data_rentgen.db.repositories.base import Repository
 from data_rentgen.dto import SchemaDTO
 
 # schema JSON can be heavy, avoid loading it if not needed
-fetch_bulk_query = select(Schema.digest, Schema.id).where(
-    Schema.digest == any_(bindparam("digests")),
+fetch_bulk_query = (
+    select(Schema.digest, Schema.id)
+    .where(
+        Schema.digest == any_(bindparam("digests")),
+    )
+    .limit(bindparam("limit"))
 )
 
-get_list_by_ids_query = select(Schema).where(Schema.id == any_(bindparam("schema_ids")))
+get_list_by_ids_query = select(Schema).where(Schema.id == any_(bindparam("schema_ids"))).limit(bindparam("limit"))
 get_one_by_digest_query = (
     select(Schema).where(Schema.digest == bindparam("digest")).limit(literal(1, literal_execute=True))
 )
@@ -25,17 +29,22 @@ class SchemaRepository(Repository[Schema]):
         if not schema_ids:
             return []
 
-        result = await self._session.scalars(get_list_by_ids_query, {"schema_ids": list(schema_ids)})
+        result = await self._session.scalars(
+            get_list_by_ids_query,
+            {"schema_ids": list(schema_ids), "limit": len(schema_ids)},
+        )
         return list(result.all())
 
     async def fetch_known_ids(self, schemas_dto: list[SchemaDTO]) -> list[tuple[SchemaDTO, int | None]]:
         if not schemas_dto:
             return []
 
+        new_digests = {item.digest for item in schemas_dto}
         existing = await self._session.execute(
             fetch_bulk_query,
             {
-                "digests": [item.digest for item in schemas_dto],
+                "digests": list(new_digests),
+                "limit": len(new_digests),
             },
         )
         known_ids = {item.digest: item.id for item in existing.all()}

--- a/data_rentgen/db/repositories/sql_query.py
+++ b/data_rentgen/db/repositories/sql_query.py
@@ -9,8 +9,12 @@ from data_rentgen.db.repositories.base import Repository
 from data_rentgen.dto import SQLQueryDTO
 
 # SQLQuery text can be heavy, avoid loading it if not needed
-fetch_bulk_query = select(SQLQuery.fingerprint, SQLQuery.id).where(
-    SQLQuery.fingerprint == any_(bindparam("fingerprints")),
+fetch_bulk_query = (
+    select(SQLQuery.fingerprint, SQLQuery.id)
+    .where(
+        SQLQuery.fingerprint == any_(bindparam("fingerprints")),
+    )
+    .limit(bindparam("limit"))
 )
 
 get_one_by_fingerprint_query = (
@@ -23,10 +27,12 @@ class SQLQueryRepository(Repository[SQLQuery]):
         if not sql_queries_dto:
             return []
 
+        new_fingerprints = {item.fingerprint for item in sql_queries_dto}
         existing = await self._session.execute(
             fetch_bulk_query,
             {
-                "fingerprints": [item.fingerprint for item in sql_queries_dto],
+                "fingerprints": list(new_fingerprints),
+                "limit": len(new_fingerprints),
             },
         )
         known_ids = {item.fingerprint: item.id for item in existing.all()}

--- a/data_rentgen/db/repositories/tag.py
+++ b/data_rentgen/db/repositories/tag.py
@@ -25,7 +25,7 @@ from data_rentgen.db.utils.search import make_tsquery, ts_match, ts_rank
 from data_rentgen.dto.pagination import PaginationDTO
 from data_rentgen.dto.tag import TagDTO
 
-fetch_bulk_query = select(Tag).where(Tag.name_lower == any_(bindparam("names")))
+fetch_bulk_query = select(Tag).where(Tag.name_lower == any_(bindparam("names"))).limit(bindparam("limit"))
 get_one_by_name_query = select(Tag).where(Tag.name_lower == bindparam("name")).limit(literal(1, literal_execute=True))
 
 
@@ -87,6 +87,7 @@ class TagRepository(Repository[Tag]):
             fetch_bulk_query,
             {
                 "names": [item.name.lower() for item in tags_dto],
+                "limit": len(tags_dto),
             },
         )
         existing = {tag.name.lower(): tag for tag in scalars.all()}

--- a/data_rentgen/db/repositories/tag_value.py
+++ b/data_rentgen/db/repositories/tag_value.py
@@ -18,18 +18,23 @@ from data_rentgen.db.models.tag_value import TagValue
 from data_rentgen.db.repositories.base import Repository
 from data_rentgen.dto.tag import TagValueDTO
 
-fetch_bulk_query = select(TagValue).where(
-    tuple_(TagValue.tag_id, TagValue.value_lower).in_(
-        select(
-            func.unnest(
-                cast(bindparam("tag_ids"), ARRAY(Integer())),
-                cast(bindparam("values"), ARRAY(String())),
-            )
-            .table_valued("tag_ids", "values")
-            .render_derived(),
+fetch_bulk_query = (
+    select(TagValue)
+    .where(
+        tuple_(TagValue.tag_id, TagValue.value_lower).in_(
+            select(
+                func.unnest(
+                    cast(bindparam("tag_ids"), ARRAY(Integer())),
+                    cast(bindparam("values"), ARRAY(String())),
+                )
+                .table_valued("tag_ids", "values")
+                .render_derived(),
+            ),
         ),
-    ),
+    )
+    .limit(bindparam("limit"))
 )
+
 get_one_query = (
     select(TagValue)
     .where(TagValue.tag_id == bindparam("tag_id"), TagValue.value_lower == bindparam("value"))
@@ -47,6 +52,7 @@ class TagValueRepository(Repository[TagValue]):
             {
                 "tag_ids": [item.tag.id for item in tag_values_dto],
                 "values": [item.value for item in tag_values_dto],
+                "limit": len(tag_values_dto),
             },
         )
         existing = {(v.tag_id, v.value.lower()): v for v in scalars.all()}

--- a/data_rentgen/db/repositories/user.py
+++ b/data_rentgen/db/repositories/user.py
@@ -7,8 +7,12 @@ from data_rentgen.db.models import User
 from data_rentgen.db.repositories.base import Repository
 from data_rentgen.dto import UserDTO
 
-fetch_bulk_query = select(User).where(
-    User.name_lower == any_(bindparam("names_lower")),
+fetch_bulk_query = (
+    select(User)
+    .where(
+        User.name_lower == any_(bindparam("names_lower")),
+    )
+    .limit(bindparam("limit"))
 )
 
 get_one_by_name_query = (
@@ -37,6 +41,7 @@ class UserRepository(Repository[User]):
             fetch_bulk_query,
             {
                 "names_lower": [item.name.lower() for item in users_dto],
+                "limit": len(users_dto),
             },
         )
         existing = {user.name.lower(): user for user in scalars.all()}

--- a/mddocs/docs/changelog/next_release/497.improvement.md
+++ b/mddocs/docs/changelog/next_release/497.improvement.md
@@ -1,0 +1,1 @@
+Improve query plan for bulk queries by preferring index scan.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Without limit:
```
explain analyze select * from run where id = any('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]) order by id desc, created_at desc;
                                                                           QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=41.37..41.42 rows=21 width=510) (actual time=0.132..0.135 rows=2 loops=1)
   Sort Key: run.id DESC, run.created_at DESC
   Sort Method: quicksort  Memory: 25kB
   ->  Append  (cost=0.00..40.90 rows=21 width=510) (actual time=0.114..0.124 rows=2 loops=1)
         ->  Seq Scan on run_y2020 run_1  (cost=0.00..0.00 rows=1 width=508) (actual time=0.007..0.008 rows=0 loops=1)
               Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]))
         ->  Seq Scan on run_y2021 run_2  (cost=0.00..0.00 rows=1 width=508) (actual time=0.002..0.002 rows=0 loops=1)
               Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]))
         ->  Seq Scan on run_y2022 run_3  (cost=0.00..0.00 rows=1 width=538) (actual time=0.002..0.002 rows=0 loops=1)
               Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]))
         ->  Seq Scan on run_y2023 run_4  (cost=0.00..0.00 rows=1 width=537) (actual time=0.001..0.001 rows=0 loops=1)
               Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]))
         ->  Seq Scan on run_y2024 run_5  (cost=0.00..0.00 rows=1 width=537) (actual time=0.001..0.002 rows=0 loops=1)
               Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]))
         ->  Seq Scan on run_y2025 run_6  (cost=0.00..2.21 rows=2 width=505) (actual time=0.013..0.013 rows=0 loops=1)
               Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]))
               Rows Removed by Filter: 17
         ->  Seq Scan on run_y2026_m01 run_7  (cost=0.00..0.00 rows=1 width=525) (actual time=0.001..0.002 rows=0 loops=1)
               Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]))
         ->  Index Scan Backward using run_y2026_m02_pkey on run_y2026_m02 run_8  (cost=0.43..6.07 rows=2 width=493) (actual time=0.018..0.018 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]))
         ->  Index Scan Backward using run_y2026_m03_pkey on run_y2026_m03 run_9  (cost=0.43..6.21 rows=2 width=500) (actual time=0.010..0.010 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]))
         ->  Index Scan Backward using run_y2026_m04_pkey on run_y2026_m04 run_10  (cost=0.43..6.66 rows=2 width=492) (actual time=0.010..0.010 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]))
         ->  Index Scan Backward using run_y2026_m05_pkey on run_y2026_m05 run_11  (cost=0.43..6.70 rows=2 width=502) (actual time=0.010..0.010 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]))
         ->  Index Scan Backward using run_y2026_m06_pkey on run_y2026_m06 run_12  (cost=0.43..6.89 rows=2 width=526) (actual time=0.010..0.010 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]))
         ->  Index Scan Backward using run_y2026_m07_pkey on run_y2026_m07 run_13  (cost=0.42..6.06 rows=2 width=522) (actual time=0.026..0.030 rows=2 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]))
         ->  Seq Scan on run_y2026_m08 run_14  (cost=0.00..0.00 rows=1 width=478) (actual time=0.002..0.002 rows=0 loops=1)
               Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-5aa5-7410-8523-7c5012f84d43}'::uuid[]))
 Planning Time: 0.865 ms
 Execution Time: 0.231 ms
```

With explicit limit:
```
explain analyze select * from run where id = any('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]) order by id desc, created_at desc limit 2;
                                                                           QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=3.84..9.62 rows=2 width=510) (actual time=0.130..0.134 rows=2 loops=1)
   ->  Merge Append  (cost=3.84..64.49 rows=21 width=510) (actual time=0.129..0.133 rows=2 loops=1)
         Sort Key: run.id DESC, run.created_at DESC
         ->  Index Scan Backward using run_y2020_pkey on run_y2020 run_1  (cost=0.12..2.61 rows=1 width=508) (actual time=0.005..0.005 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]))
         ->  Index Scan Backward using run_y2021_pkey on run_y2021 run_2  (cost=0.12..2.53 rows=1 width=508) (actual time=0.003..0.003 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]))
         ->  Index Scan Backward using run_y2022_pkey on run_y2022 run_3  (cost=0.12..2.77 rows=1 width=538) (actual time=0.002..0.002 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]))
         ->  Index Scan Backward using run_y2023_pkey on run_y2023 run_4  (cost=0.12..2.50 rows=1 width=537) (actual time=0.002..0.002 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]))
         ->  Index Scan Backward using run_y2024_pkey on run_y2024 run_5  (cost=0.12..2.45 rows=1 width=537) (actual time=0.003..0.003 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]))
         ->  Index Scan Backward using run_y2025_pkey on run_y2025 run_6  (cost=0.14..5.85 rows=2 width=505) (actual time=0.004..0.004 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]))
         ->  Index Scan Backward using run_y2026_m01_pkey on run_y2026_m01 run_7  (cost=0.12..3.14 rows=1 width=525) (actual time=0.002..0.002 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]))
         ->  Index Scan Backward using run_y2026_m02_pkey on run_y2026_m02 run_8  (cost=0.43..6.07 rows=2 width=493) (actual time=0.019..0.019 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]))
         ->  Index Scan Backward using run_y2026_m03_pkey on run_y2026_m03 run_9  (cost=0.43..6.21 rows=2 width=500) (actual time=0.015..0.015 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]))
         ->  Index Scan Backward using run_y2026_m04_pkey on run_y2026_m04 run_10  (cost=0.43..6.66 rows=2 width=492) (actual time=0.010..0.010 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]))
         ->  Index Scan Backward using run_y2026_m05_pkey on run_y2026_m05 run_11  (cost=0.43..6.70 rows=2 width=502) (actual time=0.016..0.016 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]))
         ->  Index Scan Backward using run_y2026_m06_pkey on run_y2026_m06 run_12  (cost=0.43..6.89 rows=2 width=526) (actual time=0.013..0.013 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]))
         ->  Index Scan Backward using run_y2026_m07_pkey on run_y2026_m07 run_13  (cost=0.42..6.06 rows=2 width=522) (actual time=0.026..0.029 rows=2 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]))
         ->  Index Scan Backward using run_y2026_m08_pkey on run_y2026_m08 run_14  (cost=0.12..3.27 rows=1 width=478) (actual time=0.006..0.006 rows=0 loops=1)
               Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99,019f65b9-614c-7cae-a98f-8b2a4d5f119f}'::uuid[]))
 Planning Time: 0.799 ms
 Execution Time: 0.206 ms
```

This doesn't make queries faster, but replaces seq scans with index scans.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `mddocs/docs/changelog/next_release/<pull request or issue id>.<change type>.md` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
