### PR TITLE
[DOP-39140] Add KafkaPrometheusMiddleware

### DIFF
--- a/data_rentgen/consumer/__init__.py
+++ b/data_rentgen/consumer/__init__.py
@@ -10,10 +10,13 @@ from fast_depends import dependency_provider
 from faststream import ContextRepo, FastStream
 from faststream._internal._compat import ExceptionGroup
 from faststream.asgi import AsgiFastStream, AsgiResponse, get
+from faststream.asgi.types import ASGIApp
 from faststream.kafka import KafkaBroker
+from faststream.kafka.prometheus import KafkaPrometheusMiddleware
 from faststream.kafka.publisher import DefaultPublisher
 from faststream.kafka.subscriber.usecase import BatchSubscriber
 from faststream.specification.asyncapi import AsyncAPI
+from prometheus_client import CollectorRegistry, make_asgi_app
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import data_rentgen
@@ -37,13 +40,18 @@ async def liveness(scope: dict[str, Any]) -> AsgiResponse:
     return AsgiResponse(b"", status_code=204)
 
 
-def broker_factory(settings: ConsumerApplicationSettings) -> KafkaBroker:
+def broker_factory(settings: ConsumerApplicationSettings, registry: CollectorRegistry | None = None) -> KafkaBroker:
+    middlewares = []
+    if registry is not None:
+        middlewares.append(KafkaPrometheusMiddleware(registry=registry, app_name=settings.monitoring.app_name))
+
     broker = KafkaBroker(
         bootstrap_servers=settings.kafka.bootstrap_servers,
         security=settings.kafka.security.to_security(),
         compression_type=settings.kafka.compression.value if settings.kafka.compression else None,
         client_id=f"data-rentgen-{data_rentgen.__version__}",
         logger=logger,
+        middlewares=middlewares,
         **settings.kafka.security.extra_broker_kwargs(),
         **settings.kafka.model_dump(exclude={"bootstrap_servers", "security", "compression"}),
         **settings.producer.model_dump(exclude={"main_topic", "malformed_topic"}),
@@ -99,8 +107,13 @@ def application_factory(settings: ConsumerApplicationSettings) -> AsgiFastStream
             for exception in e.exceptions:  # type: ignore[attr-defined]
                 raise exception from None
 
+    registry = CollectorRegistry() if settings.monitoring.enabled else None
+    asgi_routes: list[tuple[str, ASGIApp]] = [("/monitoring/ping", liveness)]
+    if registry is not None:
+        asgi_routes.append(("/monitoring/metrics", make_asgi_app(registry)))
+
     return FastStream(
-        broker_factory(settings),
+        broker_factory(settings, registry),
         lifespan=security_lifespan,
         specification=AsyncAPI(
             title="Data.Rentgen",
@@ -108,7 +121,7 @@ def application_factory(settings: ConsumerApplicationSettings) -> AsgiFastStream
             version=data_rentgen.__version__,
         ),
         logger=logger,
-    ).as_asgi(asgi_routes=[("/monitoring/ping", liveness)])
+    ).as_asgi(asgi_routes=asgi_routes)
 
 
 def get_application():

--- a/data_rentgen/consumer/settings/__init__.py
+++ b/data_rentgen/consumer/settings/__init__.py
@@ -6,6 +6,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from data_rentgen.consumer.settings.consumer import ConsumerSettings
 from data_rentgen.consumer.settings.kafka import KafkaSettings
+from data_rentgen.consumer.settings.monitoring import MonitoringSettings
 from data_rentgen.consumer.settings.producer import ProducerSettings
 from data_rentgen.db.settings import DatabaseSettings
 from data_rentgen.logging.settings import LoggingSettings
@@ -57,6 +58,10 @@ class ConsumerApplicationSettings(BaseSettings):
     producer: ProducerSettings = Field(
         default_factory=ProducerSettings,
         description="[Producer settings][configuration-producer-specific]",
+    )
+    monitoring: MonitoringSettings = Field(
+        default_factory=MonitoringSettings,
+        description="[Monitoring settings][configuration-consumer-monitoring]",
     )
 
     model_config = SettingsConfigDict(env_prefix="DATA_RENTGEN__", env_nested_delimiter="__", extra="forbid")

