### PR TITLE
[DOP-26672] Optimize paginate queries with id filters

### DIFF
--- a/data_rentgen/db/repositories/base.py
+++ b/data_rentgen/db/repositories/base.py
@@ -50,11 +50,13 @@ class Repository(ABC, Generic[Model]):
         order_by: Sequence[ColumnElement | SQLColumnExpression],
         page: int,
         page_size: int,
+        override_limit: int = 0,
         options: Sequence[ExecutableOption] | None = None,
     ) -> PaginationDTO[Model]:
         model_type = self.model_type()
+        limit = min(page_size, override_limit) if override_limit else page_size
         items_query = select(model_type).from_statement(
-            query.order_by(*order_by).limit(page_size).offset((page - 1) * page_size),
+            query.order_by(*order_by).limit(limit).offset((page - 1) * page_size),
         )
         if options:
             items_query = items_query.options(*options)

--- a/data_rentgen/db/repositories/dataset.py
+++ b/data_rentgen/db/repositories/dataset.py
@@ -153,18 +153,23 @@ class DatasetRepository(Repository[Dataset]):
         self,
         page: int,
         page_size: int,
-        dataset_ids: Collection[int],
-        tag_value_ids: Collection[int],
-        location_ids: Collection[int],
-        location_types: Collection[str],
+        dataset_ids: list[int],
+        tag_value_ids: list[int],
+        location_ids: list[int],
+        location_types: list[str],
         search_query: str | None,
     ) -> PaginationDTO[Dataset]:
         where = []
-        location_join_clause = Location.id == Dataset.location_id
-        if dataset_ids:
-            where.append(Dataset.id == any_(list(dataset_ids)))  # type: ignore[arg-type]
+        limit = 0
+        if len(dataset_ids) == 1:
+            where.append(Dataset.id == dataset_ids[0])
+            limit = 1
+        elif dataset_ids:
+            where.append(Dataset.id == any_(dataset_ids))  # type: ignore[arg-type]
+            limit = len(dataset_ids)
+
         if location_ids:
-            where.append(Dataset.location_id == any_(list(location_ids)))  # type: ignore[arg-type]
+            where.append(Dataset.location_id == any_(location_ids))  # type: ignore[arg-type]
         if location_types:
             location_type_lower = [location_type.lower() for location_type in location_types]
             where.append(Location.type == any_(location_type_lower))  # type: ignore[arg-type]
@@ -183,6 +188,7 @@ class DatasetRepository(Repository[Dataset]):
 
         query: Select | CompoundSelect
         order_by: list[ColumnElement | SQLColumnExpression]
+        location_join_clause = Location.id == Dataset.location_id
         if search_query:
             tsquery = make_tsquery(search_query)
 
@@ -227,6 +233,7 @@ class DatasetRepository(Repository[Dataset]):
             options=options,
             page=page,
             page_size=page_size,
+            override_limit=limit,
         )
 
     async def list_by_ids(self, dataset_ids: Collection[int]) -> list[Dataset]:

--- a/data_rentgen/db/repositories/job.py
+++ b/data_rentgen/db/repositories/job.py
@@ -136,18 +136,23 @@ class JobRepository(Repository[Job]):
         self,
         page: int,
         page_size: int,
-        job_ids: Collection[int],
-        parent_job_ids: Collection[int],
-        job_types: Collection[str],
-        tag_value_ids: Collection[int],
-        location_ids: Collection[int],
-        location_types: Collection[str],
+        job_ids: list[int],
+        parent_job_ids: list[int],
+        job_types: list[str],
+        tag_value_ids: list[int],
+        location_ids: list[int],
+        location_types: list[str],
         search_query: str | None,
     ) -> PaginationDTO[Job]:
         where = []
-        location_join_clause = Location.id == Job.location_id
-        if job_ids:
+        limit = 0
+        if len(job_ids) == 1:
+            where.append(Job.id == job_ids[0])  # type: ignore[arg-type]
+            limit = 1
+        elif job_ids:
             where.append(Job.id == any_(list(job_ids)))  # type: ignore[arg-type]
