### PR TITLE
[DOP-26646] Reuse the same window clause for IO relations

### DIFF
--- a/data_rentgen/db/repositories/input.py
+++ b/data_rentgen/db/repositories/input.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from sqlalchemy import ColumnElement, Row, Select, any_, func, literal_column, select
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import InstrumentedAttribute
 
 from data_rentgen.db.models import Input, Schema
 from data_rentgen.db.repositories.base import Repository
@@ -150,29 +151,37 @@ class InputRepository(Repository[Input]):
 
     def _get_base_query(
         self,
+        return_columns: Collection[InstrumentedAttribute],
         where: Collection[ColumnElement],
     ) -> Select:
-        # For operation.type=STREAMING, there can be multiple inputs for same operation+dataset+schema,
-        # so we also need deduplication here
-        unique_ids = [Input.job_id, Input.run_id, Input.operation_id, Input.dataset_id]
-        order_by = [Input.created_at, Input.schema_id]
+        # For operation.type=STREAMING or long-running operation.type=BATCH,
+        # there can be multiple inputs for same operation+dataset+schema,
+        # so we need to get latest input for each operation before applying sum on it
+
+        partition_columns = list(return_columns)
+        if Input.operation_id not in partition_columns:
+            partition_columns.append(Input.operation_id)
 
         # Avoid sorting multiple times by different keys for performance reason,
         # instead reuse the same window expression
-        def window(expr, order_by=None):
-            return expr.over(partition_by=unique_ids, order_by=order_by)
+        def window(expr):
+            return expr.over(
+                partition_by=partition_columns,
+                order_by=[Input.created_at, Input.schema_id],
+                range_=(None, None),  # important
+            )
 
         return (
             select(
-                *unique_ids,
-                window(func.max(Input.created_at)).label("created_at"),
-                window(func.max(Input.num_bytes)).label("num_bytes"),
-                window(func.max(Input.num_rows)).label("num_rows"),
-                window(func.max(Input.num_files)).label("num_files"),
-                window(func.first_value(Input.schema_id), order_by).label("oldest_schema_id"),
-                window(func.last_value(Input.schema_id), order_by).label("newest_schema_id"),
+                *return_columns,
+                window(func.last_value(Input.created_at)).label("created_at"),
+                window(func.last_value(Input.num_bytes)).label("num_bytes"),
+                window(func.last_value(Input.num_rows)).label("num_rows"),
+                window(func.last_value(Input.num_files)).label("num_files"),
+                window(func.first_value(Input.schema_id)).label("oldest_schema_id"),
+                window(func.last_value(Input.schema_id)).label("newest_schema_id"),
             )
-            .distinct(*unique_ids)
+            .distinct(*partition_columns)
             .where(*where)
         )
 
@@ -181,8 +190,15 @@ class InputRepository(Repository[Input]):
         where: Collection[ColumnElement],
         granularity: Literal["JOB", "RUN", "OPERATION"],
     ) -> list[InputRow]:
-        base_query = self._get_base_query(where).subquery()
         if granularity == "OPERATION":
+            return_columns = [
+                # same order as in GROUP BY
+                Input.operation_id,
+                Input.run_id,
+                Input.job_id,
+                Input.dataset_id,
+            ]
+            base_query = self._get_base_query(return_columns, where).subquery()
             query = select(
                 func.max(base_query.c.created_at).label("max_created_at"),
                 base_query.c.operation_id,
@@ -201,6 +217,13 @@ class InputRepository(Repository[Input]):
                 base_query.c.dataset_id,
             )
         elif granularity == "RUN":
+            return_columns = [
+                # same order as in GROUP BY
+                Input.run_id,
+                Input.job_id,
+                Input.dataset_id,
+            ]
+            base_query = self._get_base_query(return_columns, where).subquery()
             query = select(
                 func.max(base_query.c.created_at).label("max_created_at"),
                 literal_column("NULL").label("operation_id"),
@@ -218,6 +241,12 @@ class InputRepository(Repository[Input]):
                 base_query.c.dataset_id,
             )
         else:
