### PR TITLE
[DOP-29539] Cache Keycloak certs

### DIFF
--- a/data_rentgen/server/providers/auth/keycloak_provider.py
+++ b/data_rentgen/server/providers/auth/keycloak_provider.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: 2024-present MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 import logging
+import time
 from typing import Any, NoReturn
 
 from fastapi import FastAPI, Request
+from jwcrypto import jwk
 from jwcrypto.common import JWException
 from keycloak import KeycloakOpenID, KeycloakOperationError
 from starlette.middleware.sessions import SessionMiddleware
@@ -34,6 +36,8 @@ class KeycloakAuthProvider(AuthProvider):
             client_secret_key=self.settings.keycloak.client_secret.get_secret_value(),
             verify=self.settings.keycloak.verify_ssl,
         )
+        self._key: jwk.JWKSet | None = None
+        self._key_expiration: float = time.monotonic()
 
     @classmethod
     def setup(cls, app: FastAPI) -> FastAPI:
@@ -108,9 +112,24 @@ class KeycloakAuthProvider(AuthProvider):
         async with uow:
             return await uow.user.get_or_create(UserDTO(name=login))
 
+    async def _get_key(self) -> jwk.JWKSet:
+        # avoid sending requests to Keycloak for every received token
+        if self._key is not None and self._key_expiration > time.monotonic():
+            return self._key
+
+        key = jwk.JWKSet()
+        certs = await self.keycloak_openid.a_certs()
+        for cert in certs["keys"]:
+            key.add(jwk.JWK(**cert))
+
+        self._key = key
+        self._key_expiration = time.monotonic() + self.settings.keycloak.cert_cache_ttl.total_seconds()
+        return self._key
+
     async def decode_token(self, access_token: str) -> dict[str, Any] | None:
         try:
-            return await self.keycloak_openid.a_decode_token(token=access_token)
+            key = await self._get_key()
+            return await self.keycloak_openid.a_decode_token(token=access_token, key=key)
         except (KeycloakOperationError, JWException) as err:
             logger.debug("Access token is invalid or expired: %s", err)
             return None

--- a/data_rentgen/server/settings/auth/keycloak.py
+++ b/data_rentgen/server/settings/auth/keycloak.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024-present MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 import textwrap
+from datetime import timedelta
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, SecretStr
@@ -14,6 +15,7 @@ class KeycloakSettings(BaseModel):
     ui_callback_url: str = Field(description="SyncMaster UI auth callback endpoint")
     verify_ssl: bool = Field(default=True, description="Verify SSL certificates")
     scope: str = Field(default="openid", description="Keycloak scope")
+    cert_cache_ttl: timedelta = Field(default=timedelta(hours=1), description="Keycloak certs cache TTL")
 
 
 class KeycloakCookieSettings(BaseModel):
@@ -42,6 +44,7 @@ class KeycloakCookieSettings(BaseModel):
             same_site: lax
             https_only: false
             domain: localhost
+            cert_cache_ttl: 1D
     ```
     For production environment:
 
@@ -56,6 +59,7 @@ class KeycloakCookieSettings(BaseModel):
             same_site: strict
             https_only: true
             domain: example.com
+            cert_cache_ttl: 1H
     ```
     """
 

--- a/mddocs/docs/changelog/next_release/512.improvement.md
+++ b/mddocs/docs/changelog/next_release/512.improvement.md
@@ -1,0 +1,1 @@
+Cache Keycloak certs for JWT token validation. Previously every API request with KeycloakAuthProvider enabled made a request to Keycloak.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

`KeycloakOpenID.a_decode_token` fetched Keycloak certs for every request. Now fetching certs explicitly and save into local cache (TTL is configurable, default 1 hour), to avoid those additional requests.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `mddocs/docs/changelog/next_release/<pull request or issue id>.<change type>.md` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/data-rentgen/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