+            limit = len(job_ids)
+
         if parent_job_ids:
             where.append(Job.parent_job_id == any_(list(parent_job_ids)))  # type: ignore[arg-type]
         if job_types:
@@ -172,6 +177,7 @@ class JobRepository(Repository[Job]):
 
         query: Select | CompoundSelect
         order_by: list[ColumnElement | SQLColumnExpression]
+        location_join_clause = Location.id == Job.location_id
         if search_query:
             tsquery = make_tsquery(search_query)
 
@@ -217,6 +223,7 @@ class JobRepository(Repository[Job]):
             options=options,
             page=page,
             page_size=page_size,
+            override_limit=limit,
         )
 
     async def fetch_bulk(self, jobs_dto: list[JobDTO]) -> list[tuple[JobDTO, Job | None]]:

--- a/data_rentgen/db/repositories/operation.py
+++ b/data_rentgen/db/repositories/operation.py
@@ -92,29 +92,39 @@ class OperationRepository(Repository[Operation]):
         self,
         page: int,
         page_size: int,
-        operation_ids: Collection[UUID],
+        operation_ids: list[UUID],
         since: datetime | None,
         until: datetime | None,
-        run_ids: Collection[UUID],
+        run_ids: list[UUID],
     ) -> PaginationDTO[Operation]:
         # do not use `tuple_(Operation.id, Operation.created_at).in_(...),
         # as this is too complex filter for Postgres to make an optimal query plan
         where = []
+        limit = 0
 
         # created_at and id are always correlated,
         # and primary key starts with id, so we need to apply filter on both
         # to get the most optimal query plan
-        if operation_ids:
+        if len(operation_ids) == 1:
+            operation_id = operation_ids[0]
+            created_at = extract_timestamp_from_uuid(operation_id)
+            where = [
+                Operation.id == operation_id,
+                Operation.created_at == created_at,
+            ]
+            limit = 1
+        elif operation_ids:
             min_operation_created_at = extract_timestamp_from_uuid(min(operation_ids))
             max_operation_created_at = extract_timestamp_from_uuid(max(operation_ids))
             # narrow created_at range
             min_created_at = max(filter(None, [since, min_operation_created_at]))
             max_created_at = min(filter(None, [until, max_operation_created_at]))
             where = [
+                Operation.id == any_(list(operation_ids)),  # type: ignore[arg-type]
                 Operation.created_at >= min_created_at,
                 Operation.created_at <= max_created_at,
-                Operation.id == any_(list(operation_ids)),  # type: ignore[arg-type]
             ]
+            limit = len(operation_ids)
 
         elif run_ids:
             run_created_at = extract_timestamp_from_uuid(min(run_ids))
@@ -145,6 +155,7 @@ class OperationRepository(Repository[Operation]):
             order_by=order_by,
             page=page,
             page_size=page_size,
+            override_limit=limit,
         )
 
     async def list_by_ids(self, operation_ids: Collection[UUID]) -> list[Operation]:

--- a/data_rentgen/db/repositories/personal_token.py
+++ b/data_rentgen/db/repositories/personal_token.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2025-present MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Collection
 from datetime import UTC, date, datetime
 from uuid import UUID
 
@@ -30,15 +29,20 @@ class PersonalTokenRepository(Repository[PersonalToken]):
         page: int,
         page_size: int,
         user_id: int,
-        personal_token_ids: Collection[UUID],
+        personal_token_ids: list[UUID],
     ) -> PaginationDTO[PersonalToken]:
         where = [
             PersonalToken.user_id == user_id,
             PersonalToken.revoked_at.is_(None),
         ]
+        limit = 0
 
-        if personal_token_ids:
+        if len(personal_token_ids) == 1:
+            where.append(PersonalToken.id == personal_token_ids[0])
+            limit = 1
+        elif personal_token_ids:
             where.append(PersonalToken.id == any_(list(personal_token_ids)))  # type: ignore[arg-type]