+            return_columns = [
+                # same order as in GROUP BY
+                Input.job_id,
+                Input.dataset_id,
+            ]
+            base_query = self._get_base_query(return_columns, where).subquery()
             query = select(
                 func.max(base_query.c.created_at).label("max_created_at"),
                 literal_column("NULL").label("operation_id"),
@@ -270,7 +299,12 @@ class InputRepository(Repository[Input]):
             Input.operation_id == any_(list(operation_ids)),  # type: ignore[arg-type]
         ]
 
-        base_query = self._get_base_query(where).subquery()
+        return_columns = [
+            # same order as in GROUP BY
+            Input.operation_id,
+            Input.dataset_id,
+        ]
+        base_query = self._get_base_query(return_columns, where).subquery()
         query = select(
             base_query.c.operation_id.label("operation_id"),
             func.count(base_query.c.dataset_id.distinct()).label("total_datasets"),
@@ -292,7 +326,12 @@ class InputRepository(Repository[Input]):
             Input.run_id == any_(list(run_ids)),  # type: ignore[arg-type]
         ]
 
-        base_query = self._get_base_query(where).subquery()
+        return_columns = [
+            # same order as in GROUP BY
+            Input.run_id,
+            Input.dataset_id,
+        ]
+        base_query = self._get_base_query(return_columns, where).subquery()
         query = select(
             base_query.c.run_id.label("run_id"),
             func.count(base_query.c.dataset_id.distinct()).label("total_datasets"),

--- a/data_rentgen/db/repositories/io_dataset_relation.py
+++ b/data_rentgen/db/repositories/io_dataset_relation.py
@@ -47,30 +47,34 @@ class IODatasetRelationRepository:
         if until:
             where.extend([Output.created_at <= until, Input.created_at <= until])
 
-        unique_ids = [Output.dataset_id, Input.dataset_id]
-        order_by = [Output.created_at, Input.created_at, Output.schema_id, Input.schema_id]
-
         # Avoid sorting multiple times by different keys for performance reason,
         # instead reuse the same window expression
-        def window(expr, order_by=None):
-            return expr.over(partition_by=unique_ids, order_by=order_by)
+        distinct_columns = [Output.dataset_id, Input.dataset_id]
+
+        def window(expr):
+            return expr.over(
+                partition_by=distinct_columns,
+                order_by=[Output.created_at, Input.created_at, Output.schema_id, Input.schema_id],
+                range_=(None, None),  # important
+            )
 
         # there is no need in GROUP BY, as we already select distinct values
         query = (
             select(
                 Input.dataset_id.label("in_dataset_id"),
                 Output.dataset_id.label("out_dataset_id"),
-                window(func.max(Output.created_at)).label("max_created_at"),
-                window(func.first_value(Output.schema_id), order_by).label("oldest_output_schema_id"),
-                window(func.last_value(Output.schema_id), order_by).label("newest_output_schema_id"),
-                window(func.first_value(Input.schema_id), order_by).label("oldest_input_schema_id"),
-                window(func.last_value(Input.schema_id), order_by).label("newest_input_schema_id"),
+                window(func.last_value(Output.created_at)).label("max_created_at"),
+                window(func.first_value(Output.schema_id)).label("oldest_output_schema_id"),
+                window(func.last_value(Output.schema_id)).label("newest_output_schema_id"),
+                window(func.first_value(Input.schema_id)).label("oldest_input_schema_id"),
+                window(func.last_value(Input.schema_id)).label("newest_input_schema_id"),
             )
-            .distinct(*unique_ids)
+            .distinct(*distinct_columns)
             .join(
                 Input,
                 and_(
                     Output.operation_id == Input.operation_id,
+                    Output.created_at >= Input.created_at,
                     # Avoid returning table1 -> table1 relations.
                     # TODO: cover case with self-reference via symlink
                     Output.dataset_id != Input.dataset_id,

--- a/data_rentgen/db/repositories/output.py
+++ b/data_rentgen/db/repositories/output.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from sqlalchemy import ColumnElement, Row, Select, any_, func, literal_column, select
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import InstrumentedAttribute
 
 from data_rentgen.db.models import Output, OutputType, Schema
 from data_rentgen.db.repositories.base import Repository
@@ -153,30 +154,38 @@ class OutputRepository(Repository[Output]):
 
     def _get_base_query(
         self,
+        return_columns: Collection[InstrumentedAttribute],
         where: Collection[ColumnElement],
     ) -> Select:
-        # For operation.type=STREAMING, there can be multiple outputs for same operation+dataset+schema,
-        # so we also need deduplication here
-        unique_ids = [Output.job_id, Output.run_id, Output.operation_id, Output.dataset_id]
-        order_by = [Output.created_at, Output.schema_id]
+        # For operation.type=STREAMING or long-running operation.type=BATCH,
+        # there can be multiple outputs for same operation+dataset+schema,
+        # so we need to get latest output for each operation before applying sum on it
+
+        partition_columns = list(return_columns)
+        if Output.operation_id not in partition_columns:
+            partition_columns.append(Output.operation_id)
 
         # Avoid sorting multiple times by different keys for performance reason,
         # instead reuse the same window expression
-        def window(expr, order_by=None):
-            return expr.over(partition_by=unique_ids, order_by=order_by)
+        def window(expr):
+            return expr.over(
+                partition_by=partition_columns,
+                order_by=[Output.created_at, Output.schema_id],
+                range_=(None, None),  # important
+            )
 
         return (
             select(
-                *unique_ids,
-                window(func.max(Output.created_at)).label("created_at"),
-                window(func.max(Output.num_bytes)).label("num_bytes"),
-                window(func.max(Output.num_rows)).label("num_rows"),
-                window(func.max(Output.num_files)).label("num_files"),
+                *return_columns,
+                window(func.last_value(Output.created_at)).label("created_at"),
+                window(func.last_value(Output.num_bytes)).label("num_bytes"),
+                window(func.last_value(Output.num_rows)).label("num_rows"),
+                window(func.last_value(Output.num_files)).label("num_files"),
                 window(func.bit_or(Output.type)).label("type"),
-                window(func.first_value(Output.schema_id), order_by).label("oldest_schema_id"),
-                window(func.last_value(Output.schema_id), order_by).label("newest_schema_id"),
+                window(func.first_value(Output.schema_id)).label("oldest_schema_id"),
+                window(func.last_value(Output.schema_id)).label("newest_schema_id"),
             )
-            .distinct(*unique_ids)
+            .distinct(*partition_columns)
             .where(*where)
         )
 
@@ -185,8 +194,15 @@ class OutputRepository(Repository[Output]):
         where: Collection[ColumnElement],
         granularity: Literal["JOB", "RUN", "OPERATION"],
     ) -> list[OutputRow]:
-        base_query = self._get_base_query(where).subquery()
         if granularity == "OPERATION":
+            return_columns = [
+                # same order as in GROUP BY
+                Output.operation_id,
+                Output.run_id,
+                Output.job_id,
+                Output.dataset_id,
+            ]
+            base_query = self._get_base_query(return_columns, where).subquery()
             query = select(
                 func.max(base_query.c.created_at).label("max_created_at"),
                 base_query.c.operation_id,
@@ -206,6 +222,13 @@ class OutputRepository(Repository[Output]):
                 base_query.c.dataset_id,
             )
         elif granularity == "RUN":
+            return_columns = [
+                # same order as in GROUP BY
+                Output.run_id,
+                Output.job_id,
+                Output.dataset_id,
+            ]
+            base_query = self._get_base_query(return_columns, where).subquery()
             query = select(
                 func.max(base_query.c.created_at).label("max_created_at"),
                 literal_column("NULL").label("operation_id"),
@@ -224,6 +247,12 @@ class OutputRepository(Repository[Output]):
                 base_query.c.dataset_id,
             )
         else:
+            return_columns = [
+                # same order as in GROUP BY
+                Output.job_id,
+                Output.dataset_id,
+            ]
+            base_query = self._get_base_query(return_columns, where).subquery()
             query = select(
                 func.max(base_query.c.created_at).label("max_created_at"),
                 literal_column("NULL").label("operation_id"),
@@ -276,7 +305,12 @@ class OutputRepository(Repository[Output]):
             Output.operation_id == any_(list(operation_ids)),  # type: ignore[arg-type]
         ]
 
-        base_query = self._get_base_query(where).subquery()
+        return_columns = [
+            # same order as in GROUP BY
+            Output.operation_id,
+            Output.dataset_id,
+        ]
+        base_query = self._get_base_query(return_columns, where).subquery()
         query = select(
             base_query.c.operation_id.label("operation_id"),
             func.count(base_query.c.dataset_id.distinct()).label("total_datasets"),
@@ -298,7 +332,12 @@ class OutputRepository(Repository[Output]):
             Output.run_id == any_(list(run_ids)),  # type: ignore[arg-type]
         ]
 
-        base_query = self._get_base_query(where).subquery()
+        return_columns = [
+            # same order as in GROUP BY
+            Output.run_id,
+            Output.dataset_id,
+        ]
+        base_query = self._get_base_query(return_columns, where).subquery()
         query = select(
             base_query.c.run_id.label("run_id"),
             func.count(base_query.c.dataset_id.distinct()).label("total_datasets"),

--- a/mddocs/docs/changelog/next_release/500.improvement.md
+++ b/mddocs/docs/changelog/next_release/500.improvement.md
@@ -1,0 +1,1 @@
+Simplify execution plan for SQL queries used for fetching aggregated input/outputs.

--- a/tests/test_server/fixtures/factories/lineage.py
+++ b/tests/test_server/fixtures/factories/lineage.py
@@ -1400,7 +1400,6 @@ async def lineage_with_different_dataset_interactions(
                 key=f"different_dataset_interactions_operation_{i}",
                 run=run,
                 operation_kwargs={
-                    "run_id": run.id,
                     "created_at": run.created_at + timedelta(seconds=0.2),
                 },
             )
@@ -1418,12 +1417,6 @@ async def lineage_with_different_dataset_interactions(
                 schema=schema,
                 output_kwargs={
                     "created_at": operation.created_at,
-                    "operation_id": operation.id,
-                    "run_id": operation.run_id,
-                    "job_id": job.id,
-                    "dataset_id": dataset.id,
-                    "type": type_,
-                    "schema_id": schema.id,
                 },
             )
             for i, (operation, type_) in enumerate(
@@ -1518,11 +1511,6 @@ async def lineage_for_long_running_operations(
                     schema=schema,
                     input_kwargs={
                         "created_at": operation.created_at + timedelta(hours=io),
-                        "operation_id": operation.id,
-                        "run_id": run.id,
-                        "job_id": job.id,
-                        "dataset_id": datasets[i].id,
-                        "schema_id": schema.id,
                         "num_files": io,
                         "num_rows": io,
                         "num_bytes": io,
@@ -1539,12 +1527,6 @@ async def lineage_for_long_running_operations(
                     schema=schema,
                     output_kwargs={
                         "created_at": operation.created_at + timedelta(hours=io),
-                        "operation_id": operation.id,
-                        "run_id": run.id,
-                        "job_id": job.id,
-                        "dataset_id": datasets[i + 1].id,
-                        "type": OutputType.APPEND,
-                        "schema_id": schema.id,
                         "num_files": io,
                         "num_rows": io,
                         "num_bytes": io,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Before - multiple `WINDOW` clauses with different `ORDER BY` lead to calculating window over window. Also different order of columns in `PARTITION BY` and `GROUP BY` clauses lead to re-sorting the result twice.
<details>

```sql
explain (analyze, buffers)
SELECT max(anon_1.created_at) AS max_created_at, NULL AS operation_id, NULL AS run_id, anon_1.job_id, anon_1.dataset_id, sum(anon_1.num_bytes) AS sum_num_bytes, sum(anon_1.num_rows) AS sum_num_rows, sum(anon_1.num_files) AS sum_num_files, min(anon_1.oldest_schema_id) AS min_schema_id, max(anon_1.newest_schema_id) AS max_schema_id
FROM (
  SELECT DISTINCT ON (job_id, run_id, operation_id, dataset_id)
  job_id AS job_id,
  run_id AS run_id,
  operation_id AS operation_id,
  dataset_id AS dataset_id,
  max(created_at) OVER (PARTITION BY job_id, run_id, operation_id, dataset_id) AS created_at,
  max(num_bytes) OVER (PARTITION BY job_id, run_id, operation_id, dataset_id) AS num_bytes,
  max(num_rows) OVER (PARTITION BY job_id, run_id, operation_id, dataset_id) AS num_rows,
  max(num_files) OVER (PARTITION BY job_id, run_id, operation_id, dataset_id) AS num_files,
  first_value(schema_id) OVER (PARTITION BY job_id, run_id, operation_id, dataset_id ORDER BY created_at, schema_id) AS oldest_schema_id,
  last_value(schema_id) OVER (PARTITION BY job_id, run_id, operation_id, dataset_id ORDER BY created_at, schema_id) AS newest_schema_id
FROM input_y2026_m07
WHERE created_at >= '2026-07-06T21:00:00+00:00'::TIMESTAMP WITH TIME ZONE AND job_id = ANY ('{23639}'::bigint[])) AS anon_1
GROUP BY anon_1.job_id, anon_1.dataset_id;
                                                                                                   QUERY PLAN                                                                                                    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 GroupAggregate  (cost=529.93..545.68 rows=96 width=200) (actual time=1.058..1.116 rows=8 loops=1)
   Group Key: anon_1.job_id, anon_1.dataset_id
   Buffers: shared hit=44
   ->  Incremental Sort  (cost=529.93..542.08 rows=96 width=64) (actual time=1.035..1.047 rows=81 loops=1)
         Sort Key: anon_1.job_id, anon_1.dataset_id
         Presorted Key: anon_1.job_id
         Full-sort Groups: 1  Sort Method: quicksort  Average Memory: 29kB  Peak Memory: 29kB
         Pre-sorted Groups: 1  Sort Method: quicksort  Average Memory: 30kB  Peak Memory: 30kB
         Buffers: shared hit=44
         ->  Subquery Scan on anon_1  (cost=529.84..537.76 rows=96 width=64) (actual time=0.430..0.922 rows=81 loops=1)
               Buffers: shared hit=44
               ->  Unique  (cost=529.84..536.80 rows=96 width=112) (actual time=0.428..0.859 rows=81 loops=1)
                     Buffers: shared hit=44
                     ->  WindowAgg  (cost=529.84..535.84 rows=96 width=112) (actual time=0.426..0.801 rows=81 loops=1)
                           Buffers: shared hit=44
                           ->  WindowAgg  (cost=529.84..532.96 rows=96 width=104) (actual time=0.410..0.591 rows=81 loops=1)
                                 Buffers: shared hit=44
                                 ->  Sort  (cost=529.84..530.08 rows=96 width=88) (actual time=0.391..0.403 rows=81 loops=1)
                                       Sort Key: input_y2026_m07.job_id, input_y2026_m07.run_id, input_y2026_m07.operation_id, input_y2026_m07.dataset_id, input_y2026_m07.created_at, input_y2026_m07.schema_id
                                       Sort Method: quicksort  Memory: 33kB
                                       Buffers: shared hit=44
                                       ->  Bitmap Heap Scan on input_y2026_m07  (cost=5.50..526.68 rows=96 width=88) (actual time=0.083..0.253 rows=81 loops=1)
                                             Recheck Cond: (job_id = ANY ('{23639}'::bigint[]))
                                             Filter: (created_at >= '2026-07-07 00:00:00+03'::timestamp with time zone)
                                             Rows Removed by Filter: 54
                                             Heap Blocks: exact=41
                                             Buffers: shared hit=44
                                             ->  Bitmap Index Scan on input_y2026_m07_job_id_idx  (cost=0.00..5.47 rows=140 width=0) (actual time=0.042..0.043 rows=135 loops=1)
                                                   Index Cond: (job_id = ANY ('{23639}'::bigint[]))
                                                   Buffers: shared hit=3
 Planning Time: 0.498 ms
 Execution Time: 1.273 ms
```
</details>

After - only one `WINDOW` clause, the same order of columns in `PARTITION BY` and `GROUP BY` sorts data once.
<details>

```sql
explain (analyze, buffers)
SELECT max(anon_1.created_at) AS max_created_at, NULL AS operation_id, NULL AS run_id, anon_1.job_id, anon_1.dataset_id, sum(anon_1.num_bytes) AS sum_num_bytes, sum(anon_1.num_rows) AS sum_num_rows, sum(anon_1.num_files) AS sum_num_files, min(anon_1.oldest_schema_id) AS min_schema_id, max(anon_1.newest_schema_id) AS max_schema_id
FROM (
  SELECT DISTINCT ON (job_id, dataset_id, operation_id)
  job_id AS job_id,
  dataset_id AS dataset_id,
  last_value(created_at) OVER (PARTITION BY job_id, dataset_id, operation_id ORDER BY created_at, schema_id RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS created_at,
  last_value(num_bytes) OVER (PARTITION BY job_id, dataset_id, operation_id ORDER BY created_at, schema_id RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS num_bytes,
  last_value(num_rows) OVER (PARTITION BY job_id, dataset_id, operation_id ORDER BY created_at, schema_id RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS num_rows,
  last_value(num_files) OVER (PARTITION BY job_id, dataset_id, operation_id ORDER BY created_at, schema_id RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS num_files,
  first_value(schema_id) OVER (PARTITION BY job_id, dataset_id, operation_id ORDER BY created_at, schema_id RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS oldest_schema_id,
  last_value(schema_id) OVER (PARTITION BY job_id, dataset_id, operation_id ORDER BY created_at,schema_id RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS newest_schema_id
FROM input_y2026_m07
WHERE created_at >= '2026-07-06T21:00:00+00:00'::TIMESTAMP WITH TIME ZONE AND job_id = ANY ('{23639}'::bigint[])) AS anon_1
GROUP BY anon_1.job_id, anon_1.dataset_id;
                                                                              QUERY PLAN                                                                               
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 GroupAggregate  (cost=529.84..538.96 rows=96 width=200) (actual time=0.458..0.812 rows=8 loops=1)
   Group Key: input_y2026_m07.job_id, input_y2026_m07.dataset_id
   Buffers: shared hit=44
   ->  Unique  (cost=529.84..534.40 rows=96 width=96) (actual time=0.393..0.739 rows=81 loops=1)
         Buffers: shared hit=44
         ->  WindowAgg  (cost=529.84..533.68 rows=96 width=96) (actual time=0.391..0.677 rows=81 loops=1)
               Buffers: shared hit=44
               ->  Sort  (cost=529.84..530.08 rows=96 width=72) (actual time=0.371..0.382 rows=81 loops=1)
                     Sort Key: input_y2026_m07.job_id, input_y2026_m07.dataset_id, input_y2026_m07.operation_id, input_y2026_m07.created_at, input_y2026_m07.schema_id
                     Sort Method: quicksort  Memory: 31kB
                     Buffers: shared hit=44
                     ->  Bitmap Heap Scan on input_y2026_m07  (cost=5.50..526.68 rows=96 width=72) (actual time=0.078..0.247 rows=81 loops=1)
                           Recheck Cond: (job_id = ANY ('{23639}'::bigint[]))
                           Filter: (created_at >= '2026-07-07 00:00:00+03'::timestamp with time zone)
                           Rows Removed by Filter: 54
                           Heap Blocks: exact=41
                           Buffers: shared hit=44
                           ->  Bitmap Index Scan on input_y2026_m07_job_id_idx  (cost=0.00..5.47 rows=140 width=0) (actual time=0.039..0.040 rows=135 loops=1)
                                 Index Cond: (job_id = ANY ('{23639}'::bigint[]))
                                 Buffers: shared hit=3
 Planning Time: 0.412 ms
 Execution Time: 0.973 ms
(22 rows)
```
</details>

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `mddocs/docs/changelog/next_release/<pull request or issue id>.<change type>.md` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