--- a/data_rentgen/consumer/settings/monitoring.py
+++ b/data_rentgen/consumer/settings/monitoring.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2024-present MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+
+from pydantic import BaseModel, Field
+
+
+class MonitoringSettings(BaseModel):
+    """Monitoring Settings.
+
+    See
+    [FastStream Prometheus](https://faststream.ag2.ai/latest/getting-started/observability/prometheus/) documentation.
+
+    Examples
+    --------
+
+    ```bash
+    DATA_RENTGEN__MONITORING__ENABLED=True
+    DATA_RENTGEN__MONITORING__APP_NAME=data-rentgen-consumer
+    ```
+    """
+
+    enabled: bool = Field(default=True, description="Set to `True` to enable middleware")
+    app_name: str = Field(
+        default="data-rentgen-consumer",
+        description="Application name, added to all metrics as `app_name` label",
+    )

--- a/mddocs/docs/changelog/next_release/501.feature.md
+++ b/mddocs/docs/changelog/next_release/501.feature.md
@@ -1,0 +1,1 @@
+Add Prometheus metrics middleware to Kafka consumer, exposed via `GET /monitoring/metrics` endpoint. Allows tracking message processing errors caused by database conflicts, deadlocks or unavailability.

--- a/mddocs/docs/nav.md
+++ b/mddocs/docs/nav.md
@@ -27,6 +27,7 @@
             * [Consumer-specific settings](reference/consumer/configuration/consumer-specific.md)
             * [Producer-specific settings](reference/consumer/configuration/producer-specific.md)
             * [Logging settings](reference/consumer/configuration/logging.md)
+            * [Setup monitoring](reference/consumer/configuration/monitoring.md)
     * [REST API Server](reference/server/index.md)
         * [Authentication and Authorization](reference/server/auth/index.md)
             * [Dummy Auth provider](reference/server/auth/dummy.md)

--- a/mddocs/docs/reference/consumer/configuration/index.md
+++ b/mddocs/docs/reference/consumer/configuration/index.md
@@ -9,3 +9,4 @@
             - kafka
             - consumer
             - producer
+            - monitoring