+            limit = len(personal_token_ids)
 
         query = select(PersonalToken).distinct(PersonalToken.name).where(*where)
 
@@ -47,6 +51,7 @@ class PersonalTokenRepository(Repository[PersonalToken]):
             order_by=[PersonalToken.name, PersonalToken.since.desc()],
             page=page,
             page_size=page_size,
+            override_limit=limit,
         )
 
     async def get_by_id(

--- a/data_rentgen/db/repositories/run.py
+++ b/data_rentgen/db/repositories/run.py
@@ -144,13 +144,13 @@ class RunRepository(Repository[Run]):
         page_size: int,
         since: datetime | None,
         until: datetime | None,
-        run_ids: Collection[UUID],
-        parent_run_ids: Collection[UUID],
-        job_ids: Collection[int],
-        job_types: Collection[str],
-        job_location_ids: Collection[int],
-        statuses: Collection[RunStatus],
-        started_by_users: Collection[str],
+        run_ids: list[UUID],
+        parent_run_ids: list[UUID],
+        job_ids: list[int],
+        job_types: list[str],
+        job_location_ids: list[int],
+        statuses: list[RunStatus],
+        started_by_users: list[str],
         started_since: datetime | None,
         started_until: datetime | None,
         ended_since: datetime | None,
@@ -160,11 +160,21 @@ class RunRepository(Repository[Run]):
         # do not use `tuple_(Run.id, Run.created_at).in_(...),
         # as this is too complex filter for Postgres to make an optimal query plan
         where = []
+        limit = 0
 
         # created_at and id are always correlated,
         # and primary key starts with id, so we need to apply filter on both
         # to get the most optimal query plan
-        if run_ids:
+        if len(run_ids) == 1:
+            run_id = run_ids[0]
+            created_at = extract_timestamp_from_uuid(run_id)
+            where = [
+                Run.id == run_id,
+                Run.created_at == created_at,
+            ]
+            limit = 1
+
+        elif run_ids:
             min_run_created_at = extract_timestamp_from_uuid(min(run_ids))
             max_run_created_at = extract_timestamp_from_uuid(max(run_ids))
             # narrow created_at range
@@ -175,6 +185,7 @@ class RunRepository(Repository[Run]):
                 Run.created_at <= max_created_at,
                 Run.id == any_(list(run_ids)),  # type: ignore[arg-type]
             ]
+            limit = len(run_ids)
         else:
             if since:
                 where = [
@@ -255,6 +266,7 @@ class RunRepository(Repository[Run]):
             options=options,
             page=page,
             page_size=page_size,
+            override_limit=limit,
         )
 
     async def list_by_ids(self, run_ids: Collection[UUID]) -> list[Run]:

--- a/data_rentgen/db/repositories/tag.py
+++ b/data_rentgen/db/repositories/tag.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from collections.abc import Collection
-
 from sqlalchemy import (
     ColumnElement,
     CompoundSelect,
@@ -34,12 +32,17 @@ class TagRepository(Repository[Tag]):
         self,
         page: int,
         page_size: int,
-        tag_ids: Collection[int],
+        tag_ids: list[int],
         search_query: str | None,
     ) -> PaginationDTO[Tag]:
         where = []
-        if tag_ids:
+        limit = 0
+        if len(tag_ids) == 1:
+            where.append(Tag.id == tag_ids[0])
+            limit = 1
+        elif tag_ids:
             where.append(Tag.id == any_(list(tag_ids)))  # type: ignore[arg-type]
+            limit = len(tag_ids)
 
         query: Select | CompoundSelect
         order_by: list[ColumnElement | SQLColumnExpression]
@@ -77,6 +80,7 @@ class TagRepository(Repository[Tag]):
             options=options,
             page=page,
             page_size=page_size,
+            override_limit=limit,
         )
 
     async def fetch_bulk(self, tags_dto: list[TagDTO]) -> list[tuple[TagDTO, Tag | None]]:

--- a/data_rentgen/server/api/v1/router/run.py
+++ b/data_rentgen/server/api/v1/router/run.py
@@ -41,7 +41,7 @@ async def runs(
         job_types=query_args.job_type,
         job_location_ids=query_args.job_location_id,
         search_query=query_args.search_query,
-        statuses=query_args.status,
+        statuses=query_args.status,  # type: ignore[arg-type]
         started_by_users=query_args.started_by_user,
         started_since=query_args.started_since,
         started_until=query_args.started_until,

--- a/data_rentgen/server/services/dataset.py
+++ b/data_rentgen/server/services/dataset.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2024-present MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Collection
 from dataclasses import dataclass
 from itertools import groupby
 from typing import Annotated
@@ -41,10 +40,10 @@ class DatasetService:
         self,
         page: int,
         page_size: int,
-        dataset_ids: Collection[int],
-        tag_value_ids: Collection[int],
-        location_ids: Collection[int],
-        location_types: Collection[str],
+        dataset_ids: list[int],
+        tag_value_ids: list[int],
+        location_ids: list[int],
+        location_types: list[str],
         search_query: str | None,
     ) -> DatasetServicePaginatedResult:
         pagination = await self._uow.dataset.paginate(

--- a/data_rentgen/server/services/job.py
+++ b/data_rentgen/server/services/job.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024-present MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 import logging
-from collections.abc import Collection, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from itertools import groupby
@@ -86,12 +86,12 @@ class JobService:
         self,
         page: int,
         page_size: int,
-        job_ids: Collection[int],
-        parent_job_ids: Collection[int],
-        job_types: Collection[str],
-        tag_value_ids: Collection[int],
-        location_ids: Collection[int],
-        location_types: Collection[str],
+        job_ids: list[int],
+        parent_job_ids: list[int],
+        job_types: list[str],
+        tag_value_ids: list[int],
+        location_ids: list[int],
+        location_types: list[str],
         search_query: str | None,
     ) -> JobServicePaginatedResult:
         pagination = await self._uow.job.paginate(

--- a/data_rentgen/server/services/location.py
+++ b/data_rentgen/server/services/location.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2024-present MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Collection, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Annotated
 
@@ -68,8 +68,8 @@ class LocationService:
         self,
         page: int,
         page_size: int,
-        location_ids: Collection[int],
-        location_type: Collection[str],
+        location_ids: list[int],
+        location_type: list[str],
         search_query: str | None,
     ) -> LocationServicePaginatedResult:
         pagination = await self._uow.location.paginate(

--- a/data_rentgen/server/services/operation.py
+++ b/data_rentgen/server/services/operation.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2024-present MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Annotated
@@ -61,8 +60,8 @@ class OperationService:
         page_size: int,
         since: datetime | None,
         until: datetime | None,
-        operation_ids: Collection[UUID],
-        run_ids: Collection[UUID],
+        operation_ids: list[UUID],
+        run_ids: list[UUID],
     ) -> OperationServicePaginatedResult:
         pagination = await self._uow.operation.paginate(
             page=page,

--- a/data_rentgen/server/services/run.py
+++ b/data_rentgen/server/services/run.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2024-present MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Annotated
@@ -77,13 +76,13 @@ class RunService:
         page_size: int,
         since: datetime | None,
         until: datetime | None,
-        run_ids: Collection[UUID],
-        job_ids: Collection[int],
-        parent_run_ids: Collection[UUID],
-        job_types: Collection[str],
-        job_location_ids: Collection[int],
-        statuses: Collection[str],
-        started_by_users: Collection[str],
+        run_ids: list[UUID],
+        job_ids: list[int],
+        parent_run_ids: list[UUID],
+        job_types: list[str],
+        job_location_ids: list[int],
+        statuses: list[str],
+        started_by_users: list[str],
         started_since: datetime | None,
         started_until: datetime | None,
         ended_since: datetime | None,

--- a/data_rentgen/server/services/tag.py
+++ b/data_rentgen/server/services/tag.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2024-present MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Collection
 from dataclasses import dataclass
 from typing import Annotated
 
@@ -41,7 +40,7 @@ class TagService:
         self,
         page: int,
         page_size: int,
-        tag_ids: Collection[int],
+        tag_ids: list[int],
         search_query: str | None,
     ) -> TagServicePaginatedResult:
         pagination = await self._uow.tag.paginate(

--- a/mddocs/docs/changelog/next_release/499.improvement.md
+++ b/mddocs/docs/changelog/next_release/499.improvement.md
@@ -1,0 +1,2 @@
+Improve query plan for queries with `id` filter.
+


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Calling `GET /v1/runs?run_id=019f65b9-9925-709b-bbd2-a2fb181b7c99` performs query which looks like this:
```
select * from run where id = any('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]) order by id desc, created_at
```

With limit = page size (usually 20) execution plan looks like this:
```
explain analyze select * from run where id = any('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]) order by id desc, created_at desc limit 20;
                                                                              QUERY PLAN                                                                              
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=23.20..23.23 rows=14 width=512) (actual time=0.077..0.080 rows=1 loops=1)
   ->  Sort  (cost=23.20..23.23 rows=14 width=512) (actual time=0.077..0.078 rows=1 loops=1)
         Sort Key: run.id DESC, run.created_at DESC
         Sort Method: quicksort  Memory: 25kB
         ->  Append  (cost=0.00..22.93 rows=14 width=512) (actual time=0.069..0.072 rows=1 loops=1)
               ->  Seq Scan on run_y2020 run_1  (cost=0.00..0.00 rows=1 width=508) (actual time=0.004..0.004 rows=0 loops=1)
                     Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]))
               ->  Seq Scan on run_y2021 run_2  (cost=0.00..0.00 rows=1 width=508) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]))
               ->  Seq Scan on run_y2022 run_3  (cost=0.00..0.00 rows=1 width=538) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]))
               ->  Seq Scan on run_y2023 run_4  (cost=0.00..0.00 rows=1 width=537) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]))
               ->  Seq Scan on run_y2024 run_5  (cost=0.00..0.00 rows=1 width=537) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]))
               ->  Seq Scan on run_y2025 run_6  (cost=0.00..2.19 rows=1 width=505) (actual time=0.012..0.012 rows=0 loops=1)
                     Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]))
                     Rows Removed by Filter: 22
               ->  Seq Scan on run_y2026_m01 run_7  (cost=0.00..0.00 rows=1 width=525) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]))
               ->  Index Scan Backward using run_y2026_m02_pkey on run_y2026_m02 run_8  (cost=0.43..3.45 rows=1 width=493) (actual time=0.012..0.012 rows=0 loops=1)
                     Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]))
               ->  Index Scan Backward using run_y2026_m03_pkey on run_y2026_m03 run_9  (cost=0.43..3.45 rows=1 width=500) (actual time=0.007..0.007 rows=0 loops=1)
                     Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]))
               ->  Index Scan Backward using run_y2026_m04_pkey on run_y2026_m04 run_10  (cost=0.43..3.45 rows=1 width=492) (actual time=0.006..0.006 rows=0 loops=1)
                     Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]))
               ->  Index Scan Backward using run_y2026_m05_pkey on run_y2026_m05 run_11  (cost=0.43..3.45 rows=1 width=502) (actual time=0.006..0.006 rows=0 loops=1)
                     Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]))
               ->  Index Scan Backward using run_y2026_m06_pkey on run_y2026_m06 run_12  (cost=0.43..3.45 rows=1 width=526) (actual time=0.007..0.007 rows=0 loops=1)
                     Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]))
               ->  Index Scan Backward using run_y2026_m07_pkey on run_y2026_m07 run_13  (cost=0.42..3.44 rows=1 width=522) (actual time=0.008..0.009 rows=1 loops=1)
                     Index Cond: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]))
               ->  Seq Scan on run_y2026_m08 run_14  (cost=0.00..0.00 rows=1 width=478) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (id = ANY ('{019f65b9-9925-709b-bbd2-a2fb181b7c99}'::uuid[]))
 Planning Time: 0.590 ms
 Execution Time: 0.149 ms
```

With explicit `LIMIT 1` PostgreSQL can skip scanning other partitions if result is already found in the first one:
```
explain analyze select * from run where id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid order by id desc, created_at desc limit 1;
                                                                           QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=3.58..6.34 rows=1 width=512) (actual time=0.025..0.026 rows=1 loops=1)
   ->  Append  (cost=3.58..42.25 rows=14 width=512) (actual time=0.023..0.024 rows=1 loops=1)
         ->  Index Scan Backward using run_y2026_m08_pkey on run_y2026_m08 run_14  (cost=0.12..3.14 rows=1 width=478) (actual time=0.008..0.008 rows=0 loops=1)
               Index Cond: (id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid)
         ->  Index Scan Backward using run_y2026_m07_pkey on run_y2026_m07 run_13  (cost=0.42..3.44 rows=1 width=522) (actual time=0.015..0.015 rows=1 loops=1)
               Index Cond: (id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid)
         ->  Index Scan Backward using run_y2026_m06_pkey on run_y2026_m06 run_12  (cost=0.43..3.45 rows=1 width=526) (never executed)
               Index Cond: (id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid)
         ->  Index Scan Backward using run_y2026_m05_pkey on run_y2026_m05 run_11  (cost=0.43..3.45 rows=1 width=502) (never executed)
               Index Cond: (id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid)
         ->  Index Scan Backward using run_y2026_m04_pkey on run_y2026_m04 run_10  (cost=0.43..3.45 rows=1 width=492) (never executed)
               Index Cond: (id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid)
         ->  Index Scan Backward using run_y2026_m03_pkey on run_y2026_m03 run_9  (cost=0.43..3.45 rows=1 width=500) (never executed)
               Index Cond: (id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid)
         ->  Index Scan Backward using run_y2026_m02_pkey on run_y2026_m02 run_8  (cost=0.43..3.45 rows=1 width=493) (never executed)
               Index Cond: (id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid)
         ->  Index Scan Backward using run_y2026_m01_pkey on run_y2026_m01 run_7  (cost=0.12..3.01 rows=1 width=525) (never executed)
               Index Cond: (id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid)
         ->  Index Scan Backward using run_y2025_pkey on run_y2025 run_6  (cost=0.14..3.16 rows=1 width=505) (never executed)
               Index Cond: (id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid)
         ->  Index Scan Backward using run_y2024_pkey on run_y2024 run_5  (cost=0.12..2.31 rows=1 width=537) (never executed)
               Index Cond: (id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid)
         ->  Index Scan Backward using run_y2023_pkey on run_y2023 run_4  (cost=0.12..2.37 rows=1 width=537) (never executed)
               Index Cond: (id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid)
         ->  Index Scan Backward using run_y2022_pkey on run_y2022 run_3  (cost=0.12..2.64 rows=1 width=538) (never executed)
               Index Cond: (id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid)
         ->  Index Scan Backward using run_y2021_pkey on run_y2021 run_2  (cost=0.12..2.40 rows=1 width=508) (never executed)
               Index Cond: (id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid)
         ->  Index Scan Backward using run_y2020_pkey on run_y2020 run_1  (cost=0.12..2.47 rows=1 width=508) (never executed)
               Index Cond: (id = '019f65b9-9925-709b-bbd2-a2fb181b7c99'::uuid)
 Planning Time: 0.674 ms
 Execution Time: 0.101 ms
```

For case with multiple ids passed into filter (`GET /v1/run_id=019f65b9-9925-709b-bbd2-a2fb181b7c99&run_id=019f65b9-614c-7cae-a98f-8b2a4d5f119f`) we fall back to `run.id = ANY(:run_ids) LIMIT :len_run_ids` case.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `mddocs/docs/changelog/next_release/<pull request or issue id>.<change type>.md` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