--- a/mddocs/docs/reference/consumer/configuration/monitoring.md
+++ b/mddocs/docs/reference/consumer/configuration/monitoring.md
@@ -1,0 +1,9 @@
+# Setup monitoring { #configuration-consumer-monitoring }
+
+Consumer provides the following endpoints with Prometheus compatible metrics:
+
+- `GET /monitoring/metrics` - consumer metrics, like number of received/processed messages per handler, processing duration and exceptions raised while processing (e.g. database conflicts, deadlocks or unavailability), and so on. See [FastStream Prometheus](https://faststream.ag2.ai/latest/getting-started/observability/prometheus/) documentation for the full list of metrics.
+
+These endpoints are enabled and configured using settings below:
+
+::: data_rentgen.consumer.settings.monitoring.MonitoringSettings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ server = [
   "python-keycloak~=7.1.1",
 ]
 consumer = [
-  "faststream[kafka,cli]~=0.7.1",
+  "faststream[kafka,cli,prometheus]~=0.7.1",
   "cramjam~=2.11.0",
 ]
 http2kafka = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ pytest_plugins = [
     "tests.test_database.fixtures.alembic",
     "tests.test_consumer.fixtures.consumer_app_settings",
     "tests.test_consumer.fixtures.test_broker",
+    "tests.test_consumer.fixtures.test_consumer_app",
+    "tests.test_consumer.fixtures.consumer_client",
     "tests.test_consumer.test_extractors.fixtures.io_raw",
     "tests.test_consumer.test_extractors.fixtures.io_dto",
     "tests.test_consumer.test_extractors.fixtures.dbt_raw",

--- a/tests/test_consumer/fixtures/consumer_client.py
+++ b/tests/test_consumer/fixtures/consumer_client.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from faststream.asgi import AsgiFastStream
+
+
+@pytest_asyncio.fixture
+async def consumer_client(test_consumer_app: AsgiFastStream) -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(
+        transport=ASGITransport(app=test_consumer_app),
+        base_url="http://data-rentgen",
+    ) as result:
+        yield result

--- a/tests/test_consumer/fixtures/test_broker.py
+++ b/tests/test_consumer/fixtures/test_broker.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest_asyncio
 from faststream.kafka import KafkaBroker, KafkaMessage, TestKafkaBroker
+from prometheus_client import CollectorRegistry
 
 from data_rentgen.consumer import broker_factory
 
@@ -15,7 +16,7 @@ if TYPE_CHECKING:
 
 @pytest_asyncio.fixture
 async def broker(consumer_app_settings: ConsumerApplicationSettings) -> KafkaBroker:
-    return broker_factory(settings=consumer_app_settings)
+    return broker_factory(settings=consumer_app_settings, registry=CollectorRegistry())
 
 
 @pytest_asyncio.fixture

--- a/tests/test_consumer/fixtures/test_consumer_app.py
+++ b/tests/test_consumer/fixtures/test_consumer_app.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from data_rentgen.consumer import application_factory
+
+if TYPE_CHECKING:
+    from faststream.asgi import AsgiFastStream
+
+    from data_rentgen.consumer.settings import ConsumerApplicationSettings
+
+
+@pytest.fixture(scope="session")
+def test_consumer_app(consumer_app_settings: ConsumerApplicationSettings) -> AsgiFastStream:
+    return application_factory(settings=consumer_app_settings)

--- a/tests/test_consumer/test_monitoring/test_metrics.py
+++ b/tests/test_consumer/test_monitoring/test_metrics.py
@@ -1,0 +1,13 @@
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = [pytest.mark.consumer, pytest.mark.asyncio]
+
+
+async def test_metrics(consumer_client: AsyncClient):
+    response = await consumer_client.get("/monitoring/metrics")
+    assert response.status_code == HTTPStatus.OK
+    assert "faststream_received_processed_messages_total" in response.text
+    assert "faststream_received_processed_messages_exceptions_total" in response.text

--- a/tests/test_consumer/test_monitoring/test_ping.py
+++ b/tests/test_consumer/test_monitoring/test_ping.py
@@ -1,0 +1,11 @@
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = [pytest.mark.consumer, pytest.mark.asyncio]
+
+
+async def test_ping(consumer_client: AsyncClient):
+    response = await consumer_client.get("/monitoring/ping")
+    assert response.status_code == HTTPStatus.NO_CONTENT

--- a/uv.lock
+++ b/uv.lock
@@ -622,7 +622,7 @@ dependencies = [
 [package.optional-dependencies]
 consumer = [
     { name = "cramjam" },
-    { name = "faststream", extra = ["cli", "kafka"] },
+    { name = "faststream", extra = ["cli", "kafka", "prometheus"] },
 ]
 gssapi = [
     { name = "gssapi" },
@@ -707,8 +707,8 @@ requires-dist = [
     { name = "faker", marker = "extra == 'seed'", specifier = ">=40.21,<40.29" },
     { name = "fastapi", marker = "extra == 'http2kafka'", specifier = "~=0.136.3" },
     { name = "fastapi", marker = "extra == 'server'", specifier = "~=0.136.3" },
-    { name = "faststream", extras = ["cli", "kafka"], marker = "extra == 'consumer'", specifier = "~=0.7.1" },
     { name = "faststream", extras = ["cli", "kafka"], marker = "extra == 'http2kafka'", specifier = "~=0.7.1" },
+    { name = "faststream", extras = ["cli", "kafka", "prometheus"], marker = "extra == 'consumer'", specifier = "~=0.7.1" },
     { name = "greenlet", specifier = "~=3.5.2" },
     { name = "gssapi", marker = "extra == 'gssapi'", specifier = "~=1.11.1" },
     { name = "itsdangerous", marker = "extra == 'server'", specifier = "~=2.2.0" },
@@ -871,6 +871,9 @@ cli = [
 ]
 kafka = [
     { name = "aiokafka" },
+]
+prometheus = [
+    { name = "prometheus-client" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Change Summary

Previously, we had no visibility into cases where the consumer failed to write a batch of messages to the database due to conflicts, deadlocks, or database unavailability.

Added Prometheus middleware to the consumer to collect metrics and exposed them via a Prometheus metrics endpoint:
https://faststream.ag2.ai/latest/getting-started/observability/prometheus/


## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `mddocs/docs/changelog/next_release/<pull request or issue id>.<change type>.md` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
